### PR TITLE
perf(api): cache auth sessions in a signed cookie

### DIFF
--- a/api/hono/src/middlewares/auth.ts
+++ b/api/hono/src/middlewares/auth.ts
@@ -13,7 +13,16 @@ const userRateLimiter = createRateLimiter({
 })
 
 export const authMiddleware = createMiddleware<{ Variables: Session }>(async (c, next) => {
-  const session = await auth.api.getSession({ headers: c.req.raw.headers })
+  const { headers, response: session } = await auth.api.getSession({
+    headers: c.req.raw.headers,
+    returnHeaders: true,
+  })
+
+  // forward the session_data cookie so the cookie cache actually primes;
+  // getSession without this silently drops better-auth's Set-Cookie
+  for (const cookie of headers.getSetCookie()) {
+    c.header("Set-Cookie", cookie, { append: true })
+  }
 
   if (!session) {
     return c.json({ error: { code: "UNAUTHORIZED", message: "Unauthorized" } }, 401)

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -40,6 +40,12 @@ export const auth = betterAuth({
   onAPIError: {
     throw: true,
   },
+  session: {
+    cookieCache: {
+      enabled: true,
+      maxAge: 300,
+    },
+  },
   plugins: [
     openAPIPlugin(),
     organizationPlugin({

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -97,6 +97,14 @@ Sessions are stored in the `session` database table with:
 - **IP address and user agent tracking** for security
 - **Session expiration** with automatic cleanup
 
+### Cookie Cache
+
+Session data is additionally cached in a short-lived signed cookie (`cookieCache`, 5 minutes), so most authenticated API requests validate the session from the cookie instead of hitting the database.
+
+Enabling `cookieCache` in the auth config is **not sufficient on its own**: better-auth refreshes the cache cookie via a `Set-Cookie` header on `getSession`, and a server-side `getSession` call silently drops it. The API auth middleware (`api/hono/src/middlewares/auth.ts`) calls `getSession` with `returnHeaders: true` and forwards every returned `Set-Cookie` header to the client; without that forwarding, the cookie never primes and every request falls back to the database.
+
+**Trade-off**: session revocation propagates to cache-hit paths only after the cookie expires, so the cache `maxAge` is the upper bound on how long a revoked session can keep working.
+
 ### Server-Side Session Access
 
 In Next.js server components and layouts:
@@ -120,7 +128,7 @@ const { data: session } = authClient.useSession()
 
 The `(protected)` layout in `web/next/src/app/(protected)/layout.tsx` handles route protection server-side. It checks for a valid session and redirects unauthenticated users to the home page.
 
-API routes are protected using the auth middleware in `api/hono/src/middlewares/auth.ts`, which validates the session from request headers.
+API routes are protected using the auth middleware in `api/hono/src/middlewares/auth.ts`, which validates the session from request headers and forwards refreshed cookie-cache headers back to the client.
 
 ## Rate Limiting
 


### PR DESCRIPTION
## Summary

Authenticated requests stop hitting Postgres on every call: better-auth's `cookieCache` stores session data in a short-lived signed cookie (300s window, explicit because that number is the revocation window and deserves to be a visible decision).

**The half that's easy to miss**: enabling the config alone is placebo. The auth middleware's server-side `auth.api.getSession({ headers })` silently discards better-auth's `Set-Cookie` response, so the cache cookie never reaches the client and every request still hits the database while looking perfectly healthy. The middleware switches to `returnHeaders: true` and forwards each cookie via `c.header("Set-Cookie", cookie, { append: true })`, which also forwards cookie-clearing headers on expired sessions for free.

**The tradeoff, stated**: revoked sessions stay valid on the cached cookie for up to the window (admin revocations, password-change-revokes-others, and bans all inherit it). `disableCookieCache: true` per-call is the documented escape hatch for revocation-sensitive operations; a Redis `secondaryStorage` is the multi-instance path if that ever matters.

## Changes

- `packages/auth`: `session.cookieCache` enabled, `maxAge: 300`
- `api/hono` auth middleware: `getSession` with `returnHeaders: true`, Set-Cookie forwarded
- `manage/authentication.mdx`: new Cookie Cache section covering the forwarding requirement and the revocation-window tradeoff

## Verification

- Typechecked in this clone against better-auth ^1.6.11 (the `returnHeaders` overload)
- Downstream (dalonic/cafe) verified adversarially: sign in, prime the cache cookie, revoke the session (row deleted), replay the cached cookie → 200 with the row gone, proving Postgres is bypassed; browser e2e confirmed the cookie pair primes through the dashboard and clears fully on logout
- Downstream also observed the placebo failure mode directly: with config-only, the `session_data` cookie never appears

Ported from dalonic/cafe (private downstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
