### PR TITLE
feat(db): auto-apply migrations on canary/production deploys

### DIFF
--- a/.agents/skills/db-migration/SKILL.md
+++ b/.agents/skills/db-migration/SKILL.md
@@ -29,6 +29,8 @@ Review the generated SQL in `packages/db/drizzle/` before applying. Check `meta/
 bun run db:migrate
 ```
 
+Local / ad-hoc only. On Vercel the **API build auto-applies pending migrations** on production and canary deploys (`.github/scripts/migrate-on-deploy.ts`, gated on `VERCEL_ENV`/branch; PR previews are skipped), so merging a migration to canary applies it automatically on the next deploy.
+
 ### 4. Make the running stack see it
 
 ```bash

--- a/.github/scripts/migrate-on-deploy.ts
+++ b/.github/scripts/migrate-on-deploy.ts
@@ -1,0 +1,14 @@
+import { $ } from "bun"
+
+const env = process.env.VERCEL_ENV ?? "unset"
+const ref = process.env.VERCEL_GIT_COMMIT_REF ?? "unset"
+
+// Apply pending migrations only on deploy branches (production + canary), never on PR previews (unmerged migrations against a shared DB).
+if (env !== "production" && ref !== "canary") {
+  console.log(`[migrate-on-deploy] skip — VERCEL_ENV=${env}, ref=${ref}`)
+  process.exit(0)
+}
+
+console.log(`[migrate-on-deploy] applying pending migrations — VERCEL_ENV=${env}, ref=${ref}`)
+await $`bun run db:migrate`
+console.log("[migrate-on-deploy] done")

--- a/api/hono/vercel.json
+++ b/api/hono/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "hono",
   "installCommand": "cd ../.. && bun install --ignore-scripts",
-  "buildCommand": "cd ../.. && turbo build:vercel --filter=@api/hono",
+  "buildCommand": "cd ../.. && bun .github/scripts/migrate-on-deploy.ts && turbo build:vercel --filter=@api/hono",
   "outputDirectory": "vercel-bundle",
   "bunVersion": "1.3.10"
 }


### PR DESCRIPTION
## Problem
Migrations are generated and committed, but **nothing applies them on deploy** — so the deployed database drifts from the code. This just bit us: the `console` column (migration 0002, from #464) was never applied to the DB, so GitHub auth 500'd on canary/production with `column "console" does not exist`. Fixed manually with `drizzle-kit migrate`; this prevents recurrence.

## Change
The **API build applies pending migrations before building**, gated to deploy branches:
- **`.github/scripts/migrate-on-deploy.ts`** — runs `bun run db:migrate` only when `VERCEL_ENV=production` or branch `canary`. PR previews are skipped, so unmerged migrations never hit the shared DB.
- **`api/hono/vercel.json`** — `buildCommand` runs the script before `turbo build:vercel`.
- **`db-migration` skill** — documents the auto-apply.

## Notes
- Uses Vercel's existing `POSTGRES_URL` — **no new secret/CI setup**.
- Safe for **additive** migrations (add column/table); a destructive migration (drop/rename) still needs deliberate handling.
- Starter-safe: forks inherit it and use their own Vercel DB env; a fresh install's first deploy just sets up its schema.
- The `db:migrate` root script already existed; this only adds the deploy-time trigger.