### PR TITLE
fix: prefix node builtin imports

### DIFF
--- a/web/next/src/app/layout.tsx
+++ b/web/next/src/app/layout.tsx
@@ -1,5 +1,5 @@
-import { existsSync } from "fs"
-import { join } from "path"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
 
 import type { Metadata } from "next"
 


### PR DESCRIPTION
## Summary
- prefix Node built-in imports in the Next app layout with `node:`
- align the remaining built-in imports with issue #376

## Testing
- repo-wide search for bare built-in Node imports
- unable to run `bun`-based checks in this environment because `bun` is not installed and dependencies are not present

Closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module references to align with Node.js standards. No changes to application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->