### PR TITLE
fix(web): allow crawlers to fetch OG images under /api/og

### DIFF
--- a/web/next/content/blog/web-development-2026.mdx
+++ b/web/next/content/blog/web-development-2026.mdx
@@ -533,7 +533,7 @@ Add a doc or blog post? It's automatically in the sitemap. No manual updates nee
 ```ts
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: "*", allow: "/", disallow: ["/api/", "/dashboard/"] }],
+    rules: [{ userAgent: "*", allow: ["/", "/api/og"], disallow: ["/api/", "/dashboard/"] }],
     sitemap: `${baseUrl}/sitemap.xml`,
   }
 }

--- a/web/next/content/docs/manage/og-images.mdx
+++ b/web/next/content/docs/manage/og-images.mdx
@@ -16,6 +16,8 @@ ZeroStarter generates dynamic Open Graph images for social media previews using 
 | `/api/og/blog/[[...slug]]`             | Blog post previews                           |
 | `/api/og?section=&title=&description=` | Generic parameterized preview (hire, résumé) |
 
+> **Note:** These routes live under `/api/`, which `robots.txt` disallows. An explicit `Allow: /api/og` keeps them crawlable so social unfurlers can fetch the preview images. See [robots.txt](/docs/manage/robots).
+
 ## How It Works
 
 OG images are generated as static routes at build time using `generateStaticParams`. They return PNG images with immutable cache headers (1 year).

--- a/web/next/content/docs/manage/robots.mdx
+++ b/web/next/content/docs/manage/robots.mdx
@@ -14,7 +14,7 @@ The `robots.txt` file provides instructions to search engine crawlers about whic
 The robots.txt file:
 
 - Allows all public pages to be crawled
-- Disallows API routes and private dashboard pages
+- Disallows API routes and private dashboard pages, except `/api/og` (so social unfurlers can fetch Open Graph preview images)
 - References the sitemap location
 - Uses Next.js `MetadataRoute.Robots` type
 
@@ -28,9 +28,11 @@ The robots.txt file:
 The robots.txt is implemented in `web/next/src/app/robots.ts` and configures:
 
 - **User-Agent**: `*` (all crawlers)
-- **Allowed**: All pages under `/` (public content)
+- **Allowed**:
+  - `/` - all public content
+  - `/api/og` - Open Graph image routes, so social unfurlers (Twitterbot, facebookexternalhit, LinkedInBot, Slackbot, Discordbot) can fetch link-preview images
 - **Disallowed**:
-  - `/api/` - API endpoints
+  - `/api/` - API endpoints (the more specific `/api/og` allow above wins by longest-match, so preview images stay crawlable)
   - `/dashboard/` - Dashboard routes
 - **Sitemap**: References `${baseUrl}/sitemap.xml`
 
@@ -40,5 +42,5 @@ The current configuration:
 
 - Allows all search engines (`User-Agent: *`)
 - Permits crawling of all public pages
-- Blocks API endpoints and dashboard routes
+- Blocks API endpoints (except the `/api/og` image routes) and dashboard routes
 - Points crawlers to the sitemap for efficient discovery

--- a/web/next/src/app/robots.ts
+++ b/web/next/src/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: "/",
+        allow: ["/", "/api/og"],
         disallow: ["/api/", "/dashboard/"],
       },
     ],


### PR DESCRIPTION
## Summary

`robots.txt` disallowed all of `/api/`, but OG images are served from `/api/og/...`. Social unfurlers (Twitterbot, facebookexternalhit, LinkedInBot, Slackbot, Discordbot) follow Google's robots.txt spec and refuse to fetch disallowed paths, so they skipped the `og:image` and rendered the empty placeholder card instead of the real preview.

- Add `Allow: /api/og` to `robots.ts`. By the longest-match-wins rule (RFC 9309 / Google spec), `/api/og` (allow) beats `/api/` (disallow) for every OG path, while `/api/v1`, `/api/auth`, etc. stay blocked.
- Covers all OG routes: the per-page blog/home/docs images **and** the generic `/api/og?...` endpoint used by `/hire` and `/resume`.
- Synced the related docs (`docs/manage/robots`, `docs/manage/og-images`) and the `web-development-2026` blog example to reflect the new allow rule.

## Verification

Ran both the old and new `robots.txt` through `protego` (the Google-spec-compliant parser Scrapy uses) across Twitterbot, `*`, Googlebot, facebookexternalhit, LinkedInBot, Slackbot, and Discordbot:

| Path | old | new |
| --- | --- | --- |
| `/api/og/blog/...` (blog image) | BLOCK | ALLOW |
| `/api/og/home` | BLOCK | ALLOW |
| `/api/og?section=...` (hire/résumé) | BLOCK | ALLOW |
| `/api/v1/user` | BLOCK | BLOCK |
| `/api/auth/session` | BLOCK | BLOCK |
| `/dashboard/` | BLOCK | BLOCK |

`bun run check-types` and `oxfmt --check` clean.

Note: X caches a failed card for ~24h, so re-share with a busting query (`?v=2`) after deploy to force a fresh crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated robots configuration to allow crawling of Open Graph image endpoints, enabling better social media preview unfurling.

* **Documentation**
  * Updated documentation for robots.txt behavior to clarify API route restrictions and the explicit exception for Open Graph endpoints used by social media platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->