### PR TITLE
fix: preload fontsource fonts to eliminate layout shift

### DIFF
--- a/web/next/next.config.ts
+++ b/web/next/next.config.ts
@@ -8,6 +8,13 @@ getSafeEnv(env, "@web/next")
 const nextConfig: NextConfig = {
   output: "standalone",
   reactCompiler: true,
+  turbopack: {
+    rules: {
+      "*.woff2": {
+        type: "asset",
+      },
+    },
+  },
   rewrites: async () => {
     return [
       {

--- a/web/next/src/app/layout.tsx
+++ b/web/next/src/app/layout.tsx
@@ -1,6 +1,10 @@
 import { existsSync } from "node:fs"
 import { join } from "node:path"
 
+import caveatUrl from "@fontsource-variable/caveat/files/caveat-latin-wght-normal.woff2"
+import dmSansUrl from "@fontsource-variable/dm-sans/files/dm-sans-latin-wght-normal.woff2"
+import jetbrainsMonoUrl from "@fontsource-variable/jetbrains-mono/files/jetbrains-mono-latin-wght-normal.woff2"
+import newsreaderUrl from "@fontsource-variable/newsreader/files/newsreader-latin-wght-normal.woff2"
 import type { Metadata } from "next"
 
 import { InnerProvider, OuterProvider } from "@/app/providers"
@@ -55,6 +59,36 @@ export default function RootLayout({
   return (
     <OuterProvider>
       <html lang="en" suppressHydrationWarning>
+        <head>
+          <link
+            rel="preload"
+            href={dmSansUrl}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href={caveatUrl}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href={newsreaderUrl}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href={jetbrainsMonoUrl}
+            as="font"
+            type="font/woff2"
+            crossOrigin="anonymous"
+          />
+        </head>
         <body className="min-h-dvh antialiased">
           <InnerProvider>
             <Navbar />

--- a/web/next/src/types/assets.d.ts
+++ b/web/next/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.woff2" {
+  const src: string
+  export default src
+}


### PR DESCRIPTION
## Summary
- Add turbopack `type: "asset"` rule for `.woff2` files so they can be imported as URLs
- Preload latin-subset font files (DM Sans, Caveat, Newsreader, JetBrains Mono) via `<link rel="preload">` in root layout
- Add `.woff2` module type declaration

Eliminates FOUT (Flash of Unstyled Text) by fetching fonts with high priority before CSS is parsed.

## Test plan
- [ ] Verify no layout shift on initial page load in production build
- [ ] Verify fonts render correctly across all pages
- [ ] Check Network tab shows font preload requests with high priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom font support (DM Sans, Caveat, Newsreader, JetBrains Mono) with optimized loading configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->