### PR TITLE
fix: restore turbo build graph skill with working graphviz pipeline

### DIFF
--- a/.agents/skills/turbo/generate-build-graph/SKILL.md
+++ b/.agents/skills/turbo/generate-build-graph/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: turbo-generate-build-graph
+description: Generates a styled SVG dependency graph of the Turborepo build pipeline. Use when the user asks to visualize dependencies, generate a build graph, or update the pipeline diagram.
+---
+
+# Turbo Build Graph
+
+Creates a dark-mode-friendly SVG visualization of Turborepo task dependencies.
+
+## Workflow
+
+### 1. Generate Raw Graph
+
+```bash
+npx turbo run build --graph=graph.dot
+dot -Tsvg graph.dot -o graph.svg && rm graph.dot
+```
+
+Turbo 2.x renders `--graph=*.svg` with its own built-in renderer, which produces rough output. Emit DOT and render via Graphviz `dot` instead. Requires Graphviz (`brew install graphviz` on macOS, `apt-get install graphviz` on Linux).
+
+### 2. Clean Up Labels
+
+```bash
+sed -i '' 's/\[root\] //g; s/#build//g; s/___ROOT___/ZeroStarter/g' graph.svg
+```
+
+- Remove `[root] ` prefix from package names
+- Remove `#build` suffix from task labels
+- Replace internal `___ROOT___` placeholder with project name
+
+### 3. Style for Dark Mode / Transparency
+
+```bash
+# Transparent background
+sed -i '' 's/fill="white"/fill="none"/g; s/fill="#ffffff"/fill="none"/g; s/fill="#fff"/fill="none"/g' graph.svg
+
+# GitHub blue (#1f6feb) for nodes and text
+sed -i '' 's/fill="black"/fill="#1f6feb"/g' graph.svg
+sed -i '' 's/stroke="[^"]*"/stroke="#1f6feb"/g; s/stroke:[^;]*;/stroke:#1f6feb;/g' graph.svg
+sed -i '' 's/<text\([^>]*\)>/<text\1 fill="#1f6feb">/g' graph.svg
+
+# Remove arrowhead strokes (cleaner look)
+sed -i '' 's/stroke="#1f6feb" points="-4,4/stroke="none" points="-4,4/g' graph.svg
+```
+
+### 4. Move to Assets
+
+```bash
+mkdir -p .github/assets
+mv graph.svg .github/assets/graph-build.svg
+```
+
+Output: `.github/assets/graph-build.svg`
+
+## Usage in README
+
+```markdown
+![Build Graph](.github/assets/graph-build.svg)
+```
+
+## Notes
+
+- Run from repository root
+- Requires `turbo` (installed via workspace dependencies) and Graphviz `dot`
+- macOS `sed -i ''` syntax; on Linux use `sed -i` (no empty string)

--- a/web/next/content/docs/resources/ai-skills.mdx
+++ b/web/next/content/docs/resources/ai-skills.mdx
@@ -65,7 +65,7 @@ Generates a styled SVG visualization of Turborepo task dependencies.
 
 **Workflow**:
 
-1. **Generate Raw Graph**: `npx turbo run build --graph=graph.svg`
+1. **Generate Raw Graph**: `npx turbo run build --graph=graph.dot`, then render with Graphviz: `dot -Tsvg graph.dot -o graph.svg` (turbo 2.x renders `.svg` with its own rough built-in renderer, so emit DOT and use `dot`)
 2. **Clean Up Labels**: Remove prefixes and internal placeholders
 3. **Style for Dark Mode**: Apply transparent background and GitHub blue theme
 4. **Move to Public Assets**: Save to `web/next/public/graph-build.svg`


### PR DESCRIPTION
## Summary

- Restore `.agents/skills/turbo/generate-build-graph/SKILL.md`, the AI-skills docs page references this location but the skill file no longer exists in the repo
- Fix the broken first step: `turbo run build --graph=graph.svg` no longer produces graphviz output on turbo 2.x (turbo now ships its own rough SVG renderer). The working pipeline is `--graph=graph.dot` followed by `dot -Tsvg`, which reproduces the committed `.github/assets/graph-build.svg` byte-for-byte after the existing sed transforms
- Update the workflow step in `docs/resources/ai-skills.mdx` to match

## Verification

Ran the fixed pipeline against this repo's committed `graph-build.svg`: output is identical besides the graphviz version comment (14.0.4 vs 15.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Turbo Build Graph" skill workflow documentation to clarify step 1 generates a raw build graph as a DOT file and converts it to SVG format using Graphviz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->