### PR TITLE
test(web/next): port + adapt the behavioral spec suite from downstream

### DIFF
--- a/.agents/skills/web-spec/SKILL.md
+++ b/.agents/skills/web-spec/SKILL.md
@@ -12,7 +12,9 @@ description: Run, extend, and validate the web/next behavioral spec suite for Ze
 Runnable from repo root (thin `cd web/next && bun run …` delegators in the root `package.json`) or from `web/next` directly. Not turbo tasks: the suite needs live servers and the stack helper itself spawns `turbo run dev`, so wrapping it in turbo would nest it. Every script shares the stack lifecycle in `test/stack.ts` (`run.ts` for the test tiers, `visual.ts` for the visual one, `all.ts` for both under one boot): it starts the stack if down, reuses and leaves a running one, and tears down only what it started.
 
 ```bash
-bun run test                # deterministic tiers: fast, read-only, safe anywhere
+bun run test                # deterministic (non-browser) tiers; needs the live stack + DB.
+                            # the dashboard/feedback/api tiers sign in via the idempotent
+                            # agent upsert, so it is not a pure read-only run.
 bun run test:e2e            # full behavioral run: browser interactions plus the authed
                             # dashboard/feedback tiers (agent sign-in); needs the
                             # agent-browser CLI

--- a/.agents/skills/web-spec/SKILL.md
+++ b/.agents/skills/web-spec/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: web-spec
+description: Run, extend, and validate the web/next behavioral spec suite for ZeroStarter — it asserts golden literals against a running app over HTTP/SSR plus a browser tier, so config drift fails a test instead of silently shifting the spec. Use when running the web tests, adding a spec for a new behavior, or debugging a spec failure.
+---
+
+# Web Spec Suite
+
+`web/next/test/` is a black-box behavioral spec: it asserts golden literals against a running app over HTTP/SSR plus a browser tier, so config drift fails a test instead of silently shifting the spec. It is `BASE_URL`-portable: point it at any running build and a green run is the proof.
+
+## Running
+
+Runnable from repo root (thin `cd web/next && bun run …` delegators in the root `package.json`) or from `web/next` directly. Not turbo tasks: the suite needs live servers and the stack helper itself spawns `turbo run dev`, so wrapping it in turbo would nest it. Every script shares the stack lifecycle in `test/stack.ts` (`run.ts` for the test tiers, `visual.ts` for the visual one, `all.ts` for both under one boot): it starts the stack if down, reuses and leaves a running one, and tears down only what it started.
+
+```bash
+bun run test                # deterministic tiers: fast, read-only, safe anywhere
+bun run test:e2e            # full behavioral run: browser interactions plus the authed
+                            # dashboard/feedback tiers (agent sign-in); needs the
+                            # agent-browser CLI
+bun run test:visual         # pixel-diff each page vs a baseline (CSS/layout parity)
+bun run test:visual:update  # (re)capture baselines from the current BASE_URL
+bun run test:all            # the whole suite in one boot: behavioral then visual;
+                            # needs a baseline first (test:visual:update)
+```
+
+- Use `bun run test`, not `bun test`. `bun test` is Bun's built-in runner: it ignores the script, so it skips the orchestrator (no stack management, no env gates) and runs every tier regardless.
+- `test/run.ts` manages only what it starts. Stack already up: reuse it, leave it running. Stack down: `bun dev` it, run, then stop it. SIGINT/SIGTERM and a crashed run still tear down what it launched; it refuses to start if a port is held by a non-ZeroStarter process.
+
+## Visual parity (the axis HTTP can't see)
+
+HTTP/SSR assertions are blind to CSS and layout, so `test/visual.ts` screenshots each page x viewport x theme via agent-browser and pixel-diffs against a baseline with sharp (differing pixels rendered magenta into `test/screenshots/diff/`). Baselines are machine-specific (font rendering), so `test/screenshots/` is gitignored: regenerate locally before comparing.
+
+```bash
+bun run test:visual:update                          # capture golden baselines
+BASE_URL=http://localhost:3101 bun run test:visual  # diff another build vs the golden
+```
+
+### Contract vs implementation detail
+
+The suite pins only observable behavior, never framework-specific implementation. Deliberately NOT pinned:
+
+- Exact redirect status codes (the portable contract is `3xx` + the redirect target, not `307` vs `308`).
+- The framework-default 404 `<title>` (the contract is the 404 status + the body copy).
+- Font preload `<link>`s and next/font class names (appearance is the visual layer's job).
+- Per-page meta descriptions (the 29 docs drift often): titles are pinned exactly, descriptions are only asserted present.
+
+Pinned despite looking internal, because they are part of the shared contract: the fumadocs DOM markers, the `llms.txt` section structure, the `robots.txt` body, and the OG image dimensions/cache headers.
+
+## Env flags
+
+| Var | Default | Effect |
+| --- | --- | --- |
+| `BASE_URL` | `http://localhost:3000` | the app under test |
+| `API_URL` | `http://localhost:4000` | the Hono API (proxy/search/agents/dashboard tests need it) |
+| `TEST_MODE` | `dev` | `prod` flips the agents-login expectation (set it only against a production build) |
+| `BROWSER_TESTS` | unset | `true` enables the browser tier (set by `test:e2e`) |
+
+## Auth and self-cleanup
+
+The dashboard and feedback tiers sign in via the local `/api/agents/sign-in-as` endpoint, which is origin-gated and local-only (see `api.test.ts`). It upserts a single agent user (`agent@zerostarter.dev` / `AgentZero`), so it leaves no per-run residue: there is nothing to clean up. ZeroStarter has no DB-writing test, so there is no `ALLOW_DB_WRITES` gate and no smoke-row cleanup.
+
+## Layout
+
+| File | Covers |
+| --- | --- |
+| `helpers.ts` | base URLs, `req`/`get` (429-retrying), head/PNG parsers, content inventory, `signInAsAgent`, tier-wide timeout |
+| `routing.test.ts` | status/HEAD, 404s, trailing-slash, favicon, protected `/dashboard` redirect |
+| `content.test.ts` | `robots.txt` + `sitemap.xml`, the llms.txt family, `.md`/`.txt` aliases |
+| `meta.test.ts` | title template, OpenGraph/Twitter sets, page content markers |
+| `og.test.ts` | OG PNG (1200x630 + size floor + cache), param truncation, 404s |
+| `api.test.ts` | proxy semantics (og-exclusion edges), search, auth + system endpoints, agents origin gating |
+| `dashboard.test.ts` | authed SSR markers, `sidebar_state` cookie, session passthrough |
+| `feedback.test.ts` | USERJOT conditional (docs footer + dashboard menu agree) |
+| `browser.test.ts` | theme cycle, login dialog, Cmd-K search, copy-as-markdown, sidebar, mobile |
+| `stack.ts` | shared stack lifecycle (ensure-up, port guard, reuse-or-start, teardown) |
+| `run.ts` | test-tier wrapper over `stack.ts` |
+| `visual.ts` | visual-parity capture + sharp diff (uses `stack.ts`); exports `visualParity` |
+| `all.ts` | `test:all`: behavioral suite + visual diff under one `ensureStack` |
+
+## Gotchas
+
+- Golden literals are intentional: a copy/title/route change should fail a test. Update the `helpers.ts` inventory when content lands.
+- `setDefaultTimeout` covers tests, not hooks: `beforeAll` hooks that sign in or fetch carry explicit `30_000` timeouts, since the 429 retry budget can exceed the 5s hook default.
+- base-ui triggers ignore synthetic `.click()`: `clickByName` resolves a snapshot ref and does a real CDP click against an interactive role, so a same-named heading never shadows its button.
+- Clipboard write throws in headless (document-not-focused): copy-as-markdown asserts the affordance, not the post-write state.
+- The browser tier polls, not sleeps: interactions wait via `waitFor(boolExpr)` (returns the moment the condition holds), so it is fast and stable enough; the only blocking dep is the agent-browser CLI.
+
+## Notes
+
+- Not wired into turbo/CI: it needs live servers. `check-types` does cover the tests via `tsc -p test/tsconfig.json`, chained into the package `check-types`.
+- The agent session for the dashboard/feedback hooks comes from the local `/api/agents/sign-in-as` endpoint; it is origin-gated (see `api.test.ts`).

--- a/package.json
+++ b/package.json
@@ -33,7 +33,12 @@
     "lint": "turbo run lint --summarize",
     "prepare": "bunx lefthook install",
     "shadcn:update": "bash .github/scripts/shadcn-update.sh && bun i",
