### PR TITLE
chore(agents): gh-commit, docker-test, and ignore-sync skills

### DIFF
--- a/.agents/skills/docker-test/SKILL.md
+++ b/.agents/skills/docker-test/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: docker-test
+description: Build and smoke-test the Docker images with docker compose. Use when touching Dockerfiles, the bundle build, compose config, or anything that changes how containers are packaged.
+---
+
+# Docker Testing
+
+Canonical flow (full stack, mirrors the production images):
+
+```bash
+docker compose build --no-cache && docker compose up
+```
+
+Scope to one service while iterating:
+
+```bash
+docker compose build --no-cache api && docker compose up -d api
+curl -sf --retry 30 --retry-delay 1 --retry-connrefused http://localhost:4000/api/health
+docker compose logs -f api
+docker compose down
+```
+
+## .env requirements
+
+- Builds consume `.env` as a BuildKit secret (compose wires `secrets: dotenv` from `./.env`; plain builds pass `--secret id=dotenv,src=.env`). The file mounts only during the build RUN and never lands in a layer; env validation runs in full during the build. Missing `.env` fails fast and clearly (compose: secret file not found; docker build: secret not provided).
+- Real images get the real `.env`. Simulation/smoke builds on a clean checkout get a dummy: `.env.example` with the empty required values filled in:
+
+  ```bash
+  sed -e 's|^BETTER_AUTH_SECRET=$|BETTER_AUTH_SECRET=dummy|' \
+      -e 's|^GITHUB_CLIENT_ID=$|GITHUB_CLIENT_ID=dummy|' \
+      -e 's|^GITHUB_CLIENT_SECRET=$|GITHUB_CLIENT_SECRET=dummy|' \
+      -e 's|^GOOGLE_CLIENT_ID=$|GOOGLE_CLIENT_ID=dummy|' \
+      -e 's|^GOOGLE_CLIENT_SECRET=$|GOOGLE_CLIENT_SECRET=dummy|' \
+      -e 's|^POSTGRES_URL=$|POSTGRES_URL=postgres://dummy:dummy@localhost:5432/dummy|' \
+      .env.example > .env
+  ```
+
+  (empty optionals like `NEXT_PUBLIC_POSTHOG_KEY=` pass via `emptyStringAsUndefined`)
+- Dummy-built images are for smoke tests ONLY, never promote one to a deploy: Next inlines `NEXT_PUBLIC_*` into the bundle at build, so a dummy-built web image carries dummy URLs forever. Deploy images must build with the real `.env`.
+- Secret contents are NOT part of BuildKit's cache key: after editing `.env`, a plain rebuild can reuse the cached build RUN and silently ship stale baked values (web's `NEXT_PUBLIC_*`). Rebuild with `--no-cache` after env changes.
+- Runtime requires `.env` too: compose `env_file: .env` for `up`; an invalid runtime env fails the container loudly at boot.
+- `docker run --env-file` does NOT strip inline comments: `HONO_RATE_LIMIT=60 # note` arrives as `"60 # note"`, coerces to NaN, and validation rejects it. Compose's env_file parser strips them. For direct `docker run`, sanitize first: `sed 's/ #.*//' .env > .env.docker`.
+- `SKIP_ENV_VALIDATION=true` has no place in the Docker flow (builds and runtime both validate). It also skips zod **defaults and transforms**: `HONO_PORT` arrives undefined (Bun.serve falls back to 3000, breaking the `4000:4000` mapping), and `HONO_TRUSTED_ORIGINS` stays a raw comma string instead of an array, which kills CORS. On Vercel an env var cannot be split into build-only vs runtime, so "scoping" means: give production/preview a complete real env so validation passes WITHOUT the variable (keep `SKIP_ENV_VALIDATION` on the development scope only), and reserve SKIP for contexts that genuinely lack a `.env` (CI).
+- Without a reachable `POSTGRES_URL`, DB-backed routes (e.g. `/api/waitlist`) return 500 while `/api/health` stays green. Full e2e needs a real database URL.
+- The host ports (`4000`, `3000`) collide with a running dev stack; for side-by-side testing bump the compose mappings (e.g. `14000:4000`) in a scratch checkout.
+
+## Self-containment check (catches runtime auto-install)
+
+When no `node_modules` exists, Bun auto-installs missing imports from npm at runtime, so a container that "works" online may be quietly downloading packages on every cold start. The api runner stage ships only `bundle/`, so the bundle must be fully self-contained. Verify offline:
+
+```bash
+docker run -d --name t-offline --network=none --env-file .env <image>
+docker exec t-offline sh -c 'for i in $(seq 1 30); do wget -qO- http://localhost:4000/api/health && exit 0; sleep 1; done; exit 1'
+docker logs t-offline        # on failure: "Cannot find package 'X'" = unresolved import
+docker rm -f t-offline
+```
+
+Forensics on an online container: `docker diff <name> | grep .bun/install/cache`. Entries there mean auto-install fired (history: `--external hono` in the bundle build did exactly this; hono was fetched from npm at cold start).
+
+## Notes
+
+- Start the daemon if needed: `open -a Docker`, then poll `docker info` until ready.
+- Build context is gitignore-shaped via `.dockerignore`, including the env stance: real `.env*` files are EXCLUDED from the context (only `.env.example` enters); the secret mount reads from the host and bypasses the context entirely, so no build can land `.env` contents in a layer.

