### PR TITLE
docs: audit and sync documentation to latest

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -2,8 +2,13 @@
 
 > bun audit --audit-level high
 
-Current fixes:
+Current status: **Clean** (no high or critical vulnerabilities as of 2026-03-24).
+
+## Active overrides and pins
 
 - `kysely` — overridden to `^0.28.14` (fixes MySQL SQL injection, GHSA-8cpq-38p9-67gx, GHSA-fr9j-6mvq-frcv). Transitive dep from better-auth and drizzle-orm. Does not affect this project (PostgreSQL only).
-- `esbuild` — NOT overridden. Moderate vulnerability (GHSA-67mh-4wv8-2f99, dev server only). Override to `^0.25.0` breaks fumadocs-mdx build. Dev-only dep, not shipped to production. Will resolve when drizzle-kit/fumadocs-mdx update their esbuild dependency.
 - `fumadocs-core`, `fumadocs-ui` — pinned to `16.7.1`. Versions `16.7.2`–`16.7.5` introduce a breaking change causing "Element type is invalid" errors during static page generation.
+
+## Resolved
+
+- `esbuild` — Moderate vulnerability (GHSA-67mh-4wv8-2f99, dev server only) no longer flagged. Was a dev-only dep not shipped to production.

--- a/web/next/content/docs/getting-started/roadmap.mdx
+++ b/web/next/content/docs/getting-started/roadmap.mdx
@@ -412,16 +412,16 @@ Integration with [Dodo](https://dodopayments.com) for payment processing service
 
 ### Phase 1 (High Priority)
 
-1. **Resend Email** - Critical for user communication
-2. ~~**Better Auth Organizations**~~ - ✅ Implemented
-3. **Stripe Payments** - Essential for monetization
+1. **Vercel AI SDK** - Modern AI capabilities
+2. **Resend Email** - Critical for user communication
+3. ~~**Better Auth Organizations**~~ - ✅ Implemented
+4. **Stripe Payments** - Essential for monetization
 
 ### Phase 2 (Medium Priority)
 
-1. **Vercel AI SDK** - Modern AI capabilities
-2. **Background Tasks** (Inngest/Trigger.dev) - Async processing
-3. ~~**Scalar API Docs**~~ - ✅ Implemented
-4. **next-intl** - Internationalization
+1. **Background Tasks** (Inngest/Trigger.dev) - Async processing
+2. ~~**Scalar API Docs**~~ - ✅ Implemented
+3. **next-intl** - Internationalization
 
 ### Phase 3 (Lower Priority)
 

--- a/web/next/content/docs/manage/blog.mdx
+++ b/web/next/content/docs/manage/blog.mdx
@@ -27,6 +27,11 @@ Blog source is configured in `web/next/source.config.ts`:
 ```ts
 export const blog = defineDocs({
   dir: "content/blog",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 })
 ```
 

--- a/web/next/content/docs/manage/documentation.mdx
+++ b/web/next/content/docs/manage/documentation.mdx
@@ -27,6 +27,11 @@ Documentation source is configured in `web/next/source.config.ts`:
 ```ts
 export const docs = defineDocs({
   dir: "content/docs",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 })
 ```
 

--- a/web/next/content/docs/manage/environment.mdx
+++ b/web/next/content/docs/manage/environment.mdx
@@ -34,7 +34,7 @@ Each package defines only the environment variables it needs:
 - **`db`**: `POSTGRES_URL`
 - **`web-next`**:
   - **Server**: `INTERNAL_API_URL` (server-side only, for internal service-to-service calls)
-  - **Client**: `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_POSTHOG_HOST`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_USERJOT_URL` (exposed to browser)
+  - **Client**: `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_NODE_ENV`, `NEXT_PUBLIC_POSTHOG_HOST`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_USERJOT_URL` (exposed to browser)
 
 **Important**: Server variables cannot be used on the client. Only variables prefixed with `NEXT_PUBLIC_` are exposed to the browser. This prevents sensitive data like secrets and API keys from being exposed in client-side code.
 

--- a/web/next/content/docs/manage/theming.mdx
+++ b/web/next/content/docs/manage/theming.mdx
@@ -57,15 +57,22 @@ The global CSS imports Tailwind, animations, and fonts:
 ```css
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "@fontsource-variable/caveat";
 @import "@fontsource-variable/dm-sans";
+@import "@fontsource-variable/newsreader";
 @import "@fontsource-variable/jetbrains-mono";
+@import "fumadocs-ui/css/neutral.css";
+@import "fumadocs-ui/css/preset.css";
+@import "shadcn/tailwind.css";
 ```
 
 ## Fonts
 
-Two variable fonts are included:
+Four variable fonts are included:
 
 - **DM Sans** — Primary UI font (body text, headings)
+- **Caveat** — Cursive/handwriting font
+- **Newsreader** — Serif font
 - **JetBrains Mono** — Monospace font (code blocks)
 
 ## Component Styling


### PR DESCRIPTION
## Summary

- Update AUDIT.md to reflect clean audit status (no vulnerabilities), move esbuild to resolved
- Add missing Caveat and Newsreader fonts and CSS imports to theming docs
- Add missing `NEXT_PUBLIC_NODE_ENV` to environment variable docs
- Fix Vercel AI SDK priority inconsistency in roadmap (moved to Phase 1 to match High priority)
- Add `postprocess.includeProcessedMarkdown` config to fumadocs `defineDocs` in blog and documentation docs

## Test plan

- [x] Build passes (`bun run build`)
- [x] Lint passes
- [ ] Verify docs render correctly on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security audit status to clean for high/critical vulnerabilities as of latest review
  * Reordered implementation roadmap priorities with updated Phase 1 and Phase 2 focus areas
  * Added new font options (Caveat and Newsreader) available for theming customization
  * Updated environment variables documentation with new configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->