### PR TITLE
docs: order the intro to match the nav and drop the private console link

### DIFF
--- a/web/next/content/docs/index.mdx
+++ b/web/next/content/docs/index.mdx
@@ -24,14 +24,13 @@ description: A modern, type-safe, and high-performance SaaS starter template bui
 - [Database](/docs/manage/database) - PostgreSQL schema, Drizzle ORM, and migrations
 - [API Conventions](/docs/manage/api-conventions) - Response format, error handling, and middleware
 - [Analytics](/docs/manage/analytics) - Configure PostHog analytics and tracking
-- [Blog](/docs/manage/blog) - Manage blog content and articles
 - [Code Quality](/docs/manage/code-quality) - Git hooks, linting, and formatting
+- [Blog](/docs/manage/blog) - Manage blog content and articles
 - [Documentation](/docs/manage/documentation) - Manage documentation content and search
-- [Environment](/docs/manage/environment) - Manage environment variables
 - [Feedback](/docs/manage/feedback) - Configure user feedback collection
+- [Environment](/docs/manage/environment) - Manage environment variables
 - [Release](/docs/manage/release) - Manage releases and changelog
 - [Theming](/docs/manage/theming) - Dark mode, CSS variables, and styling
-- [Console](/console/docs) - Access-gated privileged admin area and its docs
 - [OG Images](/docs/manage/og-images) - Dynamic Open Graph image generation
 - [llms.txt](/docs/manage/llms-txt) - Auto-generated documentation for LLMs
 - [robots.txt](/docs/manage/robots) - Search engine crawler instructions


### PR DESCRIPTION
Two fixes to the docs introduction (`web/next/content/docs/index.mdx`):

- **Order**: the Manage list now follows the actual sidebar order from `docs.config.ts` (Authentication, Backend & Data, Analytics, Code Quality, Content Management, Environment & Release, UI & Styling, Indexing/LLM). Previously Blog/Code Quality and Feedback were out of position.
- **Removed the Console link**: the public intro linked to `/console/docs`, which is the admin-gated console area and returns 404 for non-admins, so public readers could not reach it.

The remaining `/console` references in `project-structure.mdx` and `documentation.mdx` are descriptive prose explaining the private console area (not clickable links), so they stay.

Verified with `bun run build` (docs `--strict` + `fumadocs-mdx` + `next build`). Opening for review; say the word to merge + release.