### PR TITLE
fix(api): self-contained bundle, vercel-scoped external entry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,10 +49,10 @@ dist/
 vercel-bundle/
 
 # custom files
-*.local.json
-!.env*
 .npmrc
+*.local.json
 cookies.txt
 
 # docker overrides
+!.env*
 .env.example

--- a/.dockerignore
+++ b/.dockerignore
@@ -46,6 +46,7 @@ next-env.d.ts
 .turbo/
 bundle/
 dist/
+vercel-bundle/
 
 # custom files
 *.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ next-env.d.ts
 .turbo/
 bundle/
 dist/
+vercel-bundle/
 
 # custom files
 !.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,9 @@ dist/
 vercel-bundle/
 
 # custom files
-!.env.example
 .npmrc
 *.local.json
 cookies.txt
+
+# git overrides
+!.env.example

--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -9,7 +9,8 @@
   "types": "./dist/index.d.mts",
   "exports": "./dist/index.mjs",
   "scripts": {
-    "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify --external hono",
+    "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify",
+    "build:vercel": "tsdown && bun build dist/index.mjs --outfile vercel-bundle/index.mjs --target bun --minify --external hono",
     "check-types": "tsc --noEmit",
     "dev": "concurrently \"tsdown --watch\" \"bun --hot src/index.ts\"",
     "start": "bun bundle/index.mjs"

--- a/api/hono/vercel.json
+++ b/api/hono/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "hono",
   "installCommand": "cd ../.. && bun install --ignore-scripts",
-  "buildCommand": "cd ../.. && turbo build --filter=@api/hono",
-  "outputDirectory": "bundle",
+  "buildCommand": "cd ../.. && turbo build:vercel --filter=@api/hono",
+  "outputDirectory": "vercel-bundle",
   "bunVersion": "1.3.10"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", ".source/**", "bundle/**", "dist/**"]
     },
+    "build:vercel": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "vercel-bundle/**"]
+    },
     "check-types": {
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
## Problem

`--external hono` in the shared bundle build (#416, re-merged in #424) exists only for Vercel's hono builder, which detects the entrypoint by regex-scanning the entry file for a literal hono import. But the flag breaks the bundle's actual contract:

- the Docker runner stage ships only `bundle/` with no `node_modules`, so offline it crashes at startup with `Cannot find package 'hono'`
- with network, Bun's runtime auto-install silently fetches an **unpinned** hono from npm on every cold start (`docker diff` shows it landing in `~/.bun/install/cache`)

## Fix

Each platform builds its own artifact:

- `build` stays the pure self-contained bundle: `tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify` (Docker, local, `start`)
- a new `build:vercel` turbo task builds `vercel-bundle/index.mjs` with `--external hono`; `vercel.json` runs it via `buildCommand` and serves `outputDirectory: "vercel-bundle"` — the Vercel quirk stays confined to the Vercel config, with full task-graph caching (the pure bundle is never built on Vercel)

## Verified (downstream first, now porting up)

The scheme was developed and fully verified on a ZeroStarter derivative:

| Test | Result |
| --- | --- |
| pure bundle, `docker compose build --no-cache && up` | health 200 from host |
| pure bundle, `docker run --network=none`, zero node_modules | health 200, no runtime auto-install |
| flagged bundle, `docker run --network=none` (the status quo) | crash: `Cannot find package 'hono'` |
| serving `dist` instead (rejected alternative) | passes builder detection, crashes at runtime with `ResolveMessage {}` — reconfirms #416 |
| `vercel-bundle/` on a git-triggered Vercel preview | health + db-backed route + docs all 200 |

This PR's own Vercel preview deployment is the upstream verification of the `vercel-bundle/` path; a local `docker compose` + offline-run check on this branch is in flight and will be reported in a comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build and deployment configuration to produce a dedicated deployment bundle and a matching build task.
  * Updated ignore rules to exclude the deployment bundle from repository and Docker build contexts.
  * Added a deployment-specific build script alongside the existing build pipeline for clearer deployment outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->