### PR TITLE
feat(agents): mint sessions directly, drop emulate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localh
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```
 
-Backed by a local `emulate` CLI (port 4567) configured via `api/hono/emulate.config.yaml`, started by `api/hono`'s dev script. Gated to local in both `packages/auth` and `api/hono/src/routers/agents.ts`.
+The endpoint at `api/hono/src/routers/agents.ts` mints a session directly via better-auth's internal adapter. Gated to local NODE_ENV.
 
 ## Skills
 

--- a/api/hono/emulate.config.yaml
+++ b/api/hono/emulate.config.yaml
@@ -1,4 +1,0 @@
-github:
-  users:
-    - login: AgentZero
-      email: agent@zerostarter.dev

--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify",
     "check-types": "tsc --noEmit",
-    "dev": "concurrently \"tsdown --watch\" \"bun --hot src/index.ts\" \"emulate --service github --port 4567\"",
+    "dev": "concurrently \"tsdown --watch\" \"bun --hot src/index.ts\"",
     "start": "bun bundle/index.mjs"
   },
   "dependencies": {
@@ -20,6 +20,7 @@
     "@packages/auth": "workspace:*",
     "@packages/env": "workspace:*",
     "@scalar/hono-api-reference": "catalog:",
+    "better-auth": "catalog:",
     "hono": "catalog:",
     "hono-openapi": "catalog:",
     "hono-rate-limiter": "catalog:",
@@ -30,7 +31,6 @@
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "concurrently": "catalog:",
-    "emulate": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   }

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -1,69 +1,45 @@
-import { auth, EMULATE_PROVIDER_ID, EMULATE_URL } from "@packages/auth"
+import { auth } from "@packages/auth"
 import { isLocal } from "@packages/env"
 import { env } from "@packages/env/api-hono"
+import { makeSignature } from "better-auth/crypto"
 import { Hono } from "hono"
+import { setCookie } from "hono/cookie"
 
-type EmulateAuthApi = {
-  signInWithOAuth2: (input: {
-    body: { providerId: string; callbackURL: string }
-    asResponse: true
-  }) => Promise<Response>
-  oAuth2Callback: (input: {
-    query: { code: string; state: string }
-    params: { providerId: string }
-    headers: Headers
-    asResponse: true
-  }) => Promise<Response>
-}
-
-// dts can't see the genericOAuth plugin's API additions: it's added through a
-// conditional isLocal spread in packages/auth and BetterAuthPlugin (required by
-// tsgo) erases the contributed methods.
-const emulateApi = auth.api as unknown as EmulateAuthApi
+const AGENT_EMAIL = "agent@zerostarter.dev"
+const AGENT_NAME = "AgentZero"
 
 export const agentsRouter = new Hono()
   .use(async (c, next) => (isLocal(env.NODE_ENV) ? next() : c.notFound()))
   .post("/sign-in-as", async (c) => {
-    const fail = (message: string) =>
-      c.json({ error: { code: "AGENTS_LOGIN_FAILED", message } }, 500)
     // Trusting Origin is safe only because the router middleware above gates this to local.
     const origin = c.req.header("origin")
-    if (!origin) return fail("missing Origin header")
-    const dashboardUrl = `${origin}/dashboard`
+    if (!origin) {
+      return c.json(
+        { error: { code: "AGENTS_LOGIN_FAILED", message: "missing Origin header" } },
+        500,
+      )
+    }
 
-    const authorize = await emulateApi.signInWithOAuth2({
-      body: { providerId: EMULATE_PROVIDER_ID, callbackURL: dashboardUrl },
-      asResponse: true,
-    })
-    const { url: authorizeUrl } = (await authorize.json()) as { url: string }
-    // Cookie header is name=value pairs only; getSetCookie() avoids the multi-cookie collapse
-    const stateCookie = authorize.headers
-      .getSetCookie()
-      .map((setCookie) => setCookie.split(";")[0])
-      .join("; ")
+    const ctx = await auth.$context
+    const existing = await ctx.internalAdapter.findUserByEmail(AGENT_EMAIL)
+    const user =
+      existing?.user ??
+      (await ctx.internalAdapter.createUser({
+        email: AGENT_EMAIL,
+        name: AGENT_NAME,
+        emailVerified: true,
+      }))
 
-    const pickerForm = new URL(authorizeUrl).searchParams
-    pickerForm.set("login", "AgentZero")
-    const pickerResponse = await fetch(`${EMULATE_URL}/login/oauth/callback`, {
-      method: "POST",
-      body: pickerForm,
-      redirect: "manual",
+    const session = await ctx.internalAdapter.createSession(user.id)
+    const signed = `${session.token}.${await makeSignature(session.token, ctx.secret)}`
+    const { name, attributes } = ctx.authCookies.sessionToken
+    setCookie(c, name, signed, {
+      path: attributes.path,
+      maxAge: attributes.maxAge,
+      httpOnly: attributes.httpOnly ?? true,
+      secure: attributes.secure,
+      sameSite: attributes.sameSite ?? "Lax",
+      domain: attributes.domain,
     })
-    const location = pickerResponse.headers.get("location")
-    if (!location) return fail("emulator picker did not redirect")
-    const callbackParams = new URL(location).searchParams
-    const code = callbackParams.get("code")
-    const state = callbackParams.get("state")
-    if (!code || !state) return fail("emulator did not return code/state")
-
-    const session = await emulateApi.oAuth2Callback({
-      query: { code, state },
-      params: { providerId: EMULATE_PROVIDER_ID },
-      headers: new Headers({ cookie: stateCookie }),
-      asResponse: true,
-    })
-    session.headers
-      .getSetCookie()
-      .forEach((setCookie) => c.header("Set-Cookie", setCookie, { append: true }))
-    return c.redirect(dashboardUrl, 302)
+    return c.redirect(`${origin}/dashboard`, 302)
   })

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "@packages/auth": "workspace:*",
         "@packages/env": "workspace:*",
         "@scalar/hono-api-reference": "catalog:",
+        "better-auth": "catalog:",
         "hono": "catalog:",
         "hono-openapi": "catalog:",
         "hono-rate-limiter": "catalog:",
@@ -40,7 +41,6 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "concurrently": "catalog:",
-        "emulate": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
       },
@@ -1322,8 +1322,6 @@
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
-
-    "emulate": ["emulate@0.5.0", "", { "dependencies": { "@hono/node-server": "^1", "commander": "^14", "picocolors": "^1.1.1", "yaml": "^2" }, "bin": { "emulate": "dist/index.js" } }, "sha512-2LrOE8sqa1ITQ1aRR3kZhAhOCNz8hu+Kea9oBKdG/jEK6I/RYlMgHbsvQmbTTtr+nx6+fOOWkL6wqvfLeF5vuA=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -10,42 +10,15 @@ import {
   user,
   verification,
 } from "@packages/db"
-import { isLocal } from "@packages/env"
 import { env } from "@packages/env/auth"
-import { type BetterAuthPlugin, betterAuth } from "better-auth"
+import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
-import {
-  genericOAuth,
-  openAPI as openAPIPlugin,
-  organization as organizationPlugin,
-} from "better-auth/plugins"
+import { openAPI as openAPIPlugin, organization as organizationPlugin } from "better-auth/plugins"
 
 import { getCookieDomain, getCookiePrefix } from "@/lib/utils"
 
 const cookieDomain = getCookieDomain(env.HONO_APP_URL)
 const cookiePrefix = getCookiePrefix(env.HONO_APP_URL)
-
-export const EMULATE_PROVIDER_ID = "github-emulate"
-export const EMULATE_URL = "http://localhost:4567"
-
-const emulateOAuthPlugin: BetterAuthPlugin = genericOAuth({
-  config: [
-    {
-      providerId: EMULATE_PROVIDER_ID,
-      clientId: "emulate",
-      clientSecret: "emulate",
-      authorizationUrl: `${EMULATE_URL}/login/oauth/authorize`,
-      tokenUrl: `${EMULATE_URL}/login/oauth/access_token`,
-      userInfoUrl: `${EMULATE_URL}/user`,
-      scopes: ["read:user", "user:email"],
-      mapProfileToUser: ({ name, login, email, avatar_url }) => ({
-        name: name ?? login,
-        email,
-        image: avatar_url,
-      }),
-    },
-  ],
-})
 
 export const auth = betterAuth({
   baseURL: env.HONO_APP_URL,
@@ -72,7 +45,6 @@ export const auth = betterAuth({
     organizationPlugin({
       teams: { enabled: true },
     }),
-    ...(isLocal(env.NODE_ENV) ? [emulateOAuthPlugin] : []),
   ],
   socialProviders: {
     github: {
@@ -84,9 +56,6 @@ export const auth = betterAuth({
       clientSecret: env.GOOGLE_CLIENT_SECRET,
     },
   },
-  ...(isLocal(env.NODE_ENV)
-    ? { account: { accountLinking: { enabled: true, trustedProviders: [EMULATE_PROVIDER_ID] } } }
-    : {}),
   advanced: {
     ...(cookiePrefix && { cookiePrefix }),
     ...(cookieDomain && {


### PR DESCRIPTION
## Summary

Replaces the emulate-backed OAuth dance for headless agent login with a direct session mint via better-auth's internal adapter. Drops `@packages/emulate`'s last footprint: the `emulate` devDep, the concurrent CLI process on port 4567, and the seed yaml.

## Why

The emulate stack existed only to back `/api/agents/sign-in-as`. Agents don't need OAuth-flow fidelity — they just need a session as AgentZero. The OAuth path is already exercised by real GitHub/Google sign-ins, so emulate added no test coverage that wasn't already there.

## Changes

- `api/hono/src/routers/agents.ts` — find/create AgentZero via `ctx.internalAdapter.findUserByEmail` + `createUser`, mint via `createSession`, sign cookie with `makeSignature`, set via Hono `setCookie`, redirect. ~70 lines → ~45.
- `api/hono` — drop `emulate` devDep + emulate slot in dev script; add `better-auth` as a direct dep (now imported for `crypto`).
- `api/hono/emulate.config.yaml` — deleted.
- `packages/auth/src/index.ts` — drop `emulateOAuthPlugin`, `accountLinking`, `EMULATE_PROVIDER_ID`/`EMULATE_URL` exports, conditional `isLocal` spreads.
- `AGENTS.md` — trim the emulate-process reference.

## Trade-off

Couples to better-auth's `internalAdapter` + `makeSignature` (exported but lower-level than `auth.api`). A breaking change there would need a touch-up. Dev-only gate keeps blast radius nil.

## Test plan

- [x] `@api/hono` check-types green
- [x] `@packages/auth` check-types green
- [x] Headless: `POST /api/agents/sign-in-as` → 302, `GET /api/v1/user` returns AgentZero
- [x] Browser (agent-browser): Login → Login (agents) → `/dashboard` with AgentZero sidebar identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent sign-in documentation to reflect current authentication flow.

* **Chores**
  * Removed local OAuth emulation infrastructure.
  * Simplified development environment setup by eliminating separate emulator process.
  * Updated dependencies to reflect infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->