### PR TITLE
fix(ci): single honest check-build run, gh-hardened release PR automation

### DIFF
--- a/.github/workflows/auto-canary-into-main.yml
+++ b/.github/workflows/auto-canary-into-main.yml
@@ -21,36 +21,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Check if PR already exists
-        id: check-if-pr-exists
+      - name: Create release PR if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_RESPONSE=$(curl -sL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:canary&base=main&state=open")
-
-          PR_NUMBER=$(echo "$PR_RESPONSE" | bunx fx 'x => x[0]?.number ?? null')
-
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" == "null" ]; then
-            echo "pr_exists=false" >> $GITHUB_OUTPUT
-          else
-            echo "pr_exists=true" >> $GITHUB_OUTPUT
-            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          EXISTING=$(gh pr list --head canary --base main --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Pull request #$EXISTING already exists. Skipping creation."
+            exit 0
           fi
+          gh pr create --head canary --base main --draft \
+            --title "ci(release): 🚀 merge canary into main" \
+            --body "This PR was automatically created to merge changes from canary into main.
 
-      - name: Create Pull Request
-        if: steps.check-if-pr-exists.outputs.pr_exists == 'false'
-        run: |
-          curl -sL -X POST \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls" \
-            -d "{\"title\": \"ci(release): 🚀 merge canary into main\", \"head\": \"canary\", \"base\": \"main\", \"body\": \"This PR was automatically created to merge changes from canary into main.\", \"draft\": true}"
-
-      - name: Log existing PR
-        if: steps.check-if-pr-exists.outputs.pr_exists == 'true'
-        run: |
-          echo "Pull request #${{ steps.check-if-pr-exists.outputs.pr_number }} already exists. Skipping creation."
+          > [!IMPORTANT]
+          > Merge with a **merge commit** (not squash), so main keeps shared history with canary and future release diffs stay clean."

--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["canary", "main"]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    branches: ["canary", "main"]
   pull_request_review:
     types: [submitted, edited, dismissed]
 


### PR DESCRIPTION
## Summary

Two CI hygiene fixes proven downstream (dalonic/cafe).

**auto-check-build ran twice per PR, and the second run lied.** The `pull_request_target` trigger duplicated every run, and its bare checkout tests the base branch, not the PR: when the base is broken, every PR shows red even if it contains the fix. Dropping the target trigger leaves one honest run. Closes #422.

**auto-canary-into-main's curls swallowed errors.** A failed API call logged nothing and the workflow stayed green. The two curl steps collapse into one `gh` step (loud failures, no `bunx fx` JSON parsing, one less setup step), and the release PR body gains the merge-commit callout so a UI squash of a release PR stops being a one-click history disconnect (downstream learned that one the hard way).

## Changes

- `auto-check-build.yml`: `pull_request_target` trigger removed
- `auto-canary-into-main.yml`: curl + fx replaced by `gh pr list`/`gh pr create`, Bun setup step dropped, release PR body carries the merge-method callout

## Verification

- Downstream runs this exact shape: single check runs per PR since the equivalent change, and the gh-based release PR automation created every draft since
- YAML structure validated; the body's blank-line and callout de-indentation checked against the literal block base

Ported from dalonic/cafe (private downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release PR creation workflow to use GitHub CLI tooling
  * Modified build check workflow trigger configuration for improved pull request handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->