### PR TITLE
fix: copy next public assets into standalone output

### DIFF
--- a/web/next/Dockerfile
+++ b/web/next/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=prepare /app/out/full/ .
 ENV INTERNAL_API_URL=http://api:4000
 RUN bunx turbo run build --filter=@web/next
 RUN cp -r /app/web/next/.next/static /app/web/next/.next/standalone/web/next/.next/static
-RUN cp -r /app/web/next/public /app/web/next/.next/standalone/web/next/public
+RUN cp -r /app/web/next/public /app/web/next/.next/standalone/web/next
 
 FROM base AS runner
 WORKDIR /app/web/next


### PR DESCRIPTION
## Summary
- copy the Next `public` directory into the standalone output without creating `public/public`
- restore static asset paths like `/landing/*` in the Docker web container

## Testing
- `bun run build`
- verified the previous container layout had assets under `/app/web/next/public/public/...`
- confirmed the fix is a one-line Dockerfile change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build and deployment configuration for improved package efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->