### PR TITLE
chore(emulate): tighten AuthLike, derive dashboard URL from Origin, port to 4567

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,12 +9,10 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Logging in (agents)
 
-The auth dialog has a one-click **Login (agents)** button (visible only under `next dev`). It signs you in as `AgentZero` (`agent@zerostarter.dev`).
-
-Headless agents (no browser) hit the same endpoint directly:
+Signs in as `AgentZero` (`agent@zerostarter.dev`). Dev UI: **Login (agents)** button. Headless needs `Origin` matching a trusted origin:
 
 ```bash
-curl -sS -c cookies.txt -X POST http://localhost:4000/api/agents/sign-in-as
+curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```
 

--- a/packages/emulate/package.json
+++ b/packages/emulate/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsdown",
     "check-types": "tsc --noEmit",
-    "dev": "concurrently \"tsdown --watch\" \"emulate --service github --port 4001\""
+    "dev": "concurrently \"tsdown --watch\" \"emulate --service github --port 4567\""
   },
   "dependencies": {
     "@packages/env": "workspace:*",

--- a/packages/emulate/src/index.ts
+++ b/packages/emulate/src/index.ts
@@ -7,11 +7,22 @@ import { genericOAuth } from "better-auth/plugins"
 import { Hono } from "hono"
 
 export type AuthLike = {
-  api: Record<"signInWithOAuth2" | "oAuth2Callback", (a: unknown) => Promise<Response>>
+  api: {
+    signInWithOAuth2: (input: {
+      body: { providerId: string; callbackURL: string }
+      asResponse: true
+    }) => Promise<Response>
+    oAuth2Callback: (input: {
+      query: { code: string; state: string }
+      params: { providerId: string }
+      headers: Headers
+      asResponse: true
+    }) => Promise<Response>
+  }
 }
 
 const PROVIDER_ID = "github-emulate"
-const EMULATOR_URL = "http://localhost:4001"
+const EMULATOR_URL = "http://localhost:4567"
 
 export const emulateAccountLinking = {
   account: {
@@ -45,7 +56,9 @@ export const createAgentsRouter = (auth: AuthLike) =>
     .post("/sign-in-as", async (c) => {
       const fail = (message: string) =>
         c.json({ error: { code: "AGENTS_LOGIN_FAILED", message } }, 500)
-      const dashboardUrl = `${env.HONO_TRUSTED_ORIGINS[0]}/dashboard`
+      const origin = c.req.header("origin")
+      if (!origin) return fail("missing Origin header")
+      const dashboardUrl = `${origin}/dashboard`
 
       const authorize = await auth.api.signInWithOAuth2({
         body: { providerId: PROVIDER_ID, callbackURL: dashboardUrl },


### PR DESCRIPTION
## Summary

Address the [@claude review on PR #409](https://github.com/nrjdalal/zerostarter/pull/409#issuecomment-4363254740):

- **`AuthLike` tightened** — replaced `Record<…, (a: unknown) => Promise<Response>>` with precise call signatures so the inner router gets real type checking on `auth.api.signInWithOAuth2(...)` / `auth.api.oAuth2Callback(...)`. The `as unknown as AuthLike` cast at the call site stays — better-auth's inferred `auth.api` type omits the OAuth2 endpoints because `emulateOAuthConfig()` is added through a conditional `isLocal` plugin spread, so a single-step cast isn't structurally allowed.
- **Dashboard URL from `Origin` header** — replaced `env.HONO_TRUSTED_ORIGINS[0]` with the request's `Origin` header. Browsers send `Origin` automatically on cross-origin POST. Headless callers need `-H "Origin: ..."`; AGENTS.md updated with a one-liner explaining this.
- **Emulator port** 4001 → 4567.

## Test plan

- [x] `bun run check-types` passes
- [x] `bun run build` passes (lefthook pre-commit)
- [x] Browser e2e (Playwright): home → "Login" → dialog → "Login (agents)" → lands at `localhost:3000/dashboard`; `GET /api/v1/user` returns `AgentZero`
- [x] Headless curl: `-c cookies.txt POST -H "Origin: http://localhost:3000"` then `GET /api/v1/user` with `-b cookies.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated headless login instructions to include a required `Origin` header.

* **Updates**
  * Emulator service now runs on port 4567 (previously 4001).
  * Sign-in flow now derives callback URLs from the request `Origin` header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->