-    "start": "turbo run start"
+    "start": "turbo run start",
+    "test": "cd web/next && bun run test",
+    "test:all": "cd web/next && bun run test:all",
+    "test:e2e": "cd web/next && bun run test:e2e",
+    "test:visual": "cd web/next && bun run test:visual",
+    "test:visual:update": "cd web/next && bun run test:visual:update"
   },
   "devDependencies": {
     "@commitlint/cli": "catalog:",

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -4,9 +4,14 @@
   "private": true,
   "scripts": {
     "build": "bun ../../.github/scripts/compress-images.ts && fumadocs-mdx && next build",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p test/tsconfig.json",
     "dev": "next dev",
-    "start": "bun .next/standalone/web/next/server.js"
+    "start": "bun .next/standalone/web/next/server.js",
+    "test": "bun run test/run.ts -- test/",
+    "test:all": "bun run test/all.ts",
+    "test:e2e": "BROWSER_TESTS=true bun run test/run.ts --browser -- test/",
+    "test:visual": "bun run test/visual.ts",
+    "test:visual:update": "bun run test/visual.ts --update"
   },
   "dependencies": {
     "@api/hono": "workspace:*",

--- a/web/next/test/all.ts
+++ b/web/next/test/all.ts
@@ -1,0 +1,50 @@
+/**
+ * test:all — the whole suite in one stack lifecycle. Boots the stack ONCE (via
+ * the shared ensureStack), then runs the full behavioral suite (deterministic +
+ * browser tier) followed by the visual-parity diff, and
+ * tears down only what it started. Both tiers run regardless of each other's
+ * result — you get the complete picture in one pass — and the run exits non-zero
+ * if either failed.
+ *
+ * Visual parity needs a baseline: run `test:visual:update` against the reference
+ * first, or the visual tier reports the missing-baseline error. Use `bun run
+ * test:all`, not `bun test`. See the `web-spec` skill.
+ */
+import { ensureStack } from "./stack"
+import { visualParity } from "./visual"
+
+const webNext = `${import.meta.dir}/..`
+
+const teardown = await ensureStack({ browser: true })
+
+let code = 0
+try {
+  // tiers 1+2: the full behavioral suite, browser tier on (same env as
+  // test:e2e). Run as a subprocess so bun's test runner owns its own output.
+  const behavioral = Bun.spawn(["bun", "test", "test/"], {
+    cwd: webNext,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+    env: { ...process.env, BROWSER_TESTS: "true" },
+  })
+  if ((await behavioral.exited) !== 0) code = 1
+
+  // tier 3: visual parity. The stack is already up, so call it in-process — no
+  // second ensureStack, no second boot. A throw here (ab()/sharp) fails the tier
+  // without skipping teardown.
+  try {
+    const result = await visualParity(false)
+    ;(result.ok ? console.log : console.error)(result.summary)
+    if (!result.ok) code = 1
+  } catch (e) {
+    if (e instanceof Error && e.stack) console.error(e.stack)
+    console.error(`\n✗ visual run errored: ${e instanceof Error ? e.message : String(e)}\n`)
+    code = 1
+  }
+} finally {
+  teardown()
+}
+process.exit(code)
+
+export {}

--- a/web/next/test/api.test.ts
+++ b/web/next/test/api.test.ts
@@ -1,0 +1,210 @@
+/**
+ * API surface through the web app: the /api proxy semantics (og exclusions,
+ * passthrough fidelity), the search contract, the auth/system endpoints, and
+ * the agents sign-in origin gating (hit directly on the API, it is
+ * origin-scoped).
+ */
+import { describe, expect, test } from "bun:test"
+
+import { API, APP_NAME, BASE, get, req, signInAsAgent } from "./helpers"
+
+describe("api proxy semantics", () => {
+  test("/api/health proxies to the API (ok envelope)", async () => {
+    const res = await get("/api/health")
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { message: string } }
+    expect(body.data.message).toBe("ok")
+  })
+
+  test("/api/docs proxies the scalar html page", async () => {
+    const res = await get("/api/docs")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toStartWith("text/html")
+  })
+
+  test("a proxied route stays reachable with a query string appended", async () => {
+    // no proxied GET route varies by query, so this is a reachability smoke,
+    // not a semantic passthrough assertion; the proxy appends search verbatim
+    const [plain, withQuery] = await Promise.all([get("/api/health"), get("/api/health?x=1")])
+    expect(plain.status).toBe(200)
+    expect(withQuery.status).toBe(200)
+  })
+
+  test("/api/og and /api/og/* are NOT proxied (local routes win, junk 404s)", async () => {
+    // rewrite source is /api/:path((?!og$|og/).*) — the lookahead excludes the
+    // exact segment `og` and anything under `og/`, so these hit next locally
+    const res = await get("/api/og/junk")
+    expect(res.status).toBe(404)
+    // next renders its own 404 (html), not the API's json envelope
+    expect(res.headers.get("content-type") ?? "").not.toContain("application/json")
+  })
+
+  test("/api/ogx IS proxied (lookahead excludes only og and og/)", async () => {
+    // `ogx` is neither `og$` nor `og/`, so the rewrite matches and proxies it
+    const res = await get("/api/ogx")
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe("NOT_FOUND")
+  })
+
+  test("/api/v1/* IS proxied (unauthed -> API's UNAUTHORIZED envelope)", async () => {
+    const res = await get("/api/v1/user")
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe("UNAUTHORIZED")
+  })
+
+  test("anonymous get-session proxies as empty/null", async () => {
+    const res = await get("/api/auth/get-session")
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe("null")
+  })
+})
+
+describe("search contract", () => {
+  test("query returns structured page+heading results", async () => {
+    const res = await get("/api/search?query=theming")
+    expect(res.status).toBe(200)
+    const results = (await res.json()) as {
+      id: string
+      type: string
+      url: string
+      content: string
+    }[]
+    expect(Array.isArray(results)).toBe(true)
+    expect(results.length).toBeGreaterThan(0)
+    const page = results.find((r) => r.type === "page")
+    expect(page?.url).toBe("/docs/manage/theming")
+    for (const r of results) {
+      expect(typeof r.id).toBe("string")
+      expect(typeof r.url).toBe("string")
+      expect(typeof r.content).toBe("string")
+    }
+  })
+
+  test("unknown term returns empty array", async () => {
+    const res = await get("/api/search?query=zzzznotaword")
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([])
+  })
+
+  test("missing query param is handled", async () => {
+    const res = await get("/api/search")
+    expect([200, 400]).toContain(res.status)
+  })
+
+  test("POST is not allowed", async () => {
+    const res = await req("/api/search", { method: "POST" })
+    expect(res.status).toBe(405)
+  })
+})
+
+describe("auth + system endpoints", () => {
+  test("/api/health -> 200 ok envelope (version + environment)", async () => {
+    const res = await get("/api/health")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toStartWith("application/json")
+    const body = (await res.json()) as {
+      data: { message: string; version: string; environment: string }
+    }
+    expect(body.data.message).toBe("ok")
+    expect(typeof body.data.version).toBe("string")
+    expect(typeof body.data.environment).toBe("string")
+  })
+
+  test("/api/openapi.json -> 200 json document for this app", async () => {
+    const res = await get("/api/openapi.json")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type") ?? "").toContain("application/json")
+    const doc = (await res.json()) as { info: { title: string } }
+    expect(doc.info.title).toBe(APP_NAME)
+  })
+
+  test("/api/v1/user WITHOUT a session -> 401 UNAUTHORIZED", async () => {
+    const res = await get("/api/v1/user")
+    expect(res.status).toBe(401)
+    const body = (await res.json()) as { error: { code: string } }
+    expect(body.error.code).toBe("UNAUTHORIZED")
+  })
+
+  test("/api/v1/user WITH the agent session -> 200 + the agent user", async () => {
+    const cookie = await signInAsAgent()
+    expect(cookie).toContain("better-auth.session_token")
+    const res = await get("/api/v1/user", { headers: { cookie } })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      data: { id: string; email: string; name: string; emailVerified: boolean }
+    }
+    expect(typeof body.data.id).toBe("string")
+    expect(body.data.email).toBe("agent@zerostarter.dev")
+    expect(body.data.name).toBe("AgentZero")
+    expect(body.data.emailVerified).toBe(true)
+  })
+})
+
+describe("agents sign-in origin gating (local-only endpoint)", () => {
+  test("trusted origin -> 302 to <origin>/dashboard with session cookie", async () => {
+    const res = await fetch(`${API}/api/agents/sign-in-as`, {
+      method: "POST",
+      headers: { origin: BASE },
+      redirect: "manual",
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get("location")).toBe(`${BASE}/dashboard`)
+    expect(res.headers.get("set-cookie") ?? "").toContain("better-auth.session_token")
+    expect(res.headers.get("access-control-allow-origin")).toBe(BASE)
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true")
+  })
+
+  test("untrusted origin -> AGENTS_LOGIN_FAILED", async () => {
+    const res = await fetch(`${API}/api/agents/sign-in-as`, {
+      method: "POST",
+      headers: { origin: "http://evil.example" },
+      redirect: "manual",
+    })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.code).toBe("AGENTS_LOGIN_FAILED")
+    expect(body.error.message).toBe("untrusted Origin")
+  })
+
+  test("missing origin -> AGENTS_LOGIN_FAILED", async () => {
+    const res = await fetch(`${API}/api/agents/sign-in-as`, {
+      method: "POST",
+      redirect: "manual",
+    })
+    expect(res.status).toBe(500)
+    const body = (await res.json()) as { error: { code: string; message: string } }
+    expect(body.error.message).toBe("missing Origin header")
+  })
+
+  test("non-POST verb is rejected", async () => {
+    const res = await fetch(`${API}/api/agents/sign-in-as`, {
+      method: "GET",
+      headers: { origin: BASE },
+      redirect: "manual",
+    })
+    expect(res.status).toBe(404)
+  })
+})
+
+// --- coverage gap-fill: search shape + method, content-types ---
+
+describe("api gap-fill", () => {
+  test("/api/search returns application/json and rejects non-GET verbs", async () => {
+    const ok = await get("/api/search?query=theming")
+    expect(ok.headers.get("content-type")).toStartWith("application/json")
+    expect((await req("/api/search", { method: "PUT" })).status).toBe(405)
+  })
+
+  test("/api/search returns both page and text result types with string urls", async () => {
+    const results = (await (await get("/api/search?query=theming")).json()) as {
+      type: string
+      url: string
+    }[]
+    const types = new Set(results.map((r) => r.type))
+    expect(types.has("page")).toBe(true)
+    expect(types.has("text")).toBe(true)
+    expect(results.every((r) => typeof r.url === "string" && r.url.length > 0)).toBe(true)
+  })
+})

