### PR TITLE
docs(audit): dead code audit 2026-06-21

### DIFF
--- a/.github/audit/2026-06-21-dead-code.md
+++ b/.github/audit/2026-06-21-dead-code.md
@@ -54,6 +54,19 @@ Recommendation: **keep** by default. If a leaner palette is wanted, prune via th
 - `du` ("unlisted binary") — a coreutils command in `build-sizes.ts`, not an npm dep.
 - All `@takumi-rs/core-*` optional deps — platform-native binaries loaded dynamically by `takumi-js`.
 
+## Cross-check: fallow
+
+Ran `fallow@2.100.0` (deterministic codebase intelligence) as a second opinion. Its dead-code verdict matches this report: it agrees on `date-fns` and the `Config` type, and the shadcn `ui/*` files/exports, Next route-segment exports (`sitemap.ts` `dynamic`/`revalidate`, route `generateStaticParams`), and `@takumi-rs/core-*` optional deps are the same framework/palette false positives.
+
+Two fallow-only flags are false positives, recorded so they are not re-chased:
+
+- `babel-plugin-react-compiler` ("unused devDependency") — used by Next's build via `reactCompiler: true` in `next.config.ts`, not imported in source.
+- `collections` ("unlisted dependency") — a tsconfig path alias (`"collections/*": ["./.source/*"]`) to the fumadocs-mdx generated module, not an npm package.
+
+fallow also flags `postgres` and `@hono/standard-validator`; both are kept for the runtime/documented reasons above (static analysis cannot see drizzle-kit's runtime need or the docs).
+
+Beyond dead code, fallow reports good overall health (maintainability 87.2) and ~1.0% duplication worth a future refactor, mostly in `web/next/src/app/page.tsx` (the two CTA blocks at 250-272 and 763-785) and the mobile/desktop nav in `components/navbar/home.tsx`. Tracked as a quality follow-up, not dead code.
+
 ## Outcome and remaining items
 
 - The confirmed-dead items were removed in a follow-up cleanup PR (`date-fns` direct declaration, `isPublicBlogPage` export, `Config` type). `postgres` and `@hono/standard-validator` are kept per the verification above.

--- a/.github/audit/2026-06-21-dead-code.md
+++ b/.github/audit/2026-06-21-dead-code.md
@@ -1,0 +1,64 @@
+# Dead Code Audit — 2026-06-21
+
+Scope: the whole monorepo (`api/hono`, `web/next`, `packages/*`, `.github/scripts`). Goal is to inventory dead code: unused dependencies, unused files, and unused/over-exported code. Findings only; actions are deferred ("see what can be done next").
+
+## Method
+
+- Per-workspace unused-dependency scan: for each declared dependency, search code files for an import specifier (`"pkg"`, `"pkg/..."`).
+- `knip@6.17.1` for unused files, exports, and exported types.
+- Manual verification of every candidate across all file types before listing it as dead.
+
+Two method gotchas worth recording, because they caused false readings on the first pass:
+
+- **ripgrep skips hidden dirs by default.** A repo-wide `rg` without `--hidden` does not search `.github/scripts/`, so root devDeps used only there (`@octokit/rest`, `@viz-js/viz`, `globby`, `svgo`, `ts-morph`, `sharp`) looked dead but are not. Always pass an explicit path or `--hidden` when checking `.github/scripts`.
+- **knip cannot load `packages/db/drizzle.config.ts`** because it imports validated env (`POSTGRES_URL`/`NODE_ENV` are unset in a bare run), so knip's `packages/db` and parts of `api/hono` coverage are incomplete. Those were verified by hand instead. A future knip run with a dummy env (see `.claude/skills/docker-test`) would close the gap.
+
+## Confirmed dead dependencies
+
+| Dependency                 | Workspace     | Evidence                                                                                                                                                                                                 | Risk to remove                                                                                                                               |
+| -------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `date-fns`                 | `web/next`    | No import anywhere in source.                                                                                                                                                                            | None.                                                                                                                                        |
+| `@hono/standard-validator` | `api/hono`    | Zero imports in `api/hono/src`; request validation is done with `hono-openapi` (`describeRoute` + `resolver`) and Zod. Only referenced in prose (the llms preamble and a docs page).                     | None for code. Update the two doc references at the same time (see below).                                                                   |
+| `postgres` (postgres.js)   | `packages/db` | `packages/db/src/index.ts` uses Bun's native driver (`import { SQL } from "bun"` + `drizzle-orm/bun-sql`). No `from "postgres"` anywhere. `drizzle.config.ts` only sets `dialect: "postgresql"` + a url. | Low. Verify `bun run db:generate` / `db:migrate` still work after removal, since drizzle-kit could in theory pick up postgres.js if present. |
+
+Already removed in v0.0.35: `react-hook-form` + `@hookform/resolvers` (the find that kicked this off).
+
+## Dead / over-exported code
+
+| Item               | Location                        | Finding                                                                                                                                              | Suggested action                                     |
+| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `isPublicBlogPage` | `web/next/src/lib/blog.ts:25`   | Exported but only used inside `blog.ts` (by `getPublicBlogPage`, `generatePublicBlogParams`, `getPublicBlogPageTree`). Not dead, just over-exported. | Drop the `export` keyword.                           |
+| `Config` (type)    | `web/next/src/lib/config.ts:26` | `export type Config = typeof config` is never imported.                                                                                              | Remove, or keep deliberately as public type surface. |
+
+## Documentation inaccuracies surfaced by the audit
+
+- `packages/config/src/site.ts` (`llmsFullPreamble`) and `web/next/content/docs/getting-started/type-safe-api.mdx` both mention `@hono/standard-validator` as part of the stack. It is not used. Correct these when the dependency is removed.
+- Good news: the same preamble's "PostgreSQL via Bun's SQL driver" is **accurate** (the code uses `drizzle-orm/bun-sql`). No change needed.
+
+## shadcn/ui palette — a decision, not a bug
+
+knip reported 38 unused files under `web/next/src/components/ui/*` and 7 "unused" deps that back them (`cmdk`, `embla-carousel-react`, `input-otp`, `react-day-picker`, `react-resizable-panels`, `recharts`, `vaul`), plus many unused component sub-exports (e.g. `DialogClose`, `Sidebar*`, `Field*`, `buttonVariants`).
+
+These are the installed shadcn component palette, not accidental dead code:
+
+- They are regenerated by the shadcn flow (`shadcn:update` + `.github/scripts/shadcn-customize.ts`), so deleting them by hand is undone on the next sync.
+- They are the intended "available component" surface for anyone building on the starter.
+
+Recommendation: **keep** by default. If a leaner palette is wanted, prune via the shadcn generator/config (not hand-deletion), and drop the backing deps in the same change. This is a product decision about how much palette to ship, not a correctness issue.
+
+## Not dead (false positives, recorded so we don't chase them)
+
+- `.github/scripts/migrate-on-deploy.ts` — invoked by `api/hono/vercel.json` build command.
+- `.github/scripts/shadcn-customize.ts` — invoked by `.github/scripts/shadcn-update.sh`.
+- `ts-morph`, `sharp` (devDeps) — used by those scripts; `sharp` also by Next image optimization at runtime.
+- `@octokit/rest`, `@viz-js/viz`, `globby`, `svgo` — used in `.github/scripts` (hidden-dir scan gotcha above).
+- `concurrently` — used in `api/hono` `dev` script.
+- `web/next/source.config.ts` exports (`docs`, `blog`, `consoleDocs`, `default`) — consumed by `fumadocs-mdx` codegen.
+- `du` ("unlisted binary") — a coreutils command in `build-sizes.ts`, not an npm dep.
+- All `@takumi-rs/core-*` optional deps — platform-native binaries loaded dynamically by `takumi-js`.
+
+## Suggested next steps (for the follow-up decision)
+
+1. **Low-risk cleanup PR**: remove `date-fns`, `@hono/standard-validator`, `postgres` (with a `db:generate`/`db:migrate` check); un-export `isPublicBlogPage`; remove the `Config` type; fix the two `@hono/standard-validator` doc mentions.
+2. **Palette decision** (separate): keep the full shadcn palette, or curate it via the generator and drop the freed deps.
+3. **Coverage gap**: re-run knip with a dummy env so `packages/db` and `api/hono` exports get full analysis.

--- a/.github/audit/2026-06-21-dead-code.md
+++ b/.github/audit/2026-06-21-dead-code.md
@@ -1,39 +1,36 @@
 # Dead Code Audit — 2026-06-21
 
-Scope: the whole monorepo (`api/hono`, `web/next`, `packages/*`, `.github/scripts`). Goal is to inventory dead code: unused dependencies, unused files, and unused/over-exported code. Findings only; actions are deferred ("see what can be done next").
+Scope: the whole monorepo (`api/hono`, `web/next`, `packages/*`, `.github/scripts`). Goal is to inventory dead code: unused dependencies, unused files, and unused/over-exported code, then verify each candidate before acting.
 
 ## Method
 
 - Per-workspace unused-dependency scan: for each declared dependency, search code files for an import specifier (`"pkg"`, `"pkg/..."`).
 - `knip@6.17.1` for unused files, exports, and exported types.
-- Manual verification of every candidate across all file types before listing it as dead.
+- Manual verification of every candidate across all file types, plus `bun pm why`, before listing it as dead.
 
 Two method gotchas worth recording, because they caused false readings on the first pass:
 
 - **ripgrep skips hidden dirs by default.** A repo-wide `rg` without `--hidden` does not search `.github/scripts/`, so root devDeps used only there (`@octokit/rest`, `@viz-js/viz`, `globby`, `svgo`, `ts-morph`, `sharp`) looked dead but are not. Always pass an explicit path or `--hidden` when checking `.github/scripts`.
 - **knip cannot load `packages/db/drizzle.config.ts`** because it imports validated env (`POSTGRES_URL`/`NODE_ENV` are unset in a bare run), so knip's `packages/db` and parts of `api/hono` coverage are incomplete. Those were verified by hand instead. A future knip run with a dummy env (see `.claude/skills/docker-test`) would close the gap.
 
-## Confirmed dead dependencies
+## Confirmed dead, removed
 
-| Dependency                 | Workspace     | Evidence                                                                                                                                                                                                 | Risk to remove                                                                                                                               |
-| -------------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `date-fns`                 | `web/next`    | No import anywhere in source.                                                                                                                                                                            | None.                                                                                                                                        |
-| `@hono/standard-validator` | `api/hono`    | Zero imports in `api/hono/src`; request validation is done with `hono-openapi` (`describeRoute` + `resolver`) and Zod. Only referenced in prose (the llms preamble and a docs page).                     | None for code. Update the two doc references at the same time (see below).                                                                   |
-| `postgres` (postgres.js)   | `packages/db` | `packages/db/src/index.ts` uses Bun's native driver (`import { SQL } from "bun"` + `drizzle-orm/bun-sql`). No `from "postgres"` anywhere. `drizzle.config.ts` only sets `dialect: "postgresql"` + a url. | Low. Verify `bun run db:generate` / `db:migrate` still work after removal, since drizzle-kit could in theory pick up postgres.js if present. |
+| Item                    | Location                     | Finding                                                                                                                                                      | Action                      |
+| ----------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
+| `date-fns` (direct dep) | `web/next` + catalog         | Imported nowhere in web. Pulled in transitively by `react-day-picker` (a hard dep), so it stays installed; only the redundant direct declaration is dropped. | Removed direct declaration. |
+| `isPublicBlogPage`      | `web/next/src/lib/blog.ts`   | Exported but used only inside `blog.ts`. Not dead, just over-exported.                                                                                       | Un-exported.                |
+| `Config` (type)         | `web/next/src/lib/config.ts` | `export type Config = typeof config` is never imported.                                                                                                      | Removed.                    |
 
-Already removed in v0.0.35: `react-hook-form` + `@hookform/resolvers` (the find that kicked this off).
+Already removed earlier (v0.0.35): `react-hook-form` + `@hookform/resolvers`, the find that started this.
 
-## Dead / over-exported code
+## Investigated — NOT dead (kept)
 
-| Item               | Location                        | Finding                                                                                                                                              | Suggested action                                     |
-| ------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `isPublicBlogPage` | `web/next/src/lib/blog.ts:25`   | Exported but only used inside `blog.ts` (by `getPublicBlogPage`, `generatePublicBlogParams`, `getPublicBlogPageTree`). Not dead, just over-exported. | Drop the `export` keyword.                           |
-| `Config` (type)    | `web/next/src/lib/config.ts:26` | `export type Config = typeof config` is never imported.                                                                                              | Remove, or keep deliberately as public type surface. |
+The first-pass scan flagged these, but verification showed they are needed or intentional:
 
-## Documentation inaccuracies surfaced by the audit
+- **`postgres` (postgres.js)** — the runtime uses Bun's SQL driver (`drizzle-orm/bun-sql`), but `drizzle-kit migrate` (run on every prod/canary deploy via `.github/scripts/migrate-on-deploy.ts`) needs a postgres driver. `bun pm why` shows `postgres` is only an _optional peer_ of `drizzle-orm` with no other hard requirer, so dropping the direct declaration risks it not being installed on a clean deploy, breaking migrations. **Keep.**
+- **`@hono/standard-validator`** — not used in the sample routes (they are GETs; `api/hono` uses `hono-openapi` for OpenAPI schemas), but it is the _documented_ request-validation tool: `web/next/content/docs/getting-started/type-safe-api.mdx` has a "Request Validation" section teaching `standardValidator("json", schema)`. Intentionally provided + documented starter surface. **Keep.**
 
-- `packages/config/src/site.ts` (`llmsFullPreamble`) and `web/next/content/docs/getting-started/type-safe-api.mdx` both mention `@hono/standard-validator` as part of the stack. It is not used. Correct these when the dependency is removed.
-- Good news: the same preamble's "PostgreSQL via Bun's SQL driver" is **accurate** (the code uses `drizzle-orm/bun-sql`). No change needed.
+Note: the llms preamble's "PostgreSQL via Bun's SQL driver" and its mention of `@hono/standard-validator` are both accurate (the driver is `drizzle-orm/bun-sql`; standard-validator is the documented validation tool). No doc fixes needed.
 
 ## shadcn/ui palette — a decision, not a bug
 
@@ -57,8 +54,8 @@ Recommendation: **keep** by default. If a leaner palette is wanted, prune via th
 - `du` ("unlisted binary") — a coreutils command in `build-sizes.ts`, not an npm dep.
 - All `@takumi-rs/core-*` optional deps — platform-native binaries loaded dynamically by `takumi-js`.
 
-## Suggested next steps (for the follow-up decision)
+## Outcome and remaining items
 
-1. **Low-risk cleanup PR**: remove `date-fns`, `@hono/standard-validator`, `postgres` (with a `db:generate`/`db:migrate` check); un-export `isPublicBlogPage`; remove the `Config` type; fix the two `@hono/standard-validator` doc mentions.
-2. **Palette decision** (separate): keep the full shadcn palette, or curate it via the generator and drop the freed deps.
-3. **Coverage gap**: re-run knip with a dummy env so `packages/db` and `api/hono` exports get full analysis.
+- The confirmed-dead items were removed in a follow-up cleanup PR (`date-fns` direct declaration, `isPublicBlogPage` export, `Config` type). `postgres` and `@hono/standard-validator` are kept per the verification above.
+- **Palette decision** (open): keep the full shadcn palette, or curate it via the generator and drop the freed deps.
+- **Coverage gap** (open): re-run knip with a dummy env so `packages/db` and `api/hono` exports get full analysis.


### PR DESCRIPTION
Dead code audit across the whole monorepo. **Findings only, no removals** (per "later on we will see what can be done next"). Full report: `.github/audit/2026-06-21-dead-code.md`.

## Confirmed dead dependencies

- `date-fns` (`web/next`) — imported nowhere.
- `@hono/standard-validator` (`api/hono`) — validation actually uses `hono-openapi` + Zod; the dep is referenced only in docs/preamble prose.
- `postgres` / postgres.js (`packages/db`) — the db client uses Bun's native driver (`bun` `SQL` + `drizzle-orm/bun-sql`); needs a `db:generate`/`db:migrate` sanity check at removal time.

(`react-hook-form` + `@hookform/resolvers` were already removed in v0.0.35.)

## Dead / over-exported code

- `isPublicBlogPage` (`lib/blog.ts`) — used internally only; drop the `export`.
- `Config` type (`lib/config.ts`) — exported, never imported.

## Doc fixes to bundle with removal

- The llms preamble (`site.ts`) and `type-safe-api.mdx` name `@hono/standard-validator` as part of the stack. It is not used. (The "Bun's SQL driver" claim, by contrast, is correct.)

## shadcn/ui palette — a decision, not a bug

The 38 "unused" `components/ui/*` files and their 7 backing deps (`cmdk`, `embla-carousel-react`, `input-otp`, `react-day-picker`, `react-resizable-panels`, `recharts`, `vaul`) are the installed shadcn palette, regenerated by `shadcn:update`. Recommend keeping by default; curate via the generator if a leaner palette is wanted.

## Method notes

ripgrep skips hidden dirs, so `.github/scripts` deps looked dead on the first pass but are used. knip couldn't load `drizzle.config.ts` (needs env), so `packages/db`/`api/hono` were hand-verified; a knip re-run with a dummy env would close that gap.

## Suggested next steps

1. Low-risk cleanup PR: the three dead deps + the two code items + the doc fixes.
2. Separate palette decision.
3. knip re-run with dummy env for full `packages/db`/`api/hono` coverage.
