### PR TITLE
fix: generate GitHub-linked usernames in changelog via script update #156

### DIFF
--- a/.github/scripts/update-changelog-usernames.ts
+++ b/.github/scripts/update-changelog-usernames.ts
@@ -70,7 +70,10 @@ async function processChangelog() {
   let updatedContent = content
   for (const [email, username] of emailToUsername) {
     if (username) {
-      updatedContent = updatedContent.replaceAll(`<${email}>`, `@${username}`)
+      updatedContent = updatedContent.replaceAll(
+        `<${email}>`,
+        `([@${username}](https://github.com/${username}))`,
+      )
     } else {
       updatedContent = updatedContent
         .split("\n")


### PR DESCRIPTION
Fix: make contributor usernames clickable in changelog #156

This PR updates the changelog script and updates the CHANGELOG.md to expected format.

<img width="414" height="119" alt="image" src="https://github.com/user-attachments/assets/8f2b8b18-36d2-47ae-986b-bb5914d5e1f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated changelog generation to format contributor usernames as clickable GitHub profile links instead of plain text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->