### PR TITLE
chore(version): reset all non-root workspace versions to 0.0.0

### DIFF
--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api/hono",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "dist"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packages/auth",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "dist"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packages/config",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "dist",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packages/db",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "dist"

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@packages/env",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "files": [
     "dist"

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web/next",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "build": "bun ../../.github/scripts/compress-images.ts && bun ../../.github/scripts/docs.ts --strict && fumadocs-mdx && next build",


### PR DESCRIPTION
Sets every non-root workspace `package.json` version to `0.0.0`. The root `package.json` is the only versioned package (auto-release bumps it); the internal workspaces are private and never published, so their version field is metadata only and was inconsistently sitting at `0.0.1`.

## Changes
- `api/hono` `0.0.1` → `0.0.0`
- `packages/auth` `0.0.1` → `0.0.0`
- `packages/config` `0.0.1` → `0.0.0`
- `packages/db` `0.0.1` → `0.0.0`
- `packages/env` `0.0.1` → `0.0.0`
- `web/next` `0.0.1` → `0.0.0`

Root (`zerostarter`) version is unchanged.