### PR TITLE
fix(api): keep hono external in the Bun bundle for Vercel deploys (remerge #416)

### DIFF
--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.mts",
   "exports": "./dist/index.mjs",
   "scripts": {
-    "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify",
+    "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify --external hono",
     "check-types": "tsc --noEmit",
     "dev": "concurrently \"tsdown --watch\" \"bun --hot src/index.ts\"",
     "start": "bun bundle/index.mjs"


### PR DESCRIPTION
## Summary

Re-applies #416, which was merged on 2026-05-21 but its change is no longer present on `canary` HEAD (`api/hono/package.json` build script lost `--external hono`, likely clobbered by a later merge or revert).

Without it, prod API deploys crash at startup (`FUNCTION_INVOCATION_FAILED`): Vercel's `framework: "hono"` preset requires a literal `import` from `"hono"` in the bundle entry. See #416 for the original investigation and test plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)