### PR TITLE
fix: skip compress-images when public dir is missing

### DIFF
--- a/.github/scripts/compress-images.ts
+++ b/.github/scripts/compress-images.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import path from "path"
 
 import { Glob } from "bun"
@@ -9,6 +10,12 @@ const scriptDir = path.dirname(Bun.main)
 const publicDir = path.resolve(scriptDir, "../../web/next/public")
 const isCI = !!process.env.CI
 const CONCURRENCY = 8
+
+// public/ may be absent on fresh checkouts when emptied (git does not track empty dirs)
+if (!existsSync(publicDir)) {
+  console.log("compress-images: public dir not found, skipping")
+  process.exit(0)
+}
 
 const rasterGlob = new Glob("**/*.{png,jpg,jpeg,webp,avif}")
 const svgGlob = new Glob("**/*.svg")


### PR DESCRIPTION
## Summary

`compress-images.ts` crashes with `ENOENT ... web/next/public` when the directory does not exist, which breaks `bun run build` entirely (it is the first step of `@web/next#build`).

This happens on any fresh checkout after a template consumer empties `web/next/public/` (e.g. removing the starter landing assets), since git does not track empty directories. Hit this in production use downstream: local builds pass (empty dir still on disk) while CI fails on every PR.

Skip gracefully with a log line instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability by adding a startup guard that gracefully handles missing directories, preventing errors during fresh checkouts without impacting image compression functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->