--- a/web/next/test/browser.test.ts
+++ b/web/next/test/browser.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Browser tier: client-only interactions driven through the agent-browser CLI,
+ * gated behind BROWSER_TESTS. Run via `bun run test:e2e`; the `web-spec` skill
+ * covers the tier's gotchas (clicks, clipboard, popovers, polling).
+ *
+ * Waits are condition-polls (waitFor), not fixed sleeps — faster and stable
+ * enough to wire into CI.
+ */
+import { beforeAll, describe, expect, test } from "bun:test"
+
+import { BASE, MODE } from "./helpers"
+
+const enabled = process.env.BROWSER_TESTS === "true"
+
+function ab(...args: string[]): string {
+  const proc = Bun.spawnSync(["bunx", "agent-browser", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (proc.exitCode !== 0) {
+    throw new Error(
+      `agent-browser ${args[0]} failed (exit ${proc.exitCode}): ${proc.stderr.toString().trim()}`,
+    )
+  }
+  return proc.stdout.toString().trim()
+}
+
+const evaluate = (expr: string) => ab("eval", expr)
+const json = (expr: string) => JSON.parse(JSON.parse(evaluate(`JSON.stringify(${expr})`)))
+// eval returns JSON-quoted strings ("/path"); unwrap to the bare value
+const evalStr = (expr: string): string => JSON.parse(evaluate(expr))
+
+// poll a boolean JS expression until it's true — replaces fixed sleeps so the
+// tier is fast (returns the moment the condition holds) and CI-stable (no
+// hard-coded guesses). Throws with a label on timeout.
+async function waitFor(boolExpr: string, label: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (evaluate(boolExpr) === "true") return
+    if (Date.now() > deadline) throw new Error(`waitFor timed out after ${timeoutMs}ms: ${label}`)
+    await Bun.sleep(100)
+  }
+}
+const waitForPath = (path: string) =>
+  waitFor(`location.pathname === ${JSON.stringify(path)}`, `navigate to ${path}`)
+
+// base-ui triggers ignore synthetic .click(); drive a real CDP pointer click
+// by resolving the element's snapshot ref by its accessible name. Match an
+// interactive role before the name so a same-named heading (e.g. the sr-only
+// DialogTitle "Sign in/up") never shadows its button.
+function clickByName(name: string): boolean {
+  const snap = ab("snapshot", "-i")
+  const esc = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const re = new RegExp(`(?:button|link|menuitem|tab|option)\\s+"${esc}"[^\\n]*ref=(e\\d+)`)
+  const ref = snap.match(re)?.[1]
+  if (!ref) return false
+  ab("click", `@${ref}`)
+  return true
+}
+
+async function open(path: string) {
+  ab("open", `${BASE}${path}`)
+  ab("wait", "--load", "networkidle")
+}
+
+beforeAll(() => {
+  if (!enabled) return
+  // fail loudly and early if the CLI is missing rather than as cryptic
+  // assertion errors deep in a test
+  const probe = Bun.spawnSync(["bunx", "agent-browser", "--version"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  if (probe.exitCode !== 0) {
+    throw new Error(
+      "agent-browser CLI not available; install it or unset BROWSER_TESTS to skip this tier",
+    )
+  }
+  // earlier HTTP-tier tests leave an agent session in the shared daemon; a
+  // logged-in navbar hides the Login dialog the interaction tests need
+  ab("open", BASE)
+  ab("cookies", "clear")
+}, 30_000)
+
+describe.skipIf(!enabled)("browser behaviors", () => {
+  test("smart theme toggle cycles and persists", async () => {
+    await open("/docs")
+    evaluate("localStorage.removeItem('theme'); location.reload()")
+    const toggle = `button[aria-label="Switch between system/light/dark version"]`
+    await waitFor(`!!document.querySelector('${toggle}')`, "theme toggle ready")
+
+    const states: string[] = []
+    for (let i = 0; i < 2; i++) {
+      // capture before clicking so this is robust to next-themes pre-seeding
+      const before = evalStr(`localStorage.getItem('theme') ?? 'null'`)
+      clickByName("Switch between system/light/dark version")
+      await waitFor(
+        `(localStorage.getItem('theme') ?? 'null') !== ${JSON.stringify(before)}`,
+        "theme changed",
+      )
+      states.push(evalStr(`localStorage.getItem('theme') ?? 'unset'`))
+    }
+    expect(states[0]).not.toBe("unset")
+    expect(states[1]).not.toBe(states[0])
+
+    evaluate("location.reload()")
+    await waitFor(`!!document.querySelector('${toggle}')`, "toggle ready after reload")
+    expect(evalStr(`localStorage.getItem('theme')`)).toBe(states[1])
+  }, 60_000)
+
+  test("home: api status widget resolves client-side", async () => {
+    await open("/")
+    // ApiStatus flips from its invisible loading state to operational once
+    // /api/health resolves; the visible status carries role="status"
+    await waitFor(
+      `[...document.querySelectorAll('[role="status"][aria-label="API status"]')].some(el => getComputedStyle(el).visibility !== 'hidden' && el.innerText.includes('All systems are operational'))`,
+      "api status operational",
+    )
+  }, 60_000)
+
+  test("login dialog opens, shows providers, validates email", async () => {
+    await open("/docs")
+    expect(clickByName("Login")).toBe(true)
+    await waitFor(`document.body.innerText.includes('Welcome to ZeroStarter')`, "login dialog open")
+    const d = json(`({
+      github: document.body.innerText.includes('Continue with Github'),
+      google: document.body.innerText.includes('Continue with Google'),
+      agents: document.body.innerText.includes('Login (agents)'),
+      terms: document.body.innerText.includes('Terms of Service'),
+    })`)
+    expect(d.github).toBe(true)
+    expect(d.google).toBe(true)
+    expect(d.terms).toBe(true)
+    expect(d.agents).toBe(MODE === "dev")
+
+    // real CDP fill drives React's onChange directly; do NOT pre-seed the
+    // value via eval first — that desyncs the controlled input and the
+    // validator then runs against stale state
+    ab("fill", "input[type=email]", "not-an-email")
+    await waitFor(
+      `document.querySelector('input[type=email]')?.value === 'not-an-email'`,
+      "email field filled",
+    )
+    clickByName("Sign in/up")
+    await waitFor(
+      `document.body.innerText.includes('Please enter a valid email address.')`,
+      "email validation message",
+    )
+    ab("press", "Escape")
+  }, 60_000)
+
+  test("search dialog: cmd+k opens, type + arrow + enter navigates", async () => {
+    await open("/docs")
+    ab("press", "Meta+k")
+    await waitFor(
+      `!!document.querySelector('input[placeholder="Search..."],input[placeholder="Search"]')`,
+      "search dialog open",
+    )
+    ab("fill", 'input[placeholder="Search..."],input[placeholder="Search"]', "Architecture")
+    // wait for the debounced results to render the Architecture result link
+    await waitFor(
+      `[...document.querySelectorAll('a')].some(a => a.getAttribute('href') === '/docs/getting-started/architecture')`,
+      "search results",
+    )
+    ab("press", "ArrowDown")
+    ab("press", "Enter")
+    await waitForPath("/docs/getting-started/architecture")
+  }, 60_000)
+
+  test("copy-as-markdown affordance is present and clickable", async () => {
+    await open("/docs/getting-started/architecture")
+    // clipboard writeText is blocked in headless (the copied state is never
+    // reached), so this only asserts the affordance is present and the click
+    // is accepted — appearance/behavior beyond that isn't observable here
+    const sel = `button[aria-label="Copy as markdown"]`
+    expect(evaluate(`!!document.querySelector('${sel}')`)).toBe("true")
+    expect(clickByName("Copy as markdown")).toBe(true)
+  }, 60_000)
+
+  test("docs sidebar: collapsible category expands and navigates", async () => {
+    await open("/docs")
+    clickByName("Content Management")
+    await waitFor(
+      `[...document.querySelectorAll('[data-sidebar] a')].some(a => a.textContent.trim()==='Blog')`,
+      "Content Management expanded",
+    )
+    evaluate(
+      `[...document.querySelectorAll('[data-sidebar] a')].find(a => a.textContent.trim()==='Blog')?.click()`,
+    )
+    await waitForPath("/docs/manage/blog")
+  }, 60_000)
+
+  test.skipIf(MODE !== "dev")(
+    "dashboard: agents login navigates + sidebar collapse persists",
+    async () => {
+      // dropdown-driven org-switch and logout are dismissable base-ui popovers
+      // that close between separate CLI processes, so they are not asserted
+      // here; the dashboard SSR (identity, version, collapse cookie, session)
+      // is covered deterministically in dashboard.test.ts
+      await open("/docs")
+      clickByName("Login")
+      await waitFor(`document.body.innerText.includes('Login (agents)')`, "login dialog open")
+      clickByName("Login (agents)")
+      await waitForPath("/dashboard")
+
+      clickByName("Toggle Sidebar")
+      await waitFor(`document.cookie.includes('sidebar_state=false')`, "sidebar_state cookie set")
+      evaluate("location.reload()")
+      await waitFor(
+        `!!document.querySelector('[data-state="collapsed"]')`,
+        "collapsed after reload",
+      )
+
+      ab("cookies", "clear") // reset session for the rest of the suite
+    },
+    120_000,
+  )
+
+  test("mobile: sheet menu exposes nav links", async () => {
+    ab("set", "viewport", "390", "844")
+    try {
+      await open("/docs")
+      clickByName("Open menu")
+      await waitFor(
+        `[...document.querySelectorAll('a')].filter(a => /Documentation|Blog/.test(a.textContent)).length >= 2`,
+        "mobile sheet open",
+      )
+      const links = json(
+        `[...document.querySelectorAll('a')].filter(a => /Documentation|Blog/.test(a.textContent)).length`,
+      )
+      expect(links).toBeGreaterThanOrEqual(2)
+      // the sheet also carries the social links
+      const socials = json(
+        `[...document.querySelectorAll('a[aria-label]')].filter(a => ['GitHub','Discord','X'].includes(a.getAttribute('aria-label'))).length`,
+      )
+      expect(socials).toBeGreaterThanOrEqual(3)
+      ab("press", "Escape")
+    } finally {
+      // always restore the desktop viewport so later tests aren't left mobile
+      ab("set", "viewport", "1440", "900")
+    }
+  }, 60_000)
+
+  test("no console errors across pages", async () => {
+    for (const path of ["/", "/docs", "/blog", "/blog/web-development-2026"]) {
+      ab("console", "--clear")
+      await open(path)
+      await Bun.sleep(500) // grace window for late client-side errors to surface
+      const errors = ab("console", "--level", "error")
+      const real = errors
+        .split("\n")
+        .filter((l) => l.startsWith("[error]"))
+        .filter((l) => !l.includes("favicon") && !l.toLowerCase().includes("clipboard"))
+      expect(real, `${path}: ${real.join(" | ")}`).toEqual([])
+    }
+  }, 120_000)
+
+  test("home: navbar present, devtools widget in dev", async () => {
+    await open("/")
+    // the navbar renders on / regardless of mode; only the dev-only affordances
+    // (devtools widget, agents login) are gated by the build environment
+    const nav = evaluate(`!!document.querySelector('[aria-label="Main navigation"]')`)
+    expect(nav).toBe("true")
+    const widget = evaluate(`!!document.querySelector('[class*="z-100"]')`)
+    expect(widget).toBe(MODE === "dev" ? "true" : "false")
+  }, 60_000)
+})

--- a/web/next/test/content.test.ts
+++ b/web/next/test/content.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Content endpoints: robots.txt, sitemap.xml, the llms.txt family, and the
+ * .md/.txt alias rewrites. Bodies are asserted as golden text where stable.
+ */
+import { describe, expect, test } from "bun:test"
+
+import { APP_DESCRIPTION, APP_NAME, BASE, DOCS_SLUGS, DOCS_TITLES, get } from "./helpers"
+
+const MD_CONTENT_TYPE = "text/markdown; charset=utf-8"
+
+describe("robots.txt", () => {
+  test("exact body", async () => {
+    const res = await get("/robots.txt")
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe(
+      `User-Agent: *
+Allow: /
+Disallow: /api/
+Disallow: /dashboard/
+
+Sitemap: ${BASE}/sitemap.xml
+`,
+    )
+  })
+})
+
+describe("sitemap.xml", () => {
+  test("lists the home url plus every docs and blog page (blog index excluded)", async () => {
+    const res = await get("/sitemap.xml")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toStartWith("application/xml")
+    const text = await res.text()
+
+    expect(text).toContain(`<loc>${BASE}</loc>`)
+
+    // every docs page (index = /docs)
+    for (const slug of DOCS_SLUGS) {
+      const url = slug ? `${BASE}/docs/${slug}` : `${BASE}/docs`
+      expect(text, `missing docs loc: ${url}`).toContain(`<loc>${url}</loc>`)
+    }
+
+    // every blog page except the /blog index
+    expect(text).toContain(`<loc>${BASE}/blog/web-development-2026</loc>`)
+    expect(text).not.toContain(`<loc>${BASE}/blog</loc>`)
+  })
+})
+
+describe("/llms.txt index", () => {
+  test("lists docs pages in meta.json order plus blog pointer", async () => {
+    const res = await get("/llms.txt")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe(MD_CONTENT_TYPE)
+    const text = await res.text()
+
+    expect(text).toStartWith(`# ${APP_NAME}\n\n> ${APP_DESCRIPTION}\n`)
+    expect(text).toContain(`## Documentation`)
+    expect(text).toContain(`- [Blog](${BASE}/blog.md)`)
+
+    // every docs page linked as .md, in meta.json order. Descriptions are not
+    // pinned (they drift), so match the `[title](url):` prefix only.
+    const linkPrefixes = DOCS_SLUGS.map((slug) => {
+      const title = DOCS_TITLES[slug]
+      const url = slug ? `${BASE}/docs/${slug}.md` : `${BASE}/docs.md`
+      return `- [${title}](${url}):`
+    })
+    let cursor = -1
+    for (const prefix of linkPrefixes) {
+      const idx = text.indexOf(prefix)
+      expect(idx, `missing or out of order: ${prefix}`).toBeGreaterThan(cursor)
+      cursor = idx
+    }
+  })
+})
+
+describe("/llms.txt/<section> indexes and pages", () => {
+  test("/llms.txt/docs returns the docs index page content with footer", async () => {
+    const res = await get("/llms.txt/docs")
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toStartWith(`# [${DOCS_TITLES[""]}](${BASE}/docs)`)
+    expect(text).toEndWith(
+      `> To find navigation and other pages in this documentation, fetch the llms.txt file at: ${BASE}/llms.txt`,
+    )
+  })
+
+  test("/llms.txt/blog returns the blog listing", async () => {
+    const res = await get("/llms.txt/blog")
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toContain("## Blog")
+    expect(text).toContain(
+      `- [How to Do Web Development in 2026](${BASE}/blog/web-development-2026.md)`,
+    )
+    expect(text).toContain(`- [Documentation](${BASE}/llms.txt)`)
+  })
+
+  for (const slug of DOCS_SLUGS.filter(Boolean)) {
+    test(`/llms.txt/docs/${slug} serves the page markdown`, async () => {
+      const res = await get(`/llms.txt/docs/${slug}`)
+      expect(res.status).toBe(200)
+      const text = await res.text()
+      expect(text).toStartWith(`# [${DOCS_TITLES[slug]}](${BASE}/docs/${slug})`)
+      // docs pages carry the navigation footer
+      expect(text).toContain("fetch the llms.txt file at:")
+    })
+  }
+
+  test("/llms.txt/blog/web-development-2026 serves the post markdown without docs footer", async () => {
+    const res = await get("/llms.txt/blog/web-development-2026")
+    expect(res.status).toBe(200)
+    const text = await res.text()
+    expect(text).toStartWith(
+      `# [How to Do Web Development in 2026](${BASE}/blog/web-development-2026)`,
+    )
+    expect(text).not.toContain("fetch the llms.txt file at:")
+  })
+
+  test("unknown sections and slugs 404", async () => {
+    for (const path of ["/llms.txt/junk", "/llms.txt/docs/nope", "/llms.txt/blog/nope"]) {
+      const res = await get(path)
+      expect(res.status, path).toBe(404)
+    }
+  })
+})
+
+describe("/llms-full.txt", () => {
+  test("authoritative context file with all pages joined", async () => {
+    const res = await get("/llms-full.txt")
+    expect(res.status).toBe(200)
+    expect(res.headers.get("content-type")).toBe(MD_CONTENT_TYPE)
+    const text = await res.text()
+
+    expect(text).toStartWith(`# ${APP_NAME} – LLM Context File`)
+    expect(text).toContain("## Instructions for AI Assistants")
+    expect(text).toContain("**Monorepo Structure:**")
+    expect(text).toContain("## Canonical Tech Stack (Authoritative)")
+    expect(text).toContain("## Project Constraints and Rules")
+    expect(text).toContain('No semicolons (Oxfmt config: `"semi": false`)')
+
+    // every docs + blog page included (blog index excluded)
+    for (const slug of DOCS_SLUGS) {
+      const title = DOCS_TITLES[slug]
+      expect(text).toContain(`# [${title}](${BASE}/docs${slug ? `/${slug}` : ""})`)
+    }
+    expect(text).toContain(
+      `# [How to Do Web Development in 2026](${BASE}/blog/web-development-2026)`,
+    )
+    expect(text).not.toContain(`# [Blog](${BASE}/blog)`)
+
+    // pages separated by horizontal rules
+    expect(text.split("\n\n---\n\n").length).toBeGreaterThanOrEqual(DOCS_SLUGS.length + 1)
+  })
+})
+
+describe(".md/.txt aliases (rewrites)", () => {
+  const aliasPairs: [string, string][] = [
+    ["/docs.md", "/llms.txt/docs"],
+    ["/docs.txt", "/llms.txt/docs"],
+    ["/blog.md", "/llms.txt/blog"],
+    ["/blog.txt", "/llms.txt/blog"],
+  ]
+  for (const slug of DOCS_SLUGS.filter(Boolean)) {
+    aliasPairs.push([`/docs/${slug}.md`, `/llms.txt/docs/${slug}`])
+    aliasPairs.push([`/docs/${slug}.txt`, `/llms.txt/docs/${slug}`])
+  }
+  aliasPairs.push(["/blog/web-development-2026.md", "/llms.txt/blog/web-development-2026"])
+  aliasPairs.push(["/blog/web-development-2026.txt", "/llms.txt/blog/web-development-2026"])
+
+  for (const [alias, canonical] of aliasPairs) {
+    test(`${alias} serves the same bytes as ${canonical}`, async () => {
+      const [a, b] = await Promise.all([get(alias), get(canonical)])
+      expect(a.status).toBe(200)
+      expect(b.status).toBe(200)
+      expect(a.headers.get("content-type")).toBe(MD_CONTENT_TYPE)
+      expect(await a.text()).toBe(await b.text())
+    })
+  }
+
+  test("alias for a missing slug 404s", async () => {
+    for (const path of ["/docs/nope.md", "/blog/nope.txt"]) {
+      const res = await get(path)
+      expect(res.status, path).toBe(404)
+    }
+  })
+})
+
+// --- coverage gap-fill (port oracle breadth) ---
+
+describe("content gap-fill", () => {
+  test("robots.txt is text/plain", async () => {
+    const res = await get("/robots.txt")
+    expect(res.headers.get("content-type")).toStartWith("text/plain")
+  })
+
+  test("/llms.txt index carries the Optional section and blog description", async () => {
+    const text = await (await get("/llms.txt")).text()
+    expect(text).toContain("## Optional")
+    expect(text).toContain(
+      `- [Blog](${BASE}/blog.md): Latest articles and updates about ${APP_NAME}`,
+    )
+  })
+
+  test("/llms.txt/blog carries the Optional section and Documentation pointer", async () => {
+    const text = await (await get("/llms.txt/blog")).text()
+    expect(text).toContain("## Optional")
+    expect(text).toContain(
+      `- [Documentation](${BASE}/llms.txt): Complete documentation for ${APP_NAME}`,
+    )
+  })
+
+  test("intermediate llms.txt segments without a page 404", async () => {
+    for (const p of ["/llms.txt/docs/getting-started", "/llms.txt/docs/manage/nope"]) {
+      expect((await get(p)).status, p).toBe(404)
+    }
+  })
+
+  test(".md alias for an intermediate non-page 404s", async () => {
+    expect((await get("/docs/getting-started.md")).status).toBe(404)
+  })
+})

--- a/web/next/test/dashboard.test.ts
+++ b/web/next/test/dashboard.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Dashboard SSR behaviors with a real agent session: authed render markers,
+ * the sidebar_state cookie contract, and session passthrough via the proxy.
+ */
+import { beforeAll, describe, expect, test } from "bun:test"
+
+import { DEFAULT_TITLE, get, signInAsAgent } from "./helpers"
+
+let cookie = ""
+
+beforeAll(async () => {
+  cookie = await signInAsAgent()
+  expect(cookie).toContain("better-auth.session_token")
+  // hook timeout (setDefaultTimeout covers tests, not hooks); the agent
+  // sign-in can be throttled under concurrent test-file load
+}, 30_000)
+
+describe("authed dashboard SSR", () => {
+  test("renders user identity, version, and chrome", async () => {
+    const res = await get("/dashboard", { headers: { cookie } })
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    expect(html).toContain("AgentZero")
+    expect(html).toContain("agent@zerostarter.dev")
+    expect(html).toContain(">RC<")
+    expect(html).toMatch(/v(<!-- -->)?\d+\.\d+\.\d+/)
+    expect(html).toContain(">Documentation<")
+    // "Log out" lives inside the closed dropdown portal: browser tier covers it
+  })
+
+  test("sidebar_state=false renders collapsed, absent renders expanded", async () => {
+    const collapsed = await (
+      await get("/dashboard", { headers: { cookie: `${cookie}; sidebar_state=false` } })
+    ).text()
+    expect(collapsed).toContain('data-state="collapsed"')
+
+    const expanded = await (await get("/dashboard", { headers: { cookie } })).text()
+    expect(expanded).toContain('data-state="expanded"')
+  })
+
+  test("authed get-session via proxy returns the agent user", async () => {
+    const res = await get("/api/auth/get-session", { headers: { cookie } })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { user: { email: string } }
+    expect(body.user.email).toBe("agent@zerostarter.dev")
+  })
+
+  test("authed /api/v1/user via proxy returns the user envelope", async () => {
+    const res = await get("/api/v1/user", { headers: { cookie } })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: { name: string } }
+    expect(body.data.name).toBe("AgentZero")
+  })
+})
+
+// --- coverage gap-fill: dashboard head, explicit-true cookie, version source ---
+
+describe("dashboard gap-fill", () => {
+  test("authed dashboard uses the default root title", async () => {
+    const res = await get("/dashboard", { headers: { cookie } })
+    expect(res.status).toBe(200)
+    const title = (await res.text()).match(/<title>(.*?)<\/title>/)?.[1]
+    expect(title).toBe(DEFAULT_TITLE)
+  })
+
+  test("sidebar_state=true renders expanded", async () => {
+    const html = await (
+      await get("/dashboard", { headers: { cookie: `${cookie}; sidebar_state=true` } })
+    ).text()
+    expect(html).toContain('data-state="expanded"')
+  })
+
+  test("docs footer and dashboard render the same version string", async () => {
+    const ver = (html: string) => html.match(/v(?:<!-- -->)?(\d+\.\d+\.\d+[^\s"<]*)/)?.[1]
+    const docsVer = ver(await (await get("/docs")).text())
+    const dashVer = ver(await (await get("/dashboard", { headers: { cookie } })).text())
+    expect(docsVer).toBeDefined()
+    expect(dashVer).toBe(docsVer)
+  })
+})

--- a/web/next/test/feedback.test.ts
+++ b/web/next/test/feedback.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Feedback (USERJOT) conditional rendering — surfaced by the zerostarter
+ * feedback doc. A Feedback link appears in BOTH the docs sidebar footer and the
+ * dashboard user menu iff NEXT_PUBLIC_USERJOT_URL is set, and nowhere when it is
+ * unset. We read the configured value (@packages/env loads the root .env) and
+ * assert the absolute presence in each location — so both-wrongly-absent is
+ * caught, not just disagreement between them.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test"
+
+import { env } from "@packages/env/web-next"
+
+import { get, signInAsAgent } from "./helpers"
+
+const FEEDBACK_CONFIGURED = Boolean(env.NEXT_PUBLIC_USERJOT_URL)
+
+let docsFeedback = false
+let dashFeedback = false
+let feedbackHref: string | undefined
+
+beforeAll(async () => {
+  const docsHtml = await (await get("/docs")).text()
+  docsFeedback = docsHtml.includes(">Feedback<")
+  feedbackHref = docsHtml.match(/<a[^>]+href="([^"]+)"[^>]*>\s*<span>Feedback/)?.[1]
+
+  const cookie = await signInAsAgent()
+  const dashHtml = await (await get("/dashboard", { headers: { cookie } })).text()
+  dashFeedback = dashHtml.includes(">Feedback")
+  // explicit hook timeout: setDefaultTimeout covers tests but not hooks, and
+  // this setup makes several requests that can hit the 429 retry budget under
+  // concurrent test-file load
+}, 30_000)
+
+describe("feedback conditional", () => {
+  test("docs sidebar footer always shows the version", async () => {
+    const html = await (await get("/docs")).text()
+    expect(html).toMatch(/text-muted-foreground[^>]*>v(<!-- -->)?[\d.]/)
+  })
+
+  test(`docs footer feedback link is ${FEEDBACK_CONFIGURED ? "present" : "absent"} (matches NEXT_PUBLIC_USERJOT_URL)`, () => {
+    expect(docsFeedback).toBe(FEEDBACK_CONFIGURED)
+  })
+
+  test(`dashboard menu feedback link is ${FEEDBACK_CONFIGURED ? "present" : "absent"} (matches NEXT_PUBLIC_USERJOT_URL)`, () => {
+    expect(dashFeedback).toBe(FEEDBACK_CONFIGURED)
+  })
+
+  test("a configured feedback link points to the external https URL", () => {
+    if (!FEEDBACK_CONFIGURED) return // nothing rendered when unset
+    expect(feedbackHref).toBe(env.NEXT_PUBLIC_USERJOT_URL)
+    expect(feedbackHref).toStartWith("http")
+  })
+})

--- a/web/next/test/helpers.ts
+++ b/web/next/test/helpers.ts
@@ -1,0 +1,174 @@
+/**
+ * Shared helpers for the web/next behavioral spec suite — the golden-master
+ * parity contract. How to run, env flags, the stack orchestrator, and the
+ * gotchas live in the `web-spec` skill (.agents/skills/web-spec/SKILL.md).
+ */
+import { setDefaultTimeout } from "bun:test"
+
+// Imported by every deterministic test file before any test() registers, so
+// this sets the tier-wide timeout. It must clear the 429 retry budget (up to
+// 4 × 2s capped sleeps, see req() below) plus request time, otherwise a
+// sustained rate-limit would surface as an opaque timeout instead of the
+// returned 429. 15s leaves headroom; the browser tier sets its own per-test
+// timeouts which override this.
+setDefaultTimeout(15_000)
+
+export const BASE = process.env.BASE_URL ?? "http://localhost:3000"
+export const API = process.env.API_URL ?? "http://localhost:4000"
+
+// dev: navbar renders on /, agents login button visible. prod builds hide both.
+const rawMode = process.env.TEST_MODE ?? "dev"
+if (rawMode !== "dev" && rawMode !== "prod") {
+  throw new Error(`TEST_MODE must be "dev" or "prod", got "${rawMode}"`)
+}
+export const MODE: "dev" | "prod" = rawMode
+
+export const APP_NAME = "ZeroStarter"
+export const APP_TAGLINE = "The SaaS Starter"
+export const APP_DESCRIPTION =
+  "A modern, type-safe, and high-performance SaaS starter template built with a monorepo architecture."
+export const DEFAULT_TITLE = `${APP_NAME} - ${APP_TAGLINE}`
+
+// One copy of the backoff policy. Retries on 429 only: the suite fires ~100
+// requests and the API rate-limits 60/min per IP, so back-to-back runs would
+// otherwise flake. Rate-limiting is deliberately not a behavior under test (it
+// would poison sibling tests), so backing off here targets the limiter without
+// masking anything. The 2s cap keeps the worst case under the hook timeout.
+async function retryOn429(send: () => Promise<Response>): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const res = await send()
+    if (res.status !== 429 || attempt >= 4) return res
+    const retryAfter = Math.min(Number(res.headers.get("retry-after")) || 1, 2)
+    await new Promise((r) => setTimeout(r, retryAfter * 1000))
+  }
+}
+
+// req: any method against the app base, redirects never auto-followed so the
+// suite can assert 3xx targets. `get` kept as a readable alias for GET sites.
+export const req = (path: string, init?: RequestInit): Promise<Response> =>
+  retryOn429(() => fetch(`${BASE}${path}`, { redirect: "manual", ...init }))
+export const get = req
+
+// Signs in as the local AgentZero user and returns the session cookie pair
+// ("better-auth.session_token=..."). The endpoint upserts a single agent user
+// (agent@zerostarter.dev), so it leaves no per-run residue to clean up.
+export const signInAsAgent = async (): Promise<string> => {
+  const res = await retryOn429(() =>
+    fetch(`${API}/api/agents/sign-in-as`, {
+      method: "POST",
+      headers: { origin: BASE },
+      redirect: "manual",
+    }),
+  )
+  return (res.headers.get("set-cookie") ?? "").split(";")[0]
+}
+
+export const stripBuster = (s: string) => s.replace(/\?t=\d+/g, "")
+
+export interface Head {
+  title?: string
+  metas: Record<string, string>
+  links: { rel: string; href: string }[]
+}
+
+export function extractHead(html: string): Head {
+  const head = html.split("</head>")[0]
+  const title = head.match(/<title>(.*?)<\/title>/)?.[1]
+  const metas: Record<string, string> = {}
+  for (const m of head.matchAll(/<meta\s+([^>]+?)\/?>/g)) {
+    const attrs = m[1]
+    const key = attrs.match(/(?:name|property)="([^"]+)"/)?.[1]
+    const content = attrs.match(/content="([^"]*)"/)?.[1]
+    if (key && content !== undefined) metas[key] = stripBuster(content)
+  }
+  const links = [...head.matchAll(/<link\s+([^>]+?)\/?>/g)].map((m) => ({
+    rel: m[1].match(/rel="([^"]+)"/)?.[1] ?? "",
+    href: m[1].match(/href="([^"]+)"/)?.[1] ?? "",
+  }))
+  return { title, metas, links }
+}
+
+export function pngInfo(bytes: Uint8Array) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  return {
+    isPng: bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47,
+    width: view.getUint32(16),
+    height: view.getUint32(20),
+    size: bytes.length,
+  }
+}
+
+// Content inventory — keep in sync with content/*/meta.json (ordered). Titles
+// are pinned as golden literals (short and stable); a copy/title change should
+// fail a test. Descriptions are not pinned exactly (29 docs drift often); the
+// meta tests assert a non-empty description per page instead.
+export const DOCS_SLUGS = [
+  "",
+  "getting-started/architecture",
+  "getting-started/project-structure",
+  "getting-started/type-safe-api",
+  "getting-started/setup",
+  "getting-started/scripts",
+  "getting-started/roadmap",
+  "manage/authentication",
+  "manage/dashboard",
+  "manage/database",
+  "manage/api-conventions",
+  "manage/analytics",
+  "manage/blog",
+  "manage/code-quality",
+  "manage/documentation",
+  "manage/feedback",
+  "manage/environment",
+  "manage/release",
+  "manage/theming",
+  "manage/og-images",
+  "manage/llms-txt",
+  "manage/robots",
+  "manage/sitemap",
+  "deployment/docker",
+  "deployment/vercel",
+  "resources/ai-skills",
+  "resources/ide-setup",
+  "resources/infisical",
+  "contributing",
+]
+
+export const BLOG_SLUGS = ["", "web-development-2026"]
+
+export const DOCS_TITLES: Record<string, string> = {
+  "": "Introduction",
+  "getting-started/architecture": "Architecture",
+  "getting-started/project-structure": "Project Structure",
+  "getting-started/type-safe-api": "Type-Safe API Client",
+  "getting-started/setup": "Setup",
+  "getting-started/scripts": "Scripts",
+  "getting-started/roadmap": "Roadmap",
+  "manage/authentication": "Authentication",
+  "manage/dashboard": "Dashboard",
+  "manage/database": "Database",
+  "manage/api-conventions": "API Conventions",
+  "manage/analytics": "Analytics",
+  "manage/blog": "Blog",
+  "manage/code-quality": "Code Quality",
+  "manage/documentation": "Documentation",
+  "manage/feedback": "Feedback",
+  "manage/environment": "Environment Variables",
+  "manage/release": "Release Management",
+  "manage/theming": "Theming",
+  "manage/og-images": "OG Images",
+  "manage/llms-txt": "llms.txt",
+  "manage/robots": "robots.txt",
+  "manage/sitemap": "Sitemap",
+  "deployment/docker": "Docker Deployment",
+  "deployment/vercel": "Deploy at Vercel",
+  "resources/ai-skills": "AI Skills",
+  "resources/ide-setup": "IDE Setup",
+  "resources/infisical": "Infisical",
+  contributing: "Contributing",
+}
+
+export const BLOG_TITLES: Record<string, string> = {
+  "": "Blog",
+  "web-development-2026": "How to Do Web Development in 2026",
+}

