### PR TITLE
fix(docker): build from a clean checkout, env via required build secret

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,5 +54,4 @@ vercel-bundle/
 cookies.txt
 
 # docker overrides
-!.env*
-.env.example
+!.env.example

--- a/api/hono/Dockerfile
+++ b/api/hono/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM oven/bun:1.3.10-alpine AS base
 WORKDIR /app
 
@@ -6,12 +7,11 @@ COPY . .
 RUN bunx turbo prune @api/hono --docker
 
 FROM base AS builder
-COPY .env* ./
 COPY --from=prepare /app/.github/scripts .github/scripts
 COPY --from=prepare /app/out/json/ .
 RUN bun install --frozen-lockfile --ignore-scripts
 COPY --from=prepare /app/out/full/ .
-RUN bunx turbo run build --filter=@api/hono
+RUN --mount=type=secret,id=dotenv,target=/app/.env,required=true bunx turbo run build --filter=@api/hono
 
 FROM base AS runner
 WORKDIR /app/api/hono

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: api/hono/Dockerfile
+      secrets:
+        - dotenv
     env_file:
       - .env
     environment:
@@ -14,9 +16,15 @@ services:
     build:
       context: .
       dockerfile: web/next/Dockerfile
+      secrets:
+        - dotenv
     env_file:
       - .env
     environment:
       - INTERNAL_API_URL=http://api:4000
     ports:
       - "3000:3000"
+
+secrets:
+  dotenv:
+    file: .env

--- a/web/next/Dockerfile
+++ b/web/next/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM oven/bun:1.3.10-alpine AS base
 WORKDIR /app
 
@@ -6,13 +7,12 @@ COPY . .
 RUN bunx turbo prune @web/next --docker
 
 FROM base AS builder
-COPY .env* ./
 COPY --from=prepare /app/.github/scripts .github/scripts
 COPY --from=prepare /app/out/json/ .
 RUN bun install --frozen-lockfile --ignore-scripts
 COPY --from=prepare /app/out/full/ .
 ENV INTERNAL_API_URL=http://api:4000
-RUN bunx turbo run build --filter=@web/next
+RUN --mount=type=secret,id=dotenv,target=/app/.env,required=true bunx turbo run build --filter=@web/next
 RUN cp -r /app/web/next/.next/static /app/web/next/.next/standalone/web/next/.next/static
 RUN cp -r /app/web/next/public /app/web/next/.next/standalone/web/next
 

--- a/web/next/content/docs/deployment/docker.mdx
+++ b/web/next/content/docs/deployment/docker.mdx
@@ -62,38 +62,40 @@ services:
 ### Backend (Hono API)
 
 ```bash
-docker build -f api/hono/Dockerfile -t zerostarter-api .
+docker build -f api/hono/Dockerfile --secret id=dotenv,src=.env -t zerostarter-api .
 docker run -p 4000:4000 --env-file .env zerostarter-api
 ```
 
 ### Frontend (Next.js)
 
 ```bash
-docker build -f web/next/Dockerfile -t zerostarter-web .
+docker build -f web/next/Dockerfile --secret id=dotenv,src=.env -t zerostarter-web .
 docker run -p 3000:3000 --env-file .env zerostarter-web
 ```
 
 ## Environment Variables
 
-Ensure your `.env` file contains all required variables before building:
+The `.env` file reaches builds only through a BuildKit secret mount: it is mounted for the build command alone, never copied into a layer, and real env files never enter the build context (`.dockerignore` excludes them). Compose wires the secret automatically; plain `docker build` passes `--secret id=dotenv,src=.env`. A missing `.env` fails the build immediately with a clear error.
 
