### PR TITLE
fix(api): keep hono external in the Bun bundle for Vercel deploys

### DIFF
--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.mts",
   "exports": "./dist/index.mjs",
   "scripts": {
-    "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify",
+    "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify --external hono",
     "check-types": "tsc --noEmit",
     "dev": "concurrently \"tsdown --watch\" \"bun --hot src/index.ts\"",
     "start": "bun bundle/index.mjs"


### PR DESCRIPTION
## Summary
- Prod (`api.zerostarter.dev`) returns `FUNCTION_INVOCATION_FAILED` on every route. Runtime crashes at startup with Bun `ResolveMessage {}` because `dist/index.mjs` externalizes runtime deps (better-auth and subpaths, @scalar/hono-api-reference, etc.) and Vercel's function packager can't find them under the project's `rootDirectory: api/hono`.
- Fix: ship the self-contained Bun bundle (`bundle/index.mjs`) as the function output. Vercel's `framework: "hono"` preset requires a literal `import` from `"hono"` in the entry, so keep just `hono` external in the bundle step. Everything else stays inlined, no runtime `node_modules` lookup.

## Test plan
- [x] Local build: `bun run --filter=@api/hono build` produces `bundle/index.mjs` (~1.4 MB) with `import { ... } from "hono"` preserved literally.
- [x] Preview deploy from this branch returns 200 on both `/` and `/api/health`:
  - https://apizerostarter-9nq1p8r2e-nrjdalal.vercel.app/ → `{"data":{"version":"0.0.15","environment":"production"}}`
  - https://apizerostarter-9nq1p8r2e-nrjdalal.vercel.app/api/health → `{"data":{"message":"ok",...}}`
- [ ] After merge to canary → auto-PR rolls into main → confirm `api.zerostarter.dev` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build configuration to improve compatibility and optimize the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nrjdalal/zerostarter/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->