### PR TITLE
fix(ui): add descriptive error message to login toast

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
       "dependencies": {
         "@packages/env": "workspace:*",
         "drizzle-orm": "catalog:",
+        "postgres": "^3.4.7",
       },
       "devDependencies": {
         "@packages/tsconfig": "workspace:*",
@@ -1341,6 +1342,8 @@
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
+
+    "postgres": ["postgres@3.4.7", "", {}, "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="],
 
     "prettier": ["prettier@3.7.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA=="],
 

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "next": "^16.1.0",
     "next-themes": "^0.4.6",
     "oxlint": "^1.34.0",
+    "postgres": "^3.4.7",
     "prettier": "^3.7.4",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "radix-ui": "^1.4.3",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@packages/env": "workspace:*",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "postgres": "catalog:"
   },
   "devDependencies": {
     "@packages/tsconfig": "workspace:*",

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -44,7 +44,7 @@ export function Access() {
         callbackURL: `${config.app.url}/x`,
       })
       if (res.error) {
-        toast.error(res.error.message)
+        toast.error(res.error.message || "Provider Not Found")
         setLoader(null)
       } else {
         toast.success("Check your email for the magic link!")


### PR DESCRIPTION
This PR addresses issue #123 where the toast notification appeared empty when an email provider was not found or an error occurred during the login/signup process.

I have updated the error handling logic with a fall back message : `Provider Not Found` in the authentication form to ensure that a descriptive message is always passed to the toast component. If the server provides a specific error message, it is displayed; otherwise, it defaults to a user-friendly fallback.

<img width="1920" height="1080" alt="err" src="https://github.com/user-attachments/assets/27c4ce01-68f3-4a58-97b6-d2532717100a" />
