### PR TITLE
chore: update deps and copy build scripts in Dockerfiles

### DIFF
--- a/api/hono/Dockerfile
+++ b/api/hono/Dockerfile
@@ -7,6 +7,7 @@ RUN bunx turbo prune @api/hono --docker
 
 FROM base AS builder
 COPY .env* ./
+COPY --from=prepare /app/.github/scripts .github/scripts
 COPY --from=prepare /app/out/json/ .
 RUN bun install --frozen-lockfile --ignore-scripts
 COPY --from=prepare /app/out/full/ .

--- a/web/next/Dockerfile
+++ b/web/next/Dockerfile
@@ -7,6 +7,7 @@ RUN bunx turbo prune @web/next --docker
 
 FROM base AS builder
 COPY .env* ./
+COPY --from=prepare /app/.github/scripts .github/scripts
 COPY --from=prepare /app/out/json/ .
 RUN bun install --frozen-lockfile --ignore-scripts
 COPY --from=prepare /app/out/full/ .


### PR DESCRIPTION
## Summary
- Update `@takumi-rs/*` packages from v0.73.1 to v1.0.2 and other minor dependency bumps (`turbo`, `@types/bun`, `@tanstack/react-form`, `@typescript/native-preview`)
- Add `COPY --from=prepare /app/.github/scripts .github/scripts` to both `api/hono` and `web/next` Dockerfiles to ensure build scripts (e.g. image compression) are available during Docker builds

## Test plan
- [x] Build passes (`turbo run build`)
- [x] Lint passes
- [ ] Verify Docker builds work with the updated COPY step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to include scripts directory in the builder stage for API and web services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->