### PR TITLE
feat: add cloudflare deployment adapter and docs

### DIFF
--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify",
     "check-types": "tsc --noEmit",
+    "cf:deploy": "bunx wrangler deploy --config wrangler.jsonc",
+    "cf:dev": "bunx wrangler dev --config wrangler.jsonc",
+    "cf:typegen": "bunx wrangler types --env-interface CloudflareBindings --config wrangler.jsonc",
     "dev": "concurrently \"tsdown --watch\" \"bun --hot src/index.ts\"",
     "start": "bun bundle/index.mjs"
   },

--- a/api/hono/src/app.ts
+++ b/api/hono/src/app.ts
@@ -1,0 +1,118 @@
+import { BUILD_VERSION } from "@packages/env"
+import { env } from "@packages/env/api-hono"
+import { Scalar } from "@scalar/hono-api-reference"
+import { Hono } from "hono"
+import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
+import { cors } from "hono/cors"
+import { logger } from "hono/logger"
+import { z } from "zod"
+
+import { errorHandler } from "@/lib/error"
+import { rateLimiterMiddleware } from "@/middlewares"
+import { authRouter, v1Router } from "@/routers"
+
+export const app = new Hono()
+
+app.use(
+  "*",
+  cors({
+    origin: env.HONO_TRUSTED_ORIGINS,
+    allowHeaders: ["content-type", "authorization"],
+    allowMethods: ["GET", "OPTIONS", "POST", "PUT"],
+    exposeHeaders: ["content-length"],
+    maxAge: 600,
+    credentials: true,
+  }),
+  logger(),
+  rateLimiterMiddleware,
+)
+
+app.onError(errorHandler)
+app.notFound((c) => c.json({ error: { code: "NOT_FOUND", message: "Not Found" } }, 404))
+
+export const routes = app
+  .get("/", (c) => {
+    const data = { version: BUILD_VERSION, environment: env.NODE_ENV }
+    return c.json({ data })
+  })
+  .get("/headers", (c) => {
+    if (env.NODE_ENV !== "local" && env.NODE_ENV !== "development") {
+      return c.json({ error: { code: "FORBIDDEN", message: "Forbidden" } }, 403)
+    }
+    const data = c.req.header()
+    return c.json({ data })
+  })
+  .basePath("/api")
+  .get(
+    "/health",
+    describeRoute({
+      tags: ["System"],
+      description: "Get the system health",
+      ...({
+        "x-codeSamples": [
+          {
+            lang: "typescript",
+            label: "hono/client",
+            source: `import { apiClient } from "@/lib/api/client"
+
+const response = await apiClient.health.$get()
+const { data } = await response.json()`,
+          },
+        ],
+      } as object),
+      responses: {
+        200: {
+          description: "OK",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  data: z.object({
+                    environment: z
+                      .enum(["local", "development", "test", "staging", "production"])
+                      .meta({ example: env.NODE_ENV }),
+                    message: z.string().meta({ example: "ok" }),
+                    version: z.string().meta({ example: BUILD_VERSION }),
+                  }),
+                }),
+              ),
+            },
+          },
+        },
+      },
+    }),
+    (c) => {
+      const data = { message: "ok", version: BUILD_VERSION, environment: env.NODE_ENV }
+      return c.json({ data })
+    },
+  )
+  .route("/auth", authRouter)
+  .route("/v1", v1Router)
+  .get(
+    "/openapi.json",
+    openAPIRouteHandler(app, {
+      documentation: {
+        info: {
+          version: BUILD_VERSION,
+          title: "ZeroStarter",
+          description: `API Reference for your ZeroStarter Instance.
+- [Dashboard](/dashboard) - Client-side dashboard application
+- [Better Auth Instance](/api/auth/reference) - Better Auth API reference
+- [hono/client](/docs/getting-started/type-safe-api) - Type-safe API client for frontend`,
+        },
+      },
+    }),
+  )
+  .get(
+    "/docs",
+    Scalar({
+      pageTitle: "API Reference | ZeroStarter",
+      defaultHttpClient: {
+        targetKey: "js",
+        clientKey: "hono/client",
+      },
+      defaultOpenAllTags: true,
+      expandAllResponses: true,
+      url: "/api/openapi.json",
+    }),
+  )

--- a/api/hono/src/cloudflare.ts
+++ b/api/hono/src/cloudflare.ts
@@ -1,10 +1,7 @@
-import { env } from "@packages/env/api-hono"
-
 import { app, routes } from "@/app"
 
 export type AppType = typeof routes
 
 export default {
-  port: env.HONO_PORT,
   fetch: app.fetch,
 }