+Env validation runs in full during the build and again at container boot. Do not set `SKIP_ENV_VALIDATION` in the Docker flow, and never at runtime in any deployment: skipping validation also skips zod defaults and transforms, so comma-list variables like `HONO_TRUSTED_ORIGINS` stay raw strings (CORS silently breaks) and defaulted ports go undefined. Scope that variable to CI builds that genuinely lack a `.env`.
+
+For smoke-testing a clean checkout, generate a dummy `.env` that passes validation instead of skipping it:
+
+```bash
+sed -e 's|^BETTER_AUTH_SECRET=$|BETTER_AUTH_SECRET=dummy|' \
+    -e 's|^GITHUB_CLIENT_ID=$|GITHUB_CLIENT_ID=dummy|' \
+    -e 's|^GITHUB_CLIENT_SECRET=$|GITHUB_CLIENT_SECRET=dummy|' \
+    -e 's|^GOOGLE_CLIENT_ID=$|GOOGLE_CLIENT_ID=dummy|' \
+    -e 's|^GOOGLE_CLIENT_SECRET=$|GOOGLE_CLIENT_SECRET=dummy|' \
+    -e 's|^POSTGRES_URL=$|POSTGRES_URL=postgres://dummy:dummy@localhost:5432/dummy|' \
+    .env.example > .env
 ```
-NODE_ENV=production
 
-# Server variables
-HONO_APP_URL=http://localhost:4000
-HONO_TRUSTED_ORIGINS=http://localhost:3000
-BETTER_AUTH_SECRET=your_secret
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
-GOOGLE_CLIENT_ID=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
-POSTGRES_URL=your_postgres_url
+Traps worth knowing:
 
-# Client variables
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://localhost:4000
-```
+- Dummy-built web images are for smoke tests only, never promote one to a deployment: Next.js inlines `NEXT_PUBLIC_*` values into the bundle at build time, so a dummy-built image carries dummy URLs permanently
+- Secret contents are not part of BuildKit's cache key: after editing `.env`, rebuild with `--no-cache` or a cached build can silently ship stale baked values
+- `docker run --env-file` does not strip inline comments (`HONO_RATE_LIMIT=60 # note` arrives as a NaN), while compose's `env_file` parser does
 
 ## Internal Communication
 


### PR DESCRIPTION
## Summary

Two real problems with one root cause, proven and fixed downstream (dalonic/cafe):

**A clean checkout cannot build.** The builder stages run env validation at compile time and a fresh clone has no `.env`, so `docker compose build` dies minutes in with zod traces on undefined `NODE_ENV`/`POSTGRES_URL`.

**Secrets land in image layers.** `COPY .env* ./` bakes the env file into builder-stage layers, and the `.dockerignore` inversion (`!.env*`) pulls real env files into every build context via the prepare stage's `COPY . .`.

The fix: the env file reaches builds only through a required BuildKit secret mount (`--mount=type=secret,id=dotenv,target=/app/.env,required=true`), mounted for the build RUN alone and never cached or layered. Compose wires the secret for both services; `.dockerignore`'s env exception collapses to `.env.example` only, so the context is env-free by construction. A missing `.env` fails instantly with a clear stat error.

Validation stays ON everywhere: smoke builds on clean checkouts generate a dummy env from `.env.example` (recipe in the docs) instead of skipping validation. The docs also gain the warning that `SKIP_ENV_VALIDATION` must never be set at runtime: it skips zod transforms, comma-list envs stay raw strings, and CORS dies silently (this caused a production outage window downstream before being understood).

## Changes

- Both Dockerfiles: `# syntax=docker/dockerfile:1` directive, `COPY .env* ./` removed, required secret mount on the build RUN
- `docker-compose.yml`: top-level `secrets.dotenv` from `./.env`, wired into both services' builds
- `.dockerignore`: `!.env*` + re-exclude collapses to `!.env.example`, matching `.gitignore`
- Docker docs: env section rewritten around the secret model, dummy-env smoke recipe, and three traps (never promote dummy-built web images, secret contents don't bust the build cache, `docker run --env-file` keeps inline comments)

## Verification

- In this clone: `docker compose build` with a dummy env builds BOTH images through the secret mount; a prepare-stage probe shows only `.env.example` in the context
- Downstream verified the full matrix: instant clear failure with no `.env`, layer forensics on a tree with real secrets, runtime health, and offline self-containment

Ported from dalonic/cafe (private downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)