### PR TITLE
fix(web): wrap long OG image titles so they stay inside the frame

### DIFF
--- a/web/next/src/lib/og-image.tsx
+++ b/web/next/src/lib/og-image.tsx
@@ -41,6 +41,7 @@ export async function renderOgElement(element: ReactElement): Promise<Response> 
 export async function renderOgImage(options: RenderOgImageOptions): Promise<Response> {
   const { sectionName, title, description } = options
   const label = sectionName ? `${config.app.name} - ${sectionName}` : config.app.name
+  const titleFontSize = title.length > 50 ? 52 : title.length > 30 ? 64 : 72
 
   const element = (
     <div
@@ -72,10 +73,11 @@ export async function renderOgImage(options: RenderOgImageOptions): Promise<Resp
       <div
         style={{
           display: "flex",
-          fontSize: 72,
+          fontSize: titleFontSize,
           fontWeight: "bold",
           marginBottom: 30,
           lineHeight: 1.2,
+          maxWidth: 1040,
           background: "linear-gradient(90deg, #fff 0%, #a0a0a0 100%)",
           backgroundClip: "text",
           color: "transparent",


### PR DESCRIPTION
## Problem

Long titles overflow the right edge of the generated OG image and get clipped mid-word (e.g. the new blog post rendered as "Race-Free Identity in Claude Co…"). The title `<div>` had no width bound, so it sized to its content and ran off the 1200px frame. The description already wrapped correctly because it set `maxWidth: 900`.

## Fix

In `web/next/src/lib/og-image.tsx`:

- Add `maxWidth: 1040` to the title (content area = 1200 − 80×2 padding) so long titles wrap instead of overflowing.
- Tier the title font size by length (`>50` chars → 52px, `>30` → 64px, else 72px) so a wrapped title doesn't grow too tall.

## Verification

Rendered both cases locally against `next dev`:

- **Long** ("Race-Free Identity in Claude Code: Per-Workspace MCP, GitHub, and Git") → wraps to two lines at 52px, fully inside the frame.
- **Short** ("OG Images") → still renders large at 72px.

OG images are static (regenerated at build), so this takes effect on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced OG image title rendering with dynamic font sizing that adjusts based on title length, improving visual presentation and readability across varying content lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->