--- a/api/hono/wrangler.jsonc
+++ b/api/hono/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "zerostarter-api",
+  "main": "src/cloudflare.ts",
+  "compatibility_date": "2026-03-19",
+  "compatibility_flags": ["nodejs_compat", "nodejs_compat_populate_process_env"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,14 +14,13 @@
   },
   "dependencies": {
     "@packages/env": "workspace:*",
-    "drizzle-orm": "catalog:"
+    "drizzle-orm": "catalog:",
+    "postgres": "catalog:"
   },
   "devDependencies": {
     "@packages/tsconfig": "workspace:*",
-    "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "drizzle-kit": "catalog:",
-    "postgres": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,10 @@
 import { env } from "@packages/env/db"
-import { SQL } from "bun"
-import type { BunSQLDatabase } from "drizzle-orm/bun-sql"
-import { drizzle } from "drizzle-orm/bun-sql"
+import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import postgres from "postgres"
 
 import * as schema from "@/schema"
 
-type Database = BunSQLDatabase<typeof schema>
+type Database = PostgresJsDatabase<typeof schema>
 
 declare global {
   var db: Database
@@ -14,21 +13,19 @@ declare global {
 let db: Database
 
 if (env.NODE_ENV === "production") {
-  const client = new SQL(env.POSTGRES_URL, {
-    connectionTimeout: 10,
-    idleTimeout: 30,
-    maxLifetime: 0,
-    tls: {
-      rejectUnauthorized: true,
-    },
+  const client = postgres(env.POSTGRES_URL, {
+    connect_timeout: 10,
+    idle_timeout: 30,
+    max_lifetime: 0,
+    ssl: "require",
   })
   db = drizzle({ client, schema })
 } else {
   if (!global.db) {
-    const client = new SQL(env.POSTGRES_URL, {
-      connectionTimeout: 10,
-      idleTimeout: 30,
-      maxLifetime: 0,
+    const client = postgres(env.POSTGRES_URL, {
+      connect_timeout: 10,
+      idle_timeout: 30,
+      max_lifetime: 0,
     })
     global.db = drizzle({ client, schema })
   }

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -4,9 +4,6 @@ import { defineConfig } from "tsdown"
 
 export default [
   defineConfig({
-    deps: {
-      neverBundle: ["bun"],
-    },
     dts: {
       tsgo: true,
     },

--- a/web/next/content/docs/deployment/cloudflare.mdx
+++ b/web/next/content/docs/deployment/cloudflare.mdx
@@ -1,0 +1,112 @@
+---
+title: Deploy at Cloudflare
+description: Deploy your frontend and backend on Cloudflare.
+---
+
+## Overview
+
+ZeroStarter can be deployed to Cloudflare with a split deployment:
+
+- `api/hono` runs on Cloudflare Workers
+- `web/next` runs on Cloudflare's Next.js support via Wrangler setup
+
+Deploy backend first, then frontend, so the frontend can point to the final API URL.
+
+## Prerequisites
+
+1. A [Cloudflare](https://cloudflare.com) account
+2. Wrangler CLI `4.68.0` or newer (or use `bunx wrangler`)
+3. A PostgreSQL database reachable from Cloudflare (for example, [Neon](https://neon.tech) or [Supabase](https://supabase.com))
+4. Your repository pushed to GitHub (recommended for Workers Builds)
+
+## Backend Deployment (`api/hono`)
+
+### Configuration
+
+Cloudflare worker configuration is included at `api/hono/wrangler.jsonc`.
+
+| Option                | Value                  |
+| --------------------- | ---------------------- |
+| Worker Name           | `zerostarter-api`      |
+| Main Entry            | `src/cloudflare.ts`    |
+| Compatibility Date    | `2026-03-19`           |
+| Compatibility Flags   | `nodejs_compat`, `nodejs_compat_populate_process_env` |
+
+### Environment Variables
+
+Set non-secret values in `api/hono/wrangler.jsonc` under `vars` and set secrets with Wrangler:
+
+```bash
+bunx wrangler secret put BETTER_AUTH_SECRET --config api/hono/wrangler.jsonc
+bunx wrangler secret put GITHUB_CLIENT_ID --config api/hono/wrangler.jsonc
+bunx wrangler secret put GITHUB_CLIENT_SECRET --config api/hono/wrangler.jsonc
+bunx wrangler secret put GOOGLE_CLIENT_ID --config api/hono/wrangler.jsonc
+bunx wrangler secret put GOOGLE_CLIENT_SECRET --config api/hono/wrangler.jsonc
+bunx wrangler secret put POSTGRES_URL --config api/hono/wrangler.jsonc
+```
+
+Required runtime values:
+
+```
+NODE_ENV=production
+HONO_APP_URL=https://your-api.workers.dev
+HONO_TRUSTED_ORIGINS=https://your-frontend-domain.com
+HONO_RATE_LIMIT=60
+HONO_RATE_LIMIT_WINDOW_MS=60000
+```
+
+### Deploy Commands
+
+```bash
+# Local worker dev
+bun --cwd api/hono run cf:dev
+
+# Deploy to Cloudflare Workers
+bun --cwd api/hono run cf:deploy
+```
+
+After deploy, copy the API URL (for example, `https://zerostarter-api.<subdomain>.workers.dev`).
+
+## Frontend Deployment (`web/next`)
+
+### Automatic Setup
+
+Cloudflare Wrangler can auto-configure Next.js projects:
+
+```bash
+cd web/next
+bunx wrangler setup
+bunx wrangler deploy
+```
+
+`wrangler setup` detects the framework, installs adapters if needed, and generates project configuration.
+
+### Frontend Environment Variables
+
+Set these values in your Cloudflare frontend project:
+
+```
+NODE_ENV=production
+NEXT_PUBLIC_APP_URL=https://your-frontend-domain.com
+NEXT_PUBLIC_API_URL=https://your-api.workers.dev
+
+# Optional: Analytics
+NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com
+NEXT_PUBLIC_POSTHOG_KEY=your_posthog_key
+
+# Optional: Feedback
+NEXT_PUBLIC_USERJOT_URL=your_userjot_url
+```
+
+## Deployment Order
+
+1. Deploy backend (`api/hono`) and copy its Worker URL
+2. Set `NEXT_PUBLIC_API_URL` in frontend project to that backend URL
+3. Deploy frontend (`web/next`)
+4. Update OAuth callback URLs in GitHub/Google with production domains
+
+## Notes
+
+- `nodejs_compat_populate_process_env` is enabled so existing env access via `process.env` continues to work on Workers
+- Use a managed PostgreSQL database with SSL enabled in production
+- Keep frontend and backend as separate Cloudflare projects for clearer lifecycle and rollbacks

--- a/web/next/content/docs/index.mdx
+++ b/web/next/content/docs/index.mdx
@@ -38,6 +38,7 @@ description: A modern, type-safe, and high-performance SaaS starter template bui
 ### Deployment
 
 - [Docker](/docs/deployment/docker) - Deploy with Docker and Docker Compose
+- [Cloudflare](/docs/deployment/cloudflare) - Deploy frontend and backend on Cloudflare
 - [Vercel](/docs/deployment/vercel) - Deploy to Vercel
 
 ### Resources

--- a/web/next/content/docs/manage/database.mdx
+++ b/web/next/content/docs/manage/database.mdx
@@ -9,19 +9,18 @@ ZeroStarter uses [PostgreSQL](https://www.postgresql.org) with [Drizzle ORM](htt
 
 ## Connection
 
-The database client is initialized in `packages/db/src/index.ts` using Bun's native SQL driver:
+The database client is initialized in `packages/db/src/index.ts` using `postgres` with Drizzle's Postgres.js adapter:
 
 ```ts
 import { env } from "@packages/env/db"
-import { drizzle } from "drizzle-orm/bun-sql"
-import { SQL } from "bun"
+import { drizzle } from "drizzle-orm/postgres-js"
+import postgres from "postgres"
 
-const client = new SQL({
-  url: env.POSTGRES_URL,
-  tls: isProduction() ? { rejectUnauthorized: true } : false,
-  connectionTimeout: 10,
-  idleTimeout: 30,
-  maxLifetime: 0,
+const client = postgres(env.POSTGRES_URL, {
+  connect_timeout: 10,
+  idle_timeout: 30,
+  max_lifetime: 0,
+  tls: isProduction() ? { rejectUnauthorized: true } : undefined,
 })
 
 export const db = drizzle({ client, schema })

--- a/web/next/content/docs/manage/documentation.mdx
+++ b/web/next/content/docs/manage/documentation.mdx
@@ -59,6 +59,7 @@ Pages are listed in `web/next/content/docs/meta.json`. **The sequence matters** 
     "manage/robots",
     "manage/sitemap",
     "deployment/docker",
+    "deployment/cloudflare",
     "deployment/vercel",
     "resources/ai-skills",
     "resources/ide-setup",

--- a/web/next/content/docs/meta.json
+++ b/web/next/content/docs/meta.json
@@ -24,6 +24,7 @@
     "manage/robots",
     "manage/sitemap",
     "deployment/docker",
+    "deployment/cloudflare",
     "deployment/vercel",
     "resources/ai-skills",
     "resources/ide-setup",

--- a/web/next/src/lib/config.ts
+++ b/web/next/src/lib/config.ts
@@ -166,6 +166,10 @@ export const config = {
             url: "/docs/deployment/docker",
           },
           {
+            title: "Cloudflare",
+            url: "/docs/deployment/cloudflare",
+          },
+          {
             title: "Vercel",
             url: "/docs/deployment/vercel",
           },


### PR DESCRIPTION
## Summary
- add a Cloudflare worker entrypoint and wrangler.jsonc for api/hono
- add Cloudflare scripts (cf:dev, cf:deploy, cf:typegen) in @api/hono
- switch @packages/db from Bun SQL driver to Postgres.js adapter for broader runtime compatibility
- add a dedicated Cloudflare deployment guide and link it in docs navigation/meta
- update database docs to reflect Postgres.js usage

## Validation
- bun.cmd run check-types (pass)
- bun.cmd run lint (no lint tasks configured)

## Notes
- bun.cmd run format:check failed in this environment with spawn EPERM while setting up external formatter