### PR TITLE
Update README :  added run the app instruction before database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ const data = await res.json()
    NEXT_PUBLIC_API_URL=http://localhost:4000
    ```
 
+3. Run the Application:
+
+  
+   ```
+   bun dev
+   ```
+   
+
 ### Database Setup
 
 1. Ensure your PostgreSQL server is running.


### PR DESCRIPTION
Added instructions to run the application before doing database setup. (During first local project setup)
If we do the db setup before running the app in the first setup then it create errors. 

```
󰣇 Desktop/oss/temp   main ❯ bun db:generate                                                      07:48 
$ bun --cwd packages/db drizzle-kit generate
No config path provided, using default 'drizzle.config.ts'
Reading config file '/home/suraj/Desktop/oss/temp/packages/db/drizzle.config.ts'
Cannot find module '/home/suraj/Desktop/oss/temp/packages/db/node_modules/@packages/env/dist/db.mjs'
error: "drizzle-kit" exited with code 1
error: script "db:generate" exited with code 1
󰣇 Desktop/oss/temp   main ❯     
```
But this can be easily eliminated if we run the app : `bun dev` before hittiing the drizzle db generate and migrate command.