### PR TITLE
fix(env): prefer deploy-time sha over baked git sha in build version

### DIFF
--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -1,4 +1,4 @@
-import { BUILD_VERSION } from "@packages/env"
+import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
@@ -10,6 +10,8 @@ import { z } from "zod"
 import { errorHandler } from "@/lib/error"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router } from "@/routers"
+
+const BUILD_VERSION = getBuildVersion()
 
 const app = new Hono()
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -3,6 +3,7 @@ export {
   VERSION,
   GIT_SHA,
   BUILD_VERSION,
+  getBuildVersion,
   NODE_ENV,
   isLocal,
   isDevelopment,

--- a/packages/env/src/lib/constants.ts
+++ b/packages/env/src/lib/constants.ts
@@ -9,6 +9,16 @@ export const VERSION = __VERSION__
 export const GIT_SHA = __GIT_SHA__
 export const BUILD_VERSION = __BUILD_VERSION__
 
+// Baked __GIT_SHA__ freezes at the last source-changing build under turbo cache
+// replays; prefer the platform's deploy-time sha when one exists (#428)
+export const getBuildVersion = (): string => {
+  const sha =
+    typeof process === "undefined"
+      ? ""
+      : (process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ?? process.env.GIT_SHA ?? "")
+  return sha ? `${VERSION}-${sha}` : BUILD_VERSION
+}
+
 export const NODE_ENV = z.enum(["local", "development", "test", "staging", "production"])
 
 export type NodeEnv = z.infer<typeof NODE_ENV>


### PR DESCRIPTION
Fixes #428.

`BUILD_VERSION`'s sha is baked into `@packages/env` dist at build time, and turbo's content-addressed cache replays that dist across commits, so `/api/health` reports the sha of the last source-changing build instead of the deployed commit (observed: canary at `07e43b6` serving `0.0.15-3394804`).

## Fix

New `getBuildVersion()` in `@packages/env`: prefers `VERCEL_GIT_COMMIT_SHA` (sliced to 7) then `GIT_SHA` at runtime, falling back to the baked value. The API binds it once at module scope. Web keeps the baked `BUILD_VERSION` untouched, sidebar components render it client-side, and a runtime/baked split there would risk hydration mismatches.

Bonus: Docker images (where `turbo prune` strips `.git`, so the baked sha is empty) can now be labeled at runtime with `-e GIT_SHA=...`.

## Verified locally

| Scenario | `/api/health` version |
| --- | --- |
| no env (baked fallback) | `0.0.15-07e43b6` |
| `VERCEL_GIT_COMMIT_SHA=cafebabe...` | `0.0.15-cafebab` |
| `GIT_SHA=abc1234` | `0.0.15-abc1234` |

## The real proof comes free with the next release

On the canary → main release merge, `@packages/env` cache-hits (identical sources) with the stale baked sha, while `VERCEL_GIT_COMMIT_SHA` is the fresh main merge commit. Production showing the main sha = the runtime path working in exactly the scenario #428 describes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Build version is now calculated at runtime based on deployment information, ensuring API responses reflect accurate version details with a fallback mechanism in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->