### PR TITLE
chore(env): inline polyfill defaults under SKIP_ENV_VALIDATION

### DIFF
--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -34,5 +34,3 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: true
           NODE_ENV: production
-          NEXT_PUBLIC_APP_URL: https://polyfill.url
-          NEXT_PUBLIC_API_URL: https://polyfill.url

--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -32,5 +32,5 @@ jobs:
           bun run lint
           bun run build
         env:
-          SKIP_ENV_VALIDATION: true
           NODE_ENV: production
+          SKIP_ENV_VALIDATION: true

--- a/packages/env/src/web-next.ts
+++ b/packages/env/src/web-next.ts
@@ -11,14 +11,8 @@ export const env = createEnv({
   },
   clientPrefix: "NEXT_PUBLIC_",
   client: {
-    NEXT_PUBLIC_APP_URL:
-      process.env.SKIP_ENV_VALIDATION === "true"
-        ? z.url().default("https://polyfill.url")
-        : z.url(),
-    NEXT_PUBLIC_API_URL:
-      process.env.SKIP_ENV_VALIDATION === "true"
-        ? z.url().default("https://polyfill.url")
-        : z.url(),
+    NEXT_PUBLIC_APP_URL: z.url(),
+    NEXT_PUBLIC_API_URL: z.url(),
     NEXT_PUBLIC_NODE_ENV: NODE_ENV,
     NEXT_PUBLIC_POSTHOG_HOST: z.url().optional(),
     NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
@@ -27,8 +21,14 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     INTERNAL_API_URL: process.env.INTERNAL_API_URL,
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
-    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    // Polyfills only apply when SKIP_ENV_VALIDATION=true; production deploys
+    // still hard-fail on missing values because the schema's z.url() runs.
+    NEXT_PUBLIC_API_URL:
+      process.env.NEXT_PUBLIC_API_URL ??
+      (process.env.SKIP_ENV_VALIDATION === "true" ? "https://polyfill.url" : undefined),
+    NEXT_PUBLIC_APP_URL:
+      process.env.NEXT_PUBLIC_APP_URL ??
+      (process.env.SKIP_ENV_VALIDATION === "true" ? "https://polyfill.url" : undefined),
     NEXT_PUBLIC_NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,

--- a/packages/env/src/web-next.ts
+++ b/packages/env/src/web-next.ts
@@ -11,8 +11,14 @@ export const env = createEnv({
   },
   clientPrefix: "NEXT_PUBLIC_",
   client: {
-    NEXT_PUBLIC_APP_URL: z.url(),
-    NEXT_PUBLIC_API_URL: z.url(),
+    NEXT_PUBLIC_APP_URL:
+      process.env.SKIP_ENV_VALIDATION === "true"
+        ? z.url().default("https://polyfill.url")
+        : z.url(),
+    NEXT_PUBLIC_API_URL:
+      process.env.SKIP_ENV_VALIDATION === "true"
+        ? z.url().default("https://polyfill.url")
+        : z.url(),
     NEXT_PUBLIC_NODE_ENV: NODE_ENV,
     NEXT_PUBLIC_POSTHOG_HOST: z.url().optional(),
     NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),

--- a/packages/env/src/web-next.ts
+++ b/packages/env/src/web-next.ts
@@ -21,8 +21,6 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     INTERNAL_API_URL: process.env.INTERNAL_API_URL,
-    // Polyfills only apply when SKIP_ENV_VALIDATION=true; production deploys
-    // still hard-fail on missing values because the schema's z.url() runs.
     NEXT_PUBLIC_API_URL:
       process.env.NEXT_PUBLIC_API_URL ??
       (process.env.SKIP_ENV_VALIDATION === "true" ? "https://polyfill.url" : undefined),


### PR DESCRIPTION
## Summary

Moves the `NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_API_URL` polyfill values out of the `auto-check-build.yml` workflow and into the env schema, gated by `SKIP_ENV_VALIDATION=true`. Any CI/contributor build that already sets `SKIP_ENV_VALIDATION` is now self-sufficient — no need to also remember the URL polyfills.

## Why

Next.js itself doesn't require these. The constraint comes from `packages/env/src/web-next.ts` declaring them as `z.url()` (required), and from build-time SSG code that calls `new URL(env.NEXT_PUBLIC_APP_URL)` in sitemap/OG/metadata routes. With `SKIP_ENV_VALIDATION=true` the schema parse is skipped but the inlined value is still `undefined`, so URL constructors crashed during `next build`. Polyfilling at the workflow level worked but leaked CI-shaped concerns into a shared workflow file.

The conditional default keeps the production guarantee — real deploys (no `SKIP_ENV_VALIDATION`) still hard-fail when these vars are missing.

## Changes

- `packages/env/src/web-next.ts` — `NEXT_PUBLIC_APP_URL` / `NEXT_PUBLIC_API_URL` get a `https://polyfill.url` default only when `SKIP_ENV_VALIDATION=true`. Otherwise unchanged (required `z.url()`).
- `.github/workflows/auto-check-build.yml` — drop the two `NEXT_PUBLIC_*` lines, keep `SKIP_ENV_VALIDATION` and `NODE_ENV`.

## Test plan

- [x] `bun run clean && bun install && SKIP_ENV_VALIDATION=true NODE_ENV=production bun run build` — 5/5 tasks pass, bundle sizes unchanged.
- [ ] CI workflow re-runs green with the trimmed env block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment configuration to skip validation during builds and enable production mode.
  * Enhanced environment variable validation with default fallback values when validation is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->