### PR TITLE
fix(ui): add descriptive error message to login toast 

### DIFF
--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -44,7 +44,7 @@ export function Access() {
         callbackURL: `${config.app.url}/x`,
       })
       if (res.error) {
-        toast.error(res.error.message)
+        toast.error(res.error.message || "Provider Not Found")
         setLoader(null)
       } else {
         toast.success("Check your email for the magic link!")


### PR DESCRIPTION
This PR addresses issue https://github.com/nrjdalal/zerostarter/issues/123 where the toast notification appeared empty when an email provider was not found or an error occurred during the login/signup process.

I have updated the error handling logic with a fall back message : Provider Not Found in the authentication form to ensure that a descriptive message is always passed to the toast component. If the server provides a specific error message, it is displayed; otherwise, it defaults to a user-friendly fallback.
<img width="1920" height="1080" alt="529445903-27c4ce01-68f3-4a58-97b6-d2532717100a" src="https://github.com/user-attachments/assets/5e68e23e-38b4-4e1f-a65c-27a40d2ed28e" />
