### PR TITLE
fix(web): round the sidebar avatar image to match the squared container

### DIFF
--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -24,7 +24,7 @@ export function SidebarUserMenu({ user }: { user: User }) {
 
   const avatar = (
     <Avatar className="size-8 rounded-md after:hidden">
-      <AvatarImage src={user.image ?? ""} alt={user.name} />
+      <AvatarImage src={user.image ?? ""} alt={user.name} className="rounded-md" />
       <AvatarFallback className="rounded-md">{getInitials(user.name)}</AvatarFallback>
     </Avatar>
   )


### PR DESCRIPTION
Follow-up to #484. A user's profile photo rendered as a **circle** in the sidebar (worst in the collapsed icon: a circular photo inside the rounded-md button).

## Cause

The `Avatar` component hardcodes `rounded-full` on three parts: the root, the fallback, **and `AvatarImage`**. #484 squared the root (`rounded-md`) and the fallback (`rounded-md`) but not the image. With no photo you saw the squared fallback; with a photo, `AvatarImage`'s own `rounded-full` made it a circle.

## Fix

One line: `className="rounded-md"` on `AvatarImage` (twMerge drops the component's `rounded-full`). `user-menu.tsx` is the only `Avatar` usage in the app, so this is the complete fix.

## Verification

Browser-verified (agent-browser) by temporarily forcing a test image on the AgentZero avatar: it renders as a rounded-md square in the footer trigger, the dropdown header, and the collapsed icon. Reverted the test src; only the `rounded-md` className is committed. `check-types` 9/9, `oxlint` + `oxfmt --check` clean, build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the avatar image styling in the user menu to display with rounded corners for a refined visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->