### PR TITLE
chore(web): sync shadcn (carousel centering, spinner data-slot)

### DIFF
--- a/web/next/src/components/ui/carousel.tsx
+++ b/web/next/src/components/ui/carousel.tsx
@@ -176,7 +176,7 @@ function CarouselPrevious({
       className={cn(
         "absolute touch-manipulation rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -left-12 -translate-y-1/2"
+          ? "inset-y-0 -left-12 my-auto"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
         className,
       )}
@@ -206,7 +206,7 @@ function CarouselNext({
       className={cn(
         "absolute touch-manipulation rounded-full",
         orientation === "horizontal"
-          ? "top-1/2 -right-12 -translate-y-1/2"
+          ? "inset-y-0 -right-12 my-auto"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
         className,
       )}

--- a/web/next/src/components/ui/spinner.tsx
+++ b/web/next/src/components/ui/spinner.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils"
 function Spinner({ className, ...props }: React.ComponentProps<RemixiconComponentType>) {
   return (
     <RiLoaderLine
+      data-slot="spinner"
       role="status"
       aria-label="Loading"
       className={cn("size-4 animate-spin", className)}


### PR DESCRIPTION
Ran `bun run shadcn:update` and reconciled the diff per the `shadcn-sync` skill. Only the genuine registry deltas are committed; all local overrides and catalog pins were restored.

## Kept (registry improvements)
- `ui/carousel.tsx` — prev/next arrow centering: `top-1/2 -translate-y-1/2` → `inset-y-0 my-auto`
- `ui/spinner.tsx` — added `data-slot="spinner"` (local `RemixiconComponentType` typing preserved)

## Restored / discarded (not owned by the sync)
- `bun.lock` — sync rebuilt `web/next` deps off `catalog:` and bumped `react-day-picker` `^9.14.0` → `^10.0.1`; lock restored and react-day-picker resynced to v9
- `lib/utils.ts` — restored `slugify`/`generateId`
- `layout.tsx` + `--font-sans` in `globals.css` — restored localized fonts (init had re-injected `next/font/google`)
- `ui/button.tsx` — restored Base UI render wiring

`cd web/next && bun run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved carousel navigation button positioning for better visual alignment across different screen sizes

* **Refactor**
  * Enhanced spinner component for improved compatibility and functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->