--- a/.agents/skills/gh-commit/SKILL.md
+++ b/.agents/skills/gh-commit/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: gh-commit
+description: Create atomic commits with conventional commit format. Use when the user asks to commit, save changes, or create a commit.
+---
+
+# Git Commit
+
+Creates atomic commits with the conventional message format. Stages and commits, **does not push** unless the user explicitly asks.
+
+## Workflow
+
+### 1. Inspect Changes
+
+```bash
+git status --short
+git diff
+git diff --staged
+```
+
+Review both staged and unstaged changes before deciding what belongs together.
+
+### 2. Stage Changes
+
+Stage related changes together, one logical unit per commit. Split unrelated changes into separate commits.
+
+```bash
+git add <paths>
+```
+
+### 3. Commit
+
+```bash
+git commit -m "<type>(<scope>): <subject>"
+```
+
+| Element     | Rule                                                                      |
+| ----------- | ------------------------------------------------------------------------- |
+| **Type**    | `feat`, `fix`, `refactor`, `docs`, `chore`, `test`, `perf`, `style` preferred; `build`, `revert` also accepted. Type `ci` is RESERVED for pipeline-generated commits and is filtered out of changelog sections; real CI work uses `fix(ci)`/`feat(ci)`/`docs(ci)` |
+| **Scope**   | Optional area in parentheses (package, component, feature name)           |
+| **Subject** | Imperative mood, lowercase, no period, ≤80 chars preferred (hook enforces ≤100) |
+| **Body**    | Optional; explain "why" not "what"; wrap at 80 chars                      |
+
+Never include `Co-authored-by` (repo rule). Commitlint enforces the conventional format via the commit-msg hook; pre-commit runs build + lint-staged.
+
+**Examples**:
+
+```
+feat(auth): add OAuth provider support
+fix(api): prevent duplicate webhook delivery
+refactor(web): extract auth middleware into separate module
+docs(readme): update installation steps
+chore(deps): bump dependencies to latest versions
+```
+
+### 4. Push (only when explicitly requested)
+
+Do **not** push automatically. Push only when the user says "commit and push", "push the changes", or confirms when asked. Plain "commit"/"save changes" stops after the commit.
+
+## Notes
+
+- Never commit directly to canary; work on a feature branch and PR (see AGENTS.md)
+- The pre-commit build prints the size table only; the build graph refreshes at release (`bun .github/scripts/build-sizes.ts --graph` to run manually)

--- a/.agents/skills/ignore-sync/SKILL.md
+++ b/.agents/skills/ignore-sync/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ignore-sync
+description: Keep .dockerignore in sync with .gitignore. Use whenever an entry is added to or removed from .gitignore, or when auditing why the Docker build context is bloated.
+---
+
+# Ignore Sync
+
+`.dockerignore` does not inherit from `.gitignore`. Anything ignored by git but absent from `.dockerignore` still enters the Docker build context (`COPY . .` in the prepare stage), and on this repo that has meant gigabytes: `web/next/.next` hit 3GB and `.turbo` 23GB.
+
+## Rule
+
+Every `.gitignore` addition or removal gets mirrored into `.dockerignore`, same entry, same section, same order. Do both edits in the same commit.
+
+## Structure
+
+The shared body is line-for-line identical in both files and contains zero negations, pure ignore rules only. Every exception (`!` pattern) lives in a labeled platform tail at the end of its file:
+
+```gitignore
+# git overrides
+!.env.example        # track the example, real .env* stay ignored
+```
+
+```gitignore
+# docker overrides
+!.env.example        # same exception as git; real .env* never enter the context
+```
+
+Real `.env*` files stay OUT of the Docker context: every build takes the host file via a required BuildKit secret mount (`--secret id=dotenv,src=.env`; compose wires it from `./.env`), which bypasses the context entirely, is validated in full during the build, and never lands in a layer. The historical inversion (docker re-including `.env*` to feed a builder-stage `COPY`) is gone; if it reappears in a diff, that is drift, sync it away.
+
+## Audit
+
+```bash
+diff .gitignore .dockerignore
+```
+
+Expected output is exactly the tail labels:
+
+```diff
+-# git overrides
++# docker overrides
+```
+
+Anything else in the diff is a missing sync; fix it. New entries go in the shared body of BOTH files; new exceptions go under the matching platform tail, never inline in the shared body.

