### PR TITLE
refactor(web): extract a SidebarDropdownMenu shell for user-menu + org-switcher (audit #8)

### DIFF
--- a/.github/audit/2026-06-19-dedup-structure-architecture.md
+++ b/.github/audit/2026-06-19-dedup-structure-architecture.md
@@ -19,7 +19,7 @@ The architecture is sound. Package layering is clean and acyclic (`env ← db �
 | 5   | ✅ ~~Resolve the `SidebarTrigger` fork (retire dead shadcn export / `zeroui/` one-file namespace)~~ (done in #481: extended via post-sync generator, `zeroui/` retired)                         | medium     | ✓ verified | S      |
 | 6   | ✅ ~~Collapse 3 near-identical `tsdown.config.ts` into a shared factory~~ (done in #481: `@packages/tsconfig`→`@packages/config` + a `definePackageConfig` factory)                             | low        | high       | M      |
 | 7   | ✅ ~~`getPublicBlogPage()` helper to replace the 4× blog resolve-and-gate~~ (done in #481: `getPublicBlogPage(slug, now?)` in `lib/blog.ts`, all 4 sites gate through it)                       | medium     | high       | S      |
-| 8   | ⏭️ Shared sidebar dropdown shell for user-menu + org-switcher (deferred to its own PR)                                                                                                          | medium     | high       | M      |
+| 8   | ✅ ~~Shared sidebar dropdown shell for user-menu + org-switcher~~ (done in #484: `SidebarDropdownMenu` shell; consumers supply leading + identity + items)                                      | medium     | high       | M      |
 | 9   | 🚫 ~~Stop mirroring `.gitignore` into `.dockerignore` 1:1~~ (won't fix: keep the `.gitignore`/`.dockerignore` mirror in sync; Docker-only divergence not worth it)                              | medium     | high       | S      |
 | 10  | 🚫 ~~Remove dead env exports (`isDevelopment`/`isTest`/`isStaging`/`NodeEnv` re-export)~~ (won't fix: kept as intentional env API surface for downstream apps; all 5 checkers verified working) | low        | ✓ verified | S      |
 | 11  | ✅ ~~`jsonError()` helper for the 6 hand-written API error envelopes~~ (done in #481: `jsonError(c, status, code, message, extra?)` in `lib/error.ts`, all sites routed through it)             | low        | high       | S      |
@@ -64,6 +64,7 @@ Same `const page = blogSource.getPage(slug); if (!page || !isPublicBlogPage(page
 
 Identical trigger className (`user-menu.tsx:41`, `org-switcher.tsx:125`), identical content className (`user-menu.tsx:56`, `org-switcher.tsx:143`), and the identity block (`grid flex-1 text-left text-sm leading-tight` + truncated name/secondary) appears 4× (`user-menu.tsx:49,68`, `org-switcher.tsx:132,154`).
 **Fix:** extract a `SidebarDropdownMenu` shell (icon/avatar + primary/secondary slots + content wrapper); consumers supply only menu items.
+**Done (#484):** `SidebarDropdownMenu` (`components/sidebar/dropdown-menu.tsx`) owns the trigger, the identity header, and the content wrapper (`align`/`mobileSide`); `user-menu` and `org-switcher` pass only `leading`/`primary`/`secondary` + items. Behaviour-preserving — consumer slots keep the per-component deltas (avatar vs icon box, muted secondary, distinct trigger/header fallback text). Verified in-browser: both dropdowns render trigger + identity header + items correctly.
 
 ### 1.7 API error envelope hand-written in ~6 places
 

--- a/web/next/src/components/sidebar/dashboard/org-switcher.tsx
+++ b/web/next/src/components/sidebar/dashboard/org-switcher.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { RiAddLine, RiBuildingLine, RiExpandUpDownLine, RiLoaderLine } from "@remixicon/react"
+import { RiAddLine, RiBuildingLine, RiLoaderLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { useState } from "react"
 import { toast } from "sonner"
 import { z } from "zod"
 
+import { SidebarDropdownMenu } from "@/components/sidebar/dropdown-menu"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -14,20 +15,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar"
 import { authClient } from "@/lib/auth/client"
-import { cn, slugify } from "@/lib/utils"
+import { slugify } from "@/lib/utils"
 
 type Organization = {
   id: string
@@ -48,7 +40,6 @@ const formSchema = z.object({
 })
 
 export function SidebarDashboardOrgSwitcher() {
-  const { isMobile } = useSidebar()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [isOrgTransitioning, setIsOrgTransitioning] = useState(false)
 
@@ -117,70 +108,47 @@ export function SidebarDashboardOrgSwitcher() {
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <SidebarMenuButton
-              size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer border"
-            />
-          }
-        >
-          <div className="bg-sidebar-accent text-sidebar-accent-foreground flex aspect-square size-8 items-center justify-center rounded-md">
-            <RiBuildingLine className="size-4" />
-          </div>
-          <div className="grid flex-1 text-left text-sm leading-tight">
-            <span className="truncate font-medium">
-              {isOrgLoading ? "" : (activeOrg?.name ?? "Select Organization")}
-            </span>
-            <span className="text-muted-foreground truncate text-xs">
-              {isOrgLoading ? "" : (activeOrg?.slug ?? "No organization selected")}
-            </span>
-          </div>
-          <RiExpandUpDownLine className="ml-auto size-4" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={cn("w-(--anchor-width) min-w-56 rounded-lg", isMobile ? "mb-1" : "ml-3")}
-          side={isMobile ? "bottom" : "right"}
-          align="start"
-          sideOffset={4}
-        >
-          <DropdownMenuGroup>
-            <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                <div className="bg-sidebar-accent text-sidebar-accent-foreground flex size-8 items-center justify-center rounded-md">
-                  <RiBuildingLine className="size-4" />
-                </div>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium">
-                    {activeOrg?.name ?? "No organization"}
-                  </span>
-                  <span className="text-muted-foreground truncate text-xs">
-                    {activeOrg?.slug ?? "Create one to get started"}
-                  </span>
-                </div>
-              </div>
-            </DropdownMenuLabel>
-          </DropdownMenuGroup>
-          <DropdownMenuSeparator />
-          {organizations
-            .filter((org) => org.id !== activeOrg?.id)
-            .map((org) => (
-              <DropdownMenuItem
-                key={org.id}
-                className="cursor-pointer"
-                onClick={() => handleSetActive(org.id)}
-              >
-                <RiBuildingLine />
-                {org.name}
-              </DropdownMenuItem>
-            ))}
-          <DropdownMenuItem className="cursor-pointer" onClick={() => setCreateDialogOpen(true)}>
-            <RiAddLine />
-            Create organization
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <SidebarDropdownMenu
+        align="start"
+        mobileSide="bottom"
+        trigger={{
+          leading: (
+            <div className="bg-sidebar-accent text-sidebar-accent-foreground flex aspect-square size-8 items-center justify-center rounded-md">
+              <RiBuildingLine className="size-4" />
+            </div>
+          ),
+          primary: isOrgLoading ? "" : (activeOrg?.name ?? "Select Organization"),
+          secondary: isOrgLoading ? "" : (activeOrg?.slug ?? "No organization selected"),
+          secondaryClassName: "text-muted-foreground",
+        }}
+        header={{
+          leading: (
+            <div className="bg-sidebar-accent text-sidebar-accent-foreground flex size-8 items-center justify-center rounded-md">
+              <RiBuildingLine className="size-4" />
+            </div>
+          ),
+          primary: activeOrg?.name ?? "No organization",
+          secondary: activeOrg?.slug ?? "Create one to get started",
+          secondaryClassName: "text-muted-foreground",
+        }}
+      >
+        {organizations
+          .filter((org) => org.id !== activeOrg?.id)
+          .map((org) => (
+            <DropdownMenuItem
+              key={org.id}
+              className="cursor-pointer"
+              onClick={() => handleSetActive(org.id)}
+            >
+              <RiBuildingLine />
+              {org.name}
+            </DropdownMenuItem>
+          ))}
+        <DropdownMenuItem className="cursor-pointer" onClick={() => setCreateDialogOpen(true)}>
+          <RiAddLine />
+          Create organization
+        </DropdownMenuItem>
+      </SidebarDropdownMenu>
 
       <Dialog
         open={createDialogOpen}

--- a/web/next/src/components/sidebar/dropdown-menu.tsx
+++ b/web/next/src/components/sidebar/dropdown-menu.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { RiExpandUpDownLine } from "@remixicon/react"
+import { type ReactNode } from "react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar"
+import { cn } from "@/lib/utils"
+
+type Identity = {
+  leading: ReactNode
+  primary: ReactNode
+  secondary: ReactNode
+  secondaryClassName?: string
+}
+
+function SidebarIdentity({ primary, secondary, secondaryClassName }: Omit<Identity, "leading">) {
+  return (
+    <div className="grid flex-1 text-left text-sm leading-tight">
+      <span className="truncate font-medium">{primary}</span>
+      <span className={cn("truncate text-xs", secondaryClassName)}>{secondary}</span>
+    </div>
+  )
+}
+
+// Shared sidebar footer dropdown used by the user menu and org switcher: a SidebarMenuButton trigger (leading visual + identity + expand chevron) over a content panel that repeats the identity as a header, then the consumer's items, keeping the trigger/content/identity markup in one place.
+export function SidebarDropdownMenu({
+  trigger,
+  header,
+  align,
+  mobileSide,
+  children,
+}: {
+  trigger: Identity
+  header: Identity
+  align: "start" | "end"
+  mobileSide: "top" | "bottom"
+  children: ReactNode
+}) {
+  const { isMobile } = useSidebar()
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <SidebarMenuButton
+            size="lg"
+            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer border"
+          />
+        }
+      >
+        {trigger.leading}
+        <SidebarIdentity
+          primary={trigger.primary}
+          secondary={trigger.secondary}
+          secondaryClassName={trigger.secondaryClassName}
+        />
+        <RiExpandUpDownLine className="ml-auto size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className={cn("w-(--anchor-width) min-w-56 rounded-lg", isMobile ? "mb-1" : "ml-3")}
+        side={isMobile ? mobileSide : "right"}
+        align={align}
+        sideOffset={4}
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="p-0 font-normal">
+            <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+              {header.leading}
+              <SidebarIdentity
+                primary={header.primary}
+                secondary={header.secondary}
+                secondaryClassName={header.secondaryClassName}
+              />
+            </div>
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -1,24 +1,16 @@
 "use client"
 
 import { env } from "@packages/env/web-next"
-import { RiExpandUpDownLine, RiLogoutBoxLine, RiMessage2Line } from "@remixicon/react"
+import { RiLogoutBoxLine, RiMessage2Line } from "@remixicon/react"
 import { type User } from "better-auth/types"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
+import { SidebarDropdownMenu } from "@/components/sidebar/dropdown-menu"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import { SidebarMenuButton, SidebarMenuItem, useSidebar } from "@/components/ui/sidebar"
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
+import { SidebarMenuItem } from "@/components/ui/sidebar"
 import { authClient } from "@/lib/auth/client"
-import { cn } from "@/lib/utils"
 
 function getInitials(name: string) {
   const words = name.trim().split(/\s+/)
@@ -28,78 +20,45 @@ function getInitials(name: string) {
 
 // Shared sidebar user dropdown (avatar, identity, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
 export function SidebarUserMenu({ user }: { user: User }) {
-  const { isMobile } = useSidebar()
   const router = useRouter()
+
+  const avatar = (
+    <Avatar className="size-8 rounded-md after:hidden">
+      <AvatarImage src={user.image ?? ""} alt={user.name} />
+      <AvatarFallback className="rounded-md">{getInitials(user.name)}</AvatarFallback>
+    </Avatar>
+  )
+  const identity = { leading: avatar, primary: user.name, secondary: user.email }
 
   return (
     <SidebarMenuItem>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <SidebarMenuButton
-              size="lg"
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer border"
-            />
-          }
-        >
-          <Avatar className="size-8 rounded-md">
-            <AvatarImage src={user.image ?? ""} alt={user.name} />
-            <AvatarFallback className="rounded-md">{getInitials(user.name)}</AvatarFallback>
-          </Avatar>
-          <div className="grid flex-1 text-left text-sm leading-tight">
-            <span className="truncate font-medium">{user.name}</span>
-            <span className="truncate text-xs">{user.email}</span>
-          </div>
-          <RiExpandUpDownLine className="ml-auto size-4" />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          className={cn("w-(--anchor-width) min-w-56 rounded-lg", isMobile ? "mb-1" : "ml-3")}
-          side={isMobile ? "top" : "right"}
-          align="end"
-          sideOffset={4}
-        >
-          <DropdownMenuGroup>
-            <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                <Avatar className="size-8 rounded-md">
-                  <AvatarImage src={user.image ?? ""} alt={user.name} />
-                  <AvatarFallback className="rounded-md">{getInitials(user.name)}</AvatarFallback>
-                </Avatar>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-medium">{user.name}</span>
-                  <span className="truncate text-xs">{user.email}</span>
-                </div>
-              </div>
-            </DropdownMenuLabel>
-          </DropdownMenuGroup>
-          <DropdownMenuSeparator />
-          {env.NEXT_PUBLIC_USERJOT_URL && (
-            <DropdownMenuItem
-              render={
-                <Link
-                  href={env.NEXT_PUBLIC_USERJOT_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="cursor-pointer"
-                />
-              }
-            >
-              <RiMessage2Line />
-              Feedback
-            </DropdownMenuItem>
-          )}
+      <SidebarDropdownMenu trigger={identity} header={identity} align="end" mobileSide="top">
+        {env.NEXT_PUBLIC_USERJOT_URL && (
           <DropdownMenuItem
-            className="cursor-pointer"
-            onClick={async () => {
-              await authClient.signOut()
-              router.push("/")
-            }}
+            render={
+              <Link
+                href={env.NEXT_PUBLIC_USERJOT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="cursor-pointer"
+              />
+            }
           >
-            <RiLogoutBoxLine />
-            Log out
+            <RiMessage2Line />
+            Feedback
           </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        )}
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={async () => {
+            await authClient.signOut()
+            router.push("/")
+          }}
+        >
+          <RiLogoutBoxLine />
+          Log out
+        </DropdownMenuItem>
+      </SidebarDropdownMenu>
     </SidebarMenuItem>
   )
 }


### PR DESCRIPTION
Closes audit item **#8** (`.github/audit/2026-06-19-dedup-structure-architecture.md` §1.6), the last open item from the 2026-06-19 audit.

## What

The sidebar footer dropdown was duplicated across `user-menu.tsx` and `org-switcher.tsx`: identical `SidebarMenuButton` trigger className, identical `DropdownMenuContent` className, and the identity block (`grid flex-1 …` + truncated primary/secondary) appearing **4×**.

New `web/next/src/components/sidebar/dropdown-menu.tsx` exposes **`SidebarDropdownMenu`**, which owns the trigger (leading slot + identity + expand chevron), the content panel that repeats the identity as a header, the content wrapper (className + `side`/`align`/`sideOffset`), and `useSidebar()` for the mobile/desktop side. Consumers pass only:
- `trigger` / `header` — `{ leading, primary, secondary, secondaryClassName? }`
- `align` + `mobileSide` (desktop side is always `right`)
- children — the menu items

`user-menu` and `org-switcher` shrink to their leading visual (avatar vs icon box), text, and items.

## Behaviour-preserving

Same DOM, classNames, and props. Preserved deltas that live in the consumer slots: the org trigger icon keeps `aspect-square` while its header icon doesn't; the org secondary text keeps `text-muted-foreground` (user's doesn't); the org trigger/header show different fallback strings; `align`/`mobileSide` differ per consumer. Public exports (`SidebarUserMenu`, `SidebarDashboardOrgSwitcher`) are unchanged, so no call sites change.

## Drive-by: drop the mismatched sidebar avatar ring

The `Avatar` component ships a circular `::after` ring (`after:rounded-full after:border`) for round avatars, but the sidebar squares it to `rounded-md` inside a bordered button. The ring stayed circular over the square avatar (a visible circle on both the footer trigger and the dropdown header), and doubled the button border when the sidebar was collapsed. Fixed with `after:hidden` on the sidebar avatar. The same avatar node is reused for the trigger and the dropdown header, so both are cleaned. Result: a clean square avatar in the expanded footer, the dropdown header, and the collapsed icon.

## Verification

- `bun run check-types` 9/9, `oxlint` clean (no orphaned imports), `oxfmt --check` clean.
- `web/next` production build passes.
- **Browser-verified** (agent-browser, logged in as `AgentZero`): user-menu dropdown in `/console` (trigger + identity header + Feedback/Log out), org-switcher dropdown in the dashboard (trigger + header + Create organization), and the collapsed sidebar avatar. All render correctly; the avatar ring fix is confirmed in the footer, the dropdown header, and the collapsed icon.

## Notes

CodeRabbit's "Docstring Coverage 40% < 80%" pre-merge check is a non-blocking warning; this repo deliberately keeps comments minimal (CLAUDE.md) and ships no docstrings on presentational components, so it is left as-is.