--- a/web/next/test/meta.test.ts
+++ b/web/next/test/meta.test.ts
@@ -34,7 +34,9 @@ describe("home metadata", () => {
     expect(head.metas["og:url"]).toBe(BASE)
     expect(head.metas["og:site_name"]).toBe(APP_NAME)
     expect(head.metas["og:type"]).toBe("website")
-    expect(head.metas["og:image"]).toBe(`${BASE}/og/home.png`)
+    // getOgImageUrl() prefers the committed static /og/home.png and falls back to the dynamic
+    // /api/og/home when it's absent — accept either so the spec tracks behavior, not one file.
+    expect(head.metas["og:image"]).toMatch(/\/(og\/home\.png|api\/og\/home)$/)
     expect(head.metas["og:image:width"]).toBe("1200")
     expect(head.metas["og:image:height"]).toBe("630")
     expect(head.metas["og:image:alt"]).toBe(DEFAULT_TITLE)
@@ -42,7 +44,7 @@ describe("home metadata", () => {
     expect(head.metas["twitter:card"]).toBe("summary_large_image")
     expect(head.metas["twitter:title"]).toBe(DEFAULT_TITLE)
     expect(head.metas["twitter:description"]).toBe(APP_DESCRIPTION)
-    expect(head.metas["twitter:image"]).toBe(`${BASE}/og/home.png`)
+    expect(head.metas["twitter:image"]).toMatch(/\/(og\/home\.png|api\/og\/home)$/)
   })
 
   test("og image url carries a cache buster", async () => {

--- a/web/next/test/meta.test.ts
+++ b/web/next/test/meta.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Head metadata per page: the title template, OpenGraph/Twitter card sets,
+ * og:logo, busted og image URLs, and structural head tags.
+ */
+import { describe, expect, test } from "bun:test"
+
+import {
+  APP_DESCRIPTION,
+  APP_NAME,
+  BASE,
+  BLOG_SLUGS,
+  BLOG_TITLES,
+  DEFAULT_TITLE,
+  DOCS_SLUGS,
+  DOCS_TITLES,
+  extractHead,
+  get,
+  MODE,
+} from "./helpers"
+
+async function headOf(path: string) {
+  const res = await get(path)
+  expect(res.status).toBe(200)
+  return extractHead(await res.text())
+}
+
+describe("home metadata", () => {
+  test("default title without template suffix + full og/twitter set", async () => {
+    const head = await headOf("/")
+    expect(head.title).toBe(DEFAULT_TITLE)
+    expect(head.metas["description"]).toBe(APP_DESCRIPTION)
+    expect(head.metas["og:title"]).toBe(DEFAULT_TITLE)
+    expect(head.metas["og:description"]).toBe(APP_DESCRIPTION)
+    expect(head.metas["og:url"]).toBe(BASE)
+    expect(head.metas["og:site_name"]).toBe(APP_NAME)
+    expect(head.metas["og:type"]).toBe("website")
+    expect(head.metas["og:image"]).toBe(`${BASE}/og/home.png`)
+    expect(head.metas["og:image:width"]).toBe("1200")
+    expect(head.metas["og:image:height"]).toBe("630")
+    expect(head.metas["og:image:alt"]).toBe(DEFAULT_TITLE)
+    expect(head.metas["og:logo"]).toBe(`${BASE}/favicon.ico`)
+    expect(head.metas["twitter:card"]).toBe("summary_large_image")
+    expect(head.metas["twitter:title"]).toBe(DEFAULT_TITLE)
+    expect(head.metas["twitter:description"]).toBe(APP_DESCRIPTION)
+    expect(head.metas["twitter:image"]).toBe(`${BASE}/og/home.png`)
+  })
+
+  test("og image url carries a cache buster", async () => {
+    const res = await get("/")
+    const raw = (await res.text()).match(/property="og:image" content="([^"]+)"/)?.[1]
+    expect(raw).toMatch(/\?t=\d+$/)
+  })
+})
+
+describe("docs/blog page metadata", () => {
+  const cases: {
+    path: string
+    title: string
+    og: string
+    type: string
+  }[] = []
+  for (const slug of DOCS_SLUGS) {
+    cases.push({
+      path: slug ? `/docs/${slug}` : "/docs",
+      title: DOCS_TITLES[slug],
+      og: slug ? `${BASE}/api/og/docs/${slug}` : `${BASE}/api/og/docs`,
+      type: "website",
+    })
+  }
+  for (const slug of BLOG_SLUGS) {
+    cases.push({
+      path: slug ? `/blog/${slug}` : "/blog",
+      title: BLOG_TITLES[slug],
+      og: slug ? `${BASE}/api/og/blog/${slug}` : `${BASE}/api/og/blog`,
+      type: "article",
+    })
+  }
+
+  for (const { path, title: pageTitle, og, type } of cases) {
+    test(`${path}: "%s | ${APP_NAME}" template + og set`, async () => {
+      const head = await headOf(path)
+      const title = `${pageTitle} | ${APP_NAME}`
+      expect(head.title).toBe(title)
+      expect(head.metas["description"]).toBeTruthy()
+      expect(head.metas["og:title"]).toBe(title)
+      expect(head.metas["og:description"]).toBeTruthy()
+      expect(head.metas["og:url"]).toBe(`${BASE}${path}`)
+      expect(head.metas["og:site_name"]).toBe(APP_NAME)
+      expect(head.metas["og:type"]).toBe(type)
+      expect(head.metas["og:image"]).toBe(og)
+      expect(head.metas["og:image:alt"]).toBe(pageTitle)
+      expect(head.metas["og:logo"]).toBe(`${BASE}/favicon.ico`)
+      expect(head.metas["twitter:card"]).toBe("summary_large_image")
+      expect(head.metas["twitter:title"]).toBe(title)
+      expect(head.metas["twitter:image"]).toBe(og)
+    })
+  }
+})
+
+describe("structural head tags", () => {
+  test("charset, viewport, favicon link, lang", async () => {
+    const res = await get("/")
+    const html = await res.text()
+    const head = extractHead(html)
+    expect(head.metas["viewport"]).toBe("width=device-width, initial-scale=1")
+    expect(html).toMatch(/<meta charSet="utf-8"\/?>/i)
+    expect(html).toMatch(/<html[^>]*lang="en"/)
+    expect(head.links.some((l) => l.rel === "icon" && l.href.includes("favicon"))).toBe(true)
+  })
+})
+
+describe("page content markers", () => {
+  test("home: hero copy", async () => {
+    const html = await (await get("/")).text()
+    expect(html).toContain("Go from 0 to production in")
+    expect(html).toContain("15 minutes")
+  })
+
+  test("hire: name heading and tagline", async () => {
+    const html = await (await get("/hire")).text()
+    expect(html).toContain("nrjdalal")
+    expect(html).toContain("Crafting software that makes a difference.")
+  })
+
+  test(`navbar on / is ${MODE === "dev" ? "visible (dev)" : "hidden (prod)"}`, async () => {
+    const html = await (await get("/")).text()
+    const hasNav = html.includes('aria-label="Main navigation"')
+    expect(hasNav).toBe(MODE === "dev")
+  })
+
+  test("navbar renders on /docs with nav links and login", async () => {
+    const html = await (await get("/docs")).text()
+    expect(html).toContain('aria-label="Main navigation"')
+    expect(html).toContain(">Documentation<")
+    expect(html).toContain(">Blog<")
+    expect(html).toContain('href="/api/docs"') // external API docs link
+    expect(html).toContain(">Login<")
+    expect(html).toContain('aria-label="Switch between system/light/dark version"')
+  })
+
+  test("docs page renders sidebar chrome and version footer", async () => {
+    const html = await (await get("/docs")).text()
+    expect(html).toContain("Getting Started")
+    expect(html).toContain("Deployment")
+    expect(html).toMatch(/v(<!-- -->)?\d+\.\d+\.\d+/) // version in sidebar footer
+    expect(html).toContain('placeholder="Search"')
+  })
+
+  test("docs page h1 includes copy-as-markdown affordance", async () => {
+    const html = await (await get("/docs/getting-started/architecture")).text()
+    expect(html).toContain('aria-label="Copy as markdown"')
+  })
+
+  test("blog index hides toc and footer, blog post shows content", async () => {
+    const index = await (await get("/blog")).text()
+    expect(index).toContain("How to Do Web Development in 2026")
+    const post = await (await get("/blog/web-development-2026")).text()
+    expect(post).toContain("How to Do Web Development in 2026")
+    expect(post).not.toContain('aria-label="Copy as markdown"') // docs-only affordance
+  })
+})
+
+// --- coverage gap-fill: metadata completeness + port-stable markers ---
+
+describe("metadata gap-fill", () => {
+  test("docs/blog pages carry og:image dimensions and a twitter:description", async () => {
+    for (const path of ["/docs", "/blog", "/docs/getting-started/architecture"]) {
+      const head = await headOf(path)
+      expect(head.metas["og:image:width"], path).toBe("1200")
+      expect(head.metas["og:image:height"], path).toBe("630")
+      // twitter:description mirrors the page description (present, not absent)
+      expect(head.metas["twitter:description"], path).toBe(head.metas["description"])
+    }
+  })
+
+  test("API Docs nav link opens in a new tab", async () => {
+    const html = await (await get("/docs")).text()
+    const anchor = html.match(/<a[^>]*href="\/api\/docs"[^>]*>/)?.[0] ?? ""
+    expect(anchor).toContain('target="_blank"')
+    expect(anchor).toContain('rel="noopener noreferrer"')
+  })
+
+  test("document shell carries antialiased html and min-h-dvh body", async () => {
+    const html = await (await get("/")).text()
+    expect(html).toMatch(/<html[^>]*class="[^"]*antialiased/)
+    expect(html).toMatch(/<body[^>]*class="[^"]*min-h-dvh/)
+  })
+
+  test("docs page renders a TOC; blog index does not", async () => {
+    const docs = await (await get("/docs/getting-started/architecture")).text()
+    expect(docs).toContain('id="nd-toc"')
+    const blog = await (await get("/blog")).text()
+    expect(blog).not.toContain('id="nd-toc"')
+  })
+
+  test("docs index page also exposes copy-as-markdown", async () => {
+    const html = await (await get("/docs")).text()
+    expect(html).toContain('aria-label="Copy as markdown"')
+  })
+})

--- a/web/next/test/og.test.ts
+++ b/web/next/test/og.test.ts
@@ -1,0 +1,87 @@
+/**
+ * OG image endpoints: PNG validity, canvas size, cache headers, query-param
+ * handling including the 100/200-char truncation, and 404s.
+ */
+import { describe, expect, test } from "bun:test"
+
+import { BLOG_SLUGS, DOCS_SLUGS, get, pngInfo } from "./helpers"
+
+const OG_CACHE = "public, immutable, no-transform, max-age=31536000"
+
+async function expectPng(path: string) {
+  const res = await get(path)
+  expect(res.status, path).toBe(200)
+  expect(res.headers.get("content-type")).toBe("image/png")
+  expect(res.headers.get("cache-control")).toBe(OG_CACHE)
+  const info = pngInfo(new Uint8Array(await res.arrayBuffer()))
+  expect(info.isPng).toBe(true)
+  expect(info.width).toBe(1200)
+  expect(info.height).toBe(630)
+  expect(info.size).toBeGreaterThan(10_000)
+  return info
+}
+
+describe("static og routes", () => {
+  test("/api/og/home", async () => {
+    await expectPng("/api/og/home")
+  })
+
+  test("/api/og/hire", async () => {
+    await expectPng("/api/og/hire")
+  })
+
+  for (const slug of DOCS_SLUGS) {
+    test(`/api/og/docs${slug ? `/${slug}` : ""}`, async () => {
+      await expectPng(`/api/og/docs${slug ? `/${slug}` : ""}`)
+    })
+  }
+
+  for (const slug of BLOG_SLUGS) {
+    test(`/api/og/blog${slug ? `/${slug}` : ""}`, async () => {
+      await expectPng(`/api/og/blog${slug ? `/${slug}` : ""}`)
+    })
+  }
+})
+
+describe("dynamic og route /api/og", () => {
+  test("defaults render", async () => {
+    await expectPng("/api/og")
+  })
+
+  test("title/description/section params render", async () => {
+    await expectPng("/api/og?title=Spec&description=Golden&section=Tests")
+  })
+
+  test("oversized params are truncated server-side (100/100/200) and still render", async () => {
+    const long = "x".repeat(500)
+    await expectPng(`/api/og?title=${long}&description=${long}&section=${long}`)
+  })
+})
+
+describe("og 404s", () => {
+  for (const path of ["/api/og/docs/nope", "/api/og/blog/nope", "/api/og/junk"]) {
+    test(`${path} -> 404`, async () => {
+      const res = await get(path)
+      expect(res.status).toBe(404)
+    })
+  }
+})
+
+// --- coverage gap-fill: dynamic-render proof + default fallback ---
+
+describe("og dynamic semantics", () => {
+  test("/api/og renders different bytes for different titles (truly dynamic)", async () => {
+    const [a, b] = await Promise.all([
+      get("/api/og?title=AlphaOne").then((r) => r.arrayBuffer()),
+      get("/api/og?title=BetaTwo").then((r) => r.arrayBuffer()),
+    ])
+    expect(a.byteLength).toBeGreaterThan(10_000)
+    expect(b.byteLength).toBeGreaterThan(10_000)
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false)
+  })
+
+  test("/api/og with empty/absent title both fall back to the default and render", async () => {
+    await expectPng("/api/og?title=")
+    await expectPng("/api/og")
+  })
+})