--- a/web/next/content/docs/resources/ai-skills.mdx
+++ b/web/next/content/docs/resources/ai-skills.mdx
@@ -11,9 +11,23 @@ Skills are written in Markdown with frontmatter metadata, making them both human
 
 ## Available Skills
 
+### Docker Test
+
+**Location**: `.agents/skills/docker-test/SKILL.md`
+
+Builds and smoke-tests the Docker images with `docker compose`.
+
+**Triggers**: When touching Dockerfiles, the bundle build, compose config, or anything that changes how containers are packaged
+
+**Workflow**:
+
+1. **Build and run**: `docker compose build --no-cache && docker compose up` (scope to one service while iterating)
+2. **Smoke-test**: Hit the health endpoints and check container logs
+3. **Self-containment check**: Verify the image runs offline (env is a runtime concern, never baked into layers)
+
 ### Git Commit
 
-**Location**: `.agents/skills/git/commit/SKILL.md`
+**Location**: `.agents/skills/gh-commit/SKILL.md`
 
 Creates atomic commits with conventional commit message format.
 
@@ -55,6 +69,16 @@ docs(readme): update installation steps
 chore(deps): bump dependencies to latest versions
 ```
 
+### Ignore Sync
+
+**Location**: `.agents/skills/ignore-sync/SKILL.md`
+
+Keeps `.dockerignore` in sync with `.gitignore`.
+
+**Triggers**: Whenever an entry is added to or removed from `.gitignore`, or when auditing why the Docker build context is bloated
+
+`.dockerignore` does not inherit from `.gitignore`: anything ignored by git but absent from `.dockerignore` still enters the Docker build context. Every `.gitignore` change is mirrored into `.dockerignore` in the same commit, same entry, same section. The one intentional divergence: `.dockerignore` excludes all env files (env is a runtime concern), keeping only `.env.example`.
+
 ### Turbo Build Graph
 
 **Location**: `.agents/skills/turbo/generate-build-graph/SKILL.md`
@@ -82,9 +106,8 @@ Each skill follows a standard structure:
 
 ```
 .agents/skills/
-└── <category>/
-    └── <skill-name>/
-        └── SKILL.md
+└── <skill-name>/
+    └── SKILL.md
 ```
 
 ### SKILL.md Format
@@ -121,7 +144,7 @@ command to run
 
 To create a new skill:
 
-1. Create a directory: `.agents/skills/<category>/<skill-name>/`
+1. Create a directory: `.agents/skills/<skill-name>/`
 2. Add a `SKILL.md` file with:
    - Frontmatter with `name` and `description`
    - Clear workflow steps


### PR DESCRIPTION
## Summary

Stacked on #434 (docker-test and ignore-sync document that PR's env model); review/merge #434 first.

Three agent skills ported from downstream (dalonic/cafe), where each line was earned by an actual debugging session:

- **gh-commit**: atomic conventional commits, never auto-push, and the commit-type reservation that pairs with #432's changelog filter: bare `ci:` type belongs to the pipeline and is filtered from changelog sections; real CI work ships as `fix(ci)`/`feat(ci)`/`docs(ci)`
- **docker-test**: the compose smoke flow, the offline self-containment check (catches Bun's runtime auto-install quietly fetching packages on cold start), the dummy-env recipe, and the recorded traps: `docker run --env-file` keeps inline comments (NaN values), secret contents don't bust the build cache, dummy-built web images must never be promoted
- **ignore-sync**: `.dockerignore` doesn't inherit `.gitignore`, and unmirrored entries have cost gigabytes of build context downstream (a 23GB `.turbo` once entered a context); the skill keeps them line-for-line mirrored, with the env inversion now classified as drift rather than policy (it existed to feed the `COPY .env*` that #434 removes)

All three are generic: no downstream-specific content survives a grep.

**Docs**: `resources/ai-skills.mdx` updated with docker-test and ignore-sync sections, the Git Commit entry repointed to the real flat path (the doc referenced `.agents/skills/git/commit/`, which does not exist on canary), and the skill-structure layout corrected to flat. Note: #433 touches the same file's build-graph section; whichever merges second resolves a trivial conflict.

## Verification

- Content grep: zero downstream references
- Each skill's claims trace to verified behavior in the downstream history (offline check caught a real auto-install incident; the ignore-sync audit diff is the documented two-label expected output)

Ported from dalonic/cafe (private downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
