### PR TITLE
fix(openapi): document auth and rate limit responses

### DIFF
--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -8,6 +8,7 @@ import { logger } from "hono/logger"
 import { z } from "zod"
 
 import { errorHandler } from "@/lib/error"
+import { commonErrorResponses, openApiComponents } from "@/lib/openapi"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { authRouter, v1Router } from "@/routers"
 
@@ -79,6 +80,7 @@ const { data } = await response.json()`,
             },
           },
         },
+        ...commonErrorResponses,
       },
     }),
     (c) => {
@@ -92,6 +94,7 @@ const { data } = await response.json()`,
     "/openapi.json",
     openAPIRouteHandler(app, {
       documentation: {
+        components: openApiComponents,
         info: {
           version: BUILD_VERSION,
           title: "ZeroStarter",

--- a/api/hono/src/lib/openapi.ts
+++ b/api/hono/src/lib/openapi.ts
@@ -1,0 +1,102 @@
+import { env } from "@packages/env/api-hono"
+import { resolver } from "hono-openapi"
+import { z } from "zod"
+
+interface ErrorResponse {
+  description: string
+  content: {
+    "application/json": {
+      example: {
+        error: {
+          code: string
+          message: string
+        }
+      }
+      schema: any
+    }
+  }
+}
+
+interface OpenApiComponents {
+  responses: {
+    InternalServerError: ErrorResponse
+    TooManyRequestsError: ErrorResponse
+    UnauthorizedError: ErrorResponse
+  }
+  securitySchemes: {
+    sessionCookie: {
+      description: string
+      in: "cookie"
+      name: string
+      type: "apiKey"
+    }
+  }
+}
+
+function getSessionCookieName(url: string) {
+  const { protocol, hostname } = new URL(url)
+  const parts = hostname.split(".")
+  const isIpAddress = parts.every((part) => /^\d+$/.test(part))
+  const cookiePrefix = !isIpAddress && parts.length >= 4 ? parts[1] : "better-auth"
+  const securePrefix = protocol === "https:" ? "__Secure-" : ""
+
+  return `${securePrefix}${cookiePrefix}.session_token`
+}
+
+const errorSchema = z.object({
+  error: z.object({
+    code: z.string().meta({ example: "INTERNAL_SERVER_ERROR" }),
+    message: z.string().meta({ example: "Internal Server Error" }),
+  }),
+})
+
+function createErrorResponse(description: string, code: string, message: string) {
+  return {
+    description,
+    content: {
+      "application/json": {
+        schema: resolver(errorSchema),
+        example: {
+          error: { code, message },
+        },
+      },
+    },
+  }
+}
+
+export const openApiComponents: OpenApiComponents = {
+  responses: {
+    InternalServerError: createErrorResponse(
+      "Internal Server Error",
+      "INTERNAL_SERVER_ERROR",
+      "Internal Server Error",
+    ),
+    TooManyRequestsError: createErrorResponse(
+      "Too Many Requests",
+      "TOO_MANY_REQUESTS",
+      "Too Many Requests",
+    ),
+    UnauthorizedError: createErrorResponse("Unauthorized", "UNAUTHORIZED", "Unauthorized"),
+  },
+  securitySchemes: {
+    sessionCookie: {
+      type: "apiKey" as const,
+      in: "cookie" as const,
+      name: getSessionCookieName(env.HONO_APP_URL),
+      description:
+        "Better Auth session cookie required for protected API routes. Scalar works best when you already have an active browser session.",
+    },
+  },
+}
+
+export const commonErrorResponses = {
+  429: { $ref: "#/components/responses/TooManyRequestsError" },
+  500: { $ref: "#/components/responses/InternalServerError" },
+}
+
+export const protectedErrorResponses = {
+  401: { $ref: "#/components/responses/UnauthorizedError" },
+  ...commonErrorResponses,
+}
+
+export const protectedRouteSecurity = [{ sessionCookie: [] as string[] }]

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
+import { protectedErrorResponses, protectedRouteSecurity } from "@/lib/openapi"
 import { authMiddleware } from "@/middlewares"
 
 const sessionSchema = z.object({
@@ -35,6 +36,7 @@ export const v1Router = new Hono<{
     describeRoute({
       tags: ["v1"],
       description: "Get current session only",
+      security: protectedRouteSecurity,
       ...({
         "x-codeSamples": [
           {
@@ -56,6 +58,7 @@ const { data } = await response.json()`,
             },
           },
         },
+        ...protectedErrorResponses,
       },
     }),
     (c) => {
@@ -68,6 +71,7 @@ const { data } = await response.json()`,
     describeRoute({
       tags: ["v1"],
       description: "Get current user only",
+      security: protectedRouteSecurity,
       ...({
         "x-codeSamples": [
           {
@@ -89,6 +93,7 @@ const { data } = await response.json()`,
             },
           },
         },
+        ...protectedErrorResponses,
       },
     }),
     (c) => {


### PR DESCRIPTION
## Summary
- add shared OpenAPI response components and a Better Auth session cookie security scheme
- document shared 429/500 responses on public endpoints
- document auth requirements and 401/429/500 responses on protected v1 endpoints

## Verification
- bun --cwd api/hono run check-types
- bun --cwd api/hono run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenAPI documentation with standardized error response definitions including Internal Server Error, Rate Limit, and Unauthorized responses
  * Added security requirements metadata to protected API routes
  * Centralized OpenAPI configuration management for improved documentation maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->