--- a/web/next/test/routing.test.ts
+++ b/web/next/test/routing.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Routing layer: every route's status, headers, redirects, 404s, and method
+ * behavior. Run with the dev stack up (see the dev skill):
+ *   bun test web/next/test/
+ */
+import { describe, expect, test } from "bun:test"
+
+import { BASE, BLOG_SLUGS, DOCS_SLUGS, get } from "./helpers"
+
+const htmlPages = [
+  "/",
+  "/hire",
+  ...DOCS_SLUGS.map((s) => (s ? `/docs/${s}` : "/docs")),
+  ...BLOG_SLUGS.map((s) => (s ? `/blog/${s}` : "/blog")),
+]
+
+describe("html pages", () => {
+  for (const path of htmlPages) {
+    test(`GET ${path} -> 200 text/html`, async () => {
+      const res = await get(path)
+      expect(res.status).toBe(200)
+      expect(res.headers.get("content-type")).toStartWith("text/html")
+    })
+
+    test(`HEAD ${path} -> 200`, async () => {
+      const res = await get(path, { method: "HEAD" })
+      expect(res.status).toBe(200)
+    })
+  }
+})
+
+describe("non-html routes", () => {
+  const paths = ["/robots.txt", "/sitemap.xml", "/llms.txt"]
+  for (const path of paths) {
+    test(`GET ${path} -> 200`, async () => {
+      const res = await get(path)
+      expect(res.status).toBe(200)
+    })
+
+    test(`HEAD ${path} -> 200`, async () => {
+      const res = await get(path, { method: "HEAD" })
+      expect(res.status).toBe(200)
+    })
+  }
+})
+
+describe("404s", () => {
+  const notFound = [
+    "/nonexistent",
+    "/docs/getting-started", // intermediate path without a page
+    "/docs/manage",
+    "/docs/nope",
+    "/blog/nope",
+    "/DOCS", // routes are case-sensitive
+  ]
+  for (const path of notFound) {
+    test(`GET ${path} -> 404`, async () => {
+      const res = await get(path)
+      expect(res.status).toBe(404)
+    })
+  }
+
+  test("404 page renders the not-found copy", async () => {
+    const res = await get("/nonexistent")
+    const text = await res.text()
+    expect(text).toContain("404")
+    expect(text).toContain("This page could not be found")
+  })
+})
+
+describe("trailing slash normalization", () => {
+  const paths = ["/docs/", "/blog/", "/docs/getting-started/setup/", "/llms.txt/", "/dashboard/"]
+  for (const path of paths) {
+    test(`${path} redirects to ${path.replace(/\/+$/, "")}`, async () => {
+      const res = await get(path)
+      expect(res.status).toBeGreaterThanOrEqual(300)
+      expect(res.status).toBeLessThan(400)
+      const location = new URL(res.headers.get("location")!, BASE)
+      expect(location.pathname).toBe(path.replace(/\/+$/, ""))
+    })
+  }
+})
+
+describe("favicon", () => {
+  test("GET /favicon.ico -> 200 ico", async () => {
+    const res = await get("/favicon.ico")
+    expect(res.status).toBe(200)
+    expect(["image/x-icon", "image/vnd.microsoft.icon"]).toContain(
+      res.headers.get("content-type")?.split(";")[0] ?? "",
+    )
+  })
+})
+
+describe("protected routes", () => {
+  test("GET /dashboard anonymous -> redirect to /", async () => {
+    const res = await get("/dashboard")
+    expect(res.status).toBeGreaterThanOrEqual(300)
+    expect(res.status).toBeLessThan(400)
+    expect(new URL(res.headers.get("location")!, BASE).pathname).toBe("/")
+  })
+})
+
+// Exact redirect status codes (308 vs 307) and the framework-default 404
+// <title> are deliberately NOT pinned: they're framework impl detail a
+// cross-framework port legitimately changes. The portable contract — 3xx +
+// redirect target, and 404 status + body copy — is asserted above.

--- a/web/next/test/routing.test.ts
+++ b/web/next/test/routing.test.ts
@@ -69,7 +69,10 @@ describe("404s", () => {
 })
 
 describe("trailing slash normalization", () => {
-  const paths = ["/docs/", "/blog/", "/docs/getting-started/setup/", "/llms.txt/", "/dashboard/"]
+  // /dashboard/ is excluded on purpose: it is auth-gated, so anonymously its first hop can be
+  // either the trailing-slash normalize (-> /dashboard) or the auth redirect (-> /) depending on
+  // middleware order. The anonymous /dashboard redirect is asserted in "protected routes" below.
+  const paths = ["/docs/", "/blog/", "/docs/getting-started/setup/", "/llms.txt/"]
   for (const path of paths) {
     test(`${path} redirects to ${path.replace(/\/+$/, "")}`, async () => {
       const res = await get(path)

--- a/web/next/test/run.ts
+++ b/web/next/test/run.ts
@@ -1,0 +1,34 @@
+/**
+ * Test orchestrator: ensure the stack is up (via the shared lifecycle in
+ * stack.ts, which tears down only what it starts), then run the bun-test target
+ * passed after `--`. `--browser` also requires the agent-browser CLI.
+ *
+ * Use the package scripts (`bun run test`, `bun run test:e2e`), not `bun test` —
+ * the latter is Bun's built-in runner and skips this wrapper. See the
+ * `web-spec` skill.
+ */
+import { ensureStack } from "./stack"
+
+const webNext = `${import.meta.dir}/..`
+const wantBrowser = process.argv.includes("--browser")
+const sep = process.argv.indexOf("--")
+const testArgs = sep >= 0 ? process.argv.slice(sep + 1) : ["test/"]
+
+const teardown = await ensureStack({ browser: wantBrowser })
+
+let code = 1
+try {
+  const test = Bun.spawn(["bun", "test", ...testArgs], {
+    cwd: webNext,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+    env: process.env,
+  })
+  code = await test.exited
+} finally {
+  teardown()
+}
+process.exit(code)
+
+export {}

--- a/web/next/test/stack.ts
+++ b/web/next/test/stack.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared stack lifecycle for the test scripts. Ensures the app + API are up for
+ * a run and tears down ONLY what it starts — a running stack is reused and left
+ * alone. Used by run.ts (deterministic/e2e), visual.ts (visual parity), and
+ * all.ts (both), so every script "just works" whether or not `bun dev` is going.
+ *
+ * Platform-agnostic: no shell or external binaries (no bash/lsof/awk/xargs/kill).
+ * Port checks use Bun.connect, the dev process is spawned detached so it leads
+ * its own process group, and teardown signals that group — so it behaves the
+ * same on macOS, Linux, and CI without depending on the host's tooling.
+ *
+ * Bun-native where Bun offers it (Bun.connect, Bun.spawnSync, Bun.sleep); the
+ * dev spawn falls back to node:child_process only because Bun.spawn has no
+ * detached/process-group option, which the group-kill teardown needs.
+ */
+import { spawn, type ChildProcess } from "node:child_process"
+import { openSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+export const BASE = process.env.BASE_URL ?? "http://localhost:3000"
+export const API = process.env.API_URL ?? "http://localhost:4000"
+const repoRoot = `${import.meta.dir}/../../..`
+const stackLog = join(tmpdir(), "zerostarter-test-stack.log")
+
+const portOf = (url: string) => Number(new URL(url).port || "80")
+
+const fail = (msg: string) => {
+  console.error(`\n✗ ${msg}\n`)
+  process.exit(1)
+}
+
+async function reachable(url: string): Promise<boolean> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(2000) })
+    return res.ok || res.status === 404
+  } catch {
+    return false
+  }
+}
+
+const stackUp = async () =>
+  (await reachable(`${BASE}/robots.txt`)) && (await reachable(`${API}/api/health`))
+
+// Portable "is something listening here?" — open a TCP connection (Bun.connect)
+// and see if it's accepted, rather than shelling out to lsof. Resolves false
+// when refused; only used for localhost ports, where refusal is immediate, so
+// no extra timeout is needed.
+async function portListening(url: string): Promise<boolean> {
+  const { hostname, port } = new URL(url)
+  try {
+    const socket = await Bun.connect({
+      hostname: hostname || "127.0.0.1",
+      port: Number(port || "80"),
+      socket: { open() {}, data() {}, close() {}, error() {} },
+    })
+    socket.end()
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Ensures BASE+API are reachable, returning a teardown fn. If the stack was
+// already up it's a no-op (reuse, don't clobber); if we started it, teardown
+// stops the whole dev process group. Pass { browser: true } to also require the
+// agent-browser CLI.
+export async function ensureStack(opts: { browser?: boolean } = {}): Promise<() => void> {
+  if (opts.browser) {
+    const probe = Bun.spawnSync(["bunx", "agent-browser", "--version"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    })
+    if (probe.exitCode !== 0) {
+      fail(
+        "agent-browser CLI not found (needed for the browser/visual tier).\n" +
+          "  Install it: npm i -g agent-browser && agent-browser install",
+      )
+    }
+  }
+
+  let dev: ChildProcess | undefined
+  const teardown = () => {
+    if (!dev?.pid) return
+    // dev is spawned detached, so it leads its own process group; signalling the
+    // negative pid takes down turbo AND the dev servers it spawned (a plain
+    // kill would orphan them). try/catch: the group may already be gone.
+    try {
+      process.kill(-dev.pid, "SIGTERM")
+    } catch {
+      // already exited
+    }
+  }
+
+  for (const sig of ["SIGINT", "SIGTERM"] as const) {
+    process.on(sig, () => {
+      teardown()
+      process.exit(sig === "SIGINT" ? 130 : 143)
+    })
+  }
+
+  if (await stackUp()) {
+    console.log(`✓ reusing the running stack (${BASE}, ${API}) — leaving it up`)
+    return teardown
+  }
+
+  // don't start (and later kill) anything if a port is held by a process that
+  // isn't a full ZeroStarter stack — fail loudly instead of risking a foreign kill
+  const occupied: string[] = []
+  for (const u of [BASE, API]) {
+    if (await portListening(u)) occupied.push(u)
+  }
+  if (occupied.length > 0) {
+    fail(
+      `port(s) ${occupied.map(portOf).join(", ")} are occupied but the stack isn't healthy.\n` +
+        `  Something other than the ZeroStarter stack is on them. Free it, or point\n` +
+        `  BASE_URL / API_URL at the right target.`,
+    )
+  }
+
+  console.log("• stack not running — starting `bun dev` (will stop it after the run)…")
+  // detached so the child leads a new process group (see teardown); stdout/err
+  // go to the log file by fd. node:child_process (not Bun.spawn) for portable
+  // detached/group-kill semantics.
+  const log = openSync(stackLog, "a")
+  dev = spawn("bunx", ["turbo", "run", "dev", "--ui", "stream"], {
+    cwd: repoRoot,
+    env: process.env,
+    detached: true,
+    stdio: ["ignore", log, log],
+  })
+  const deadline = Date.now() + 120_000
+  while (!(await stackUp())) {
+    if (Date.now() > deadline) {
+      teardown()
+      fail(`stack did not become healthy within 120s. See ${stackLog}`)
+    }
+    await Bun.sleep(1000)
+  }
+  console.log("✓ stack up")
+  return teardown
+}

--- a/web/next/test/tsconfig.json
+++ b/web/next/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@packages/tsconfig/base.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "paths": {
+      "@/*": ["../src/*"]
+    }
+  },
+  "include": ["**/*.ts"]
+}

--- a/web/next/test/visual.ts
+++ b/web/next/test/visual.ts
@@ -1,0 +1,193 @@
+/**
+ * Visual-parity layer — the one axis HTTP/SSR assertions can't see: CSS and
+ * layout. Screenshots each page at key viewport × theme combos via the
+ * agent-browser CLI and pixel-diffs them against a baseline with sharp.
+ *
+ * It's the port oracle for "looks identical", not just "responds identically":
+ *   1. capture golden baselines from the reference (web/next):
+ *        bun run test:visual:update
+ *   2. diff a target (e.g. a web/start prod build) against them:
+ *        BASE_URL=http://localhost:3101 bun run test:visual
+ *
+ * Baselines are machine-specific (font rendering varies), so they live under
+ * test/screenshots/ (gitignored) — regenerate from the reference on the same
+ * machine before comparing a port. See the `web-spec` skill.
+ */
+import { mkdirSync, rmSync } from "node:fs"
+
+import sharp from "sharp"
+
+import { BASE, ensureStack } from "./stack"
+
+// max summed RGB delta (across the 3 channels) before a pixel counts as
+// changed, and the max fraction of changed pixels allowed
+const CHANNEL_TOLERANCE = 12
+const MAX_DIFF_RATIO = 0.01
+
+const dir = `${import.meta.dir}/screenshots`
+const baselineDir = `${dir}/baseline`
+const currentDir = `${dir}/current`
+const diffDir = `${dir}/diff`
+
+const VIEWPORTS = [
+  { name: "desktop", w: 1440, h: 900 },
+  { name: "mobile", w: 390, h: 844 },
+] as const
+const THEMES = ["light", "dark"] as const
+const PAGES = [
+  "/",
+  "/hire",
+  "/docs",
+  "/docs/getting-started/setup",
+  "/blog",
+  "/blog/web-development-2026",
+]
+
+function ab(...args: string[]): void {
+  const proc = Bun.spawnSync(["bunx", "agent-browser", ...args], {
+    stdout: "ignore",
+    stderr: "pipe",
+  })
+  if (proc.exitCode !== 0) {
+    throw new Error(`agent-browser ${args[0]} failed: ${proc.stderr.toString().trim()}`)
+  }
+}
+
+const slug = (page: string, vp: string, theme: string) =>
+  `${page === "/" ? "home" : page.replaceAll("/", "_").replace(/^_/, "")}__${vp}__${theme}`
+
+async function capture(into: string) {
+  for (const vp of VIEWPORTS) {
+    ab("set", "viewport", String(vp.w), String(vp.h))
+    for (const theme of THEMES) {
+      for (const page of PAGES) {
+        ab("open", `${BASE}${page}`)
+        // pin the theme deterministically rather than relying on prefers-color-scheme
+        ab("eval", `localStorage.setItem('theme', '${theme}'); location.reload()`)
+        ab("wait", "--load", "networkidle")
+        await Bun.sleep(600) // settle fonts/animations
+        ab("screenshot", "--full", `${into}/${slug(page, vp.name, theme)}.png`)
+      }
+    }
+  }
+  // leave the shared daemon at desktop so a following test:e2e isn't stuck
+  // behind the mobile sheet (the last loop iteration set 390×844)
+  ab("set", "viewport", "1440", "900")
+}
+
+// returns the fraction of pixels differing beyond tolerance, and writes a diff
+// image (differing pixels in magenta) for review; Infinity if dimensions differ
+async function diff(baseline: string, current: string, out: string): Promise<number> {
+  const a = await sharp(baseline).ensureAlpha().raw().toBuffer({ resolveWithObject: true })
+  const b = await sharp(current).ensureAlpha().raw().toBuffer({ resolveWithObject: true })
+  if (a.info.width !== b.info.width || a.info.height !== b.info.height)
+    return Number.POSITIVE_INFINITY
+
+  const { width, height } = a.info
+  const px = width * height
+  const diffBuf = Buffer.from(b.data)
+  let changed = 0
+  for (let i = 0; i < px; i++) {
+    const o = i * 4
+    const delta =
+      Math.abs(a.data[o] - b.data[o]) +
+      Math.abs(a.data[o + 1] - b.data[o + 1]) +
+      Math.abs(a.data[o + 2] - b.data[o + 2])
+    if (delta > CHANNEL_TOLERANCE) {
+      changed++
+      diffBuf[o] = 255
+      diffBuf[o + 1] = 0
+      diffBuf[o + 2] = 255
+    }
+  }
+  if (changed > 0) {
+    await sharp(diffBuf, { raw: { width, height, channels: 4 } })
+      .png()
+      .toFile(out)
+  }
+  return changed / px
+}
+
+// Run the capture + pixel-diff against an ALREADY-UP stack, returning a result
+// rather than exiting. This lets the standalone script (below) and test:all
+// (test/all.ts) drive the same logic — test:all calls it in-process so the whole
+// run shares one ensureStack instead of booting the stack a second time.
+export async function visualParity(update: boolean): Promise<{ ok: boolean; summary: string }> {
+  if (update) {
+    rmSync(baselineDir, { recursive: true, force: true })
+    mkdirSync(baselineDir, { recursive: true })
+    await capture(baselineDir)
+    return { ok: true, summary: `✓ captured baselines from ${BASE} → ${baselineDir}` }
+  }
+
+  mkdirSync(currentDir, { recursive: true })
+  rmSync(diffDir, { recursive: true, force: true })
+  mkdirSync(diffDir, { recursive: true })
+  await capture(currentDir)
+
+  const shots = new Bun.Glob("*.png")
+  const current = [...shots.scanSync({ cwd: currentDir })]
+  // a baseline with no current shot means a page silently dropped out of coverage
+  for (const base of shots.scanSync({ cwd: baselineDir })) {
+    if (!current.includes(base))
+      return { ok: false, summary: `\n✗ baseline ${base} has no current shot — coverage dropped\n` }
+  }
+
+  const failures: string[] = []
+  let compared = 0
+  for (const file of current) {
+    const baseline = `${baselineDir}/${file}`
+    if (!(await Bun.file(baseline).exists())) {
+      return {
+        ok: false,
+        summary: `\n✗ no baseline for ${file} — run \`bun run test:visual:update\` against the reference first\n`,
+      }
+    }
+    const ratio = await diff(baseline, `${currentDir}/${file}`, `${diffDir}/${file}`)
+    compared++
+    if (ratio > MAX_DIFF_RATIO) {
+      failures.push(
+        `${file}: ${(ratio * 100).toFixed(2)}% differ` +
+          (ratio === Number.POSITIVE_INFINITY
+            ? " (dimensions changed)"
+            : ` (> ${MAX_DIFF_RATIO * 100}%) — see ${diffDir}/${file}`),
+      )
+    }
+  }
+
+  if (failures.length > 0) {
+    return {
+      ok: false,
+      summary: `\n✗ visual parity failed on ${failures.length}/${compared} shots:\n  ${failures.join("\n  ")}\n`,
+    }
+  }
+  return {
+    ok: true,
+    summary: `✓ visual parity: ${compared} shots within ${MAX_DIFF_RATIO * 100}% of baseline`,
+  }
+}
+
+// Standalone entry (bun run test/visual.ts [--update]): own the stack lifecycle
+// the same way run.ts does — auto-start if down, reuse + leave a running one,
+// tear down on every exit path (done() on the explicit branches, the catch on
+// any throw; ab() throws by design and sharp can throw on a bad PNG, so an
+// auto-started stack is never orphaned). The import.meta.main guard keeps this
+// from running when test/all.ts imports visualParity.
+if (import.meta.main) {
+  const update = process.argv.includes("--update")
+  const teardown = await ensureStack({ browser: true })
+  const done = (code: number, msg: string): never => {
+    teardown()
+    ;(code ? console.error : console.log)(msg)
+    process.exit(code)
+  }
+  try {
+    const result = await visualParity(update)
+    done(result.ok ? 0 : 1, result.summary)
+  } catch (e) {
+    // ab() failures embed stderr in the message, but a sharp internal error is
+    // easier to place with the stack — print it before the summary
+    if (e instanceof Error && e.stack) console.error(e.stack)
+    done(1, `\n✗ visual run errored: ${e instanceof Error ? e.message : String(e)}\n`)
+  }
+}

--- a/web/next/tsconfig.json
+++ b/web/next/tsconfig.json
@@ -20,5 +20,5 @@
     ".next/dev/types/**/*.ts",
     "next-env.d.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
Ports the `web/next` behavioral spec suite down from `dalonic/cafe` and adapts/refines it for ZeroStarter. It's a black-box, `BASE_URL`-portable spec: golden literals asserted against a running app over HTTP/SSR plus a browser tier, so config or copy drift fails a test.

## What's included

- **Harness** (kept, lightly adapted): `stack.ts` (reuse-or-start lifecycle, port guard, group teardown), `run.ts`, `all.ts`, `visual.ts` (sharp pixel-diff), `helpers.ts` (429-retrying `req`/`get`, head/PNG parsers, `signInAsAgent`, content inventory), `tsconfig.json`.
- **Tiers**: `routing`, `content` (robots/sitemap/llms.txt + `.md`/`.txt` aliases), `meta`, `og`, `api` (proxy og-exclusion edges, search, auth + system endpoints, agents origin gating), `dashboard` (authed SSR), `feedback` (USERJOT conditional), `browser` (theme, login dialog, Cmd-K search, copy-as-markdown, sidebar, mobile).
- **Scripts** (thin root delegators + `web/next`): `test`, `test:e2e`, `test:visual`, `test:visual:update`, `test:all`; `check-types` chains `tsc -p test/tsconfig.json`; `test` excluded from the main tsc.
- **`web-spec` skill** documenting the suite (the test comments reference it).

## How it was adapted from cafe

- **Dropped the waitlist entirely** (ZeroStarter has none): the API waitlist contract, the browser signup flow + home count widget, the `db.ts` smoke-row cleanup, and the `ALLOW_DB_WRITES` gate. The only test-time write is the idempotent agent-user upsert, so there's no residue to clean.
- **Dropped the MVP `noindex`** assumptions: ZeroStarter is indexable, so the `X-Robots-Tag` assertions are gone and `robots.txt`/`sitemap` now assert the real `Allow: /` + `Disallow: /api/,/dashboard/` contract.
- **Retargeted every golden literal** to ZeroStarter's actual app: home hero (`Go from 0 to production in 15 minutes`), title template (`%s | ZeroStarter`), default title, OG `siteName`, the full 29-doc + 2-blog content inventory, agent identity (`AgentZero` / `agent@zerostarter.dev`), and added a `/hire` marker.
- **Titles pinned, descriptions left to a presence check** (29 docs drift too often to pin each description byte-for-byte).

## Verification

- `check-types` green (main tsc + `tsc -p test/tsconfig.json`), `format:check` clean, `oxlint` clean.
- Not wired into CI by design (needs live servers). A live run (`bun run test` / `test:e2e`) needs a running stack + DB locally, which I couldn't exercise here. Literals were verified against source, but a first local `bun run test` is the recommended next step to shake out any remaining copy mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite covering API, routing, content, SEO/meta, dashboard auth, browser E2E flows, and visual-regression checks.
  * Introduced visual-parity harness with baseline/current screenshot comparisons and pixel-diff reporting.
  * Added shared test helpers, orchestration for bootstrapping/tearing down the app stack, and browser-gated E2E runners.

* **Chores**
  * New npm scripts to run behavioral, e2e, and visual tests: test, test:all, test:e2e, test:visual, test:visual:update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->