### PR TITLE
fix: stop hardcoding nrjdalal/zerostarter so forks aren't mispinned

### DIFF
--- a/.github/rulesets/canary.json
+++ b/.github/rulesets/canary.json
@@ -2,7 +2,6 @@
   "name": "canary",
   "target": "branch",
   "source_type": "Repository",
-  "source": "nrjdalal/zerostarter",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -2,7 +2,6 @@
   "name": "main",
   "target": "branch",
   "source_type": "Repository",
-  "source": "nrjdalal/zerostarter",
   "enforcement": "active",
   "conditions": {
     "ref_name": {

--- a/.github/scripts/changelog-manager.ts
+++ b/.github/scripts/changelog-manager.ts
@@ -98,8 +98,7 @@ function updateCompareLinks(lines: string[], repoOwner: string, repoName: string
 }
 
 async function processChangelog() {
-  const repoOwner = process.env.GITHUB_REPOSITORY_OWNER || "nrjdalal"
-  const repoName = process.env.GITHUB_REPOSITORY_NAME || "zerostarter"
+  const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY!.split("/")
 
   const content = await Bun.file(CHANGELOG_PATH).text()
   const lines = content.split("\n")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-name: zerostarter
-
 services:
   api:
     build:

--- a/web/next/content/docs/deployment/docker.mdx
+++ b/web/next/content/docs/deployment/docker.mdx
@@ -27,8 +27,6 @@ This starts both the frontend (Next.js) and backend (Hono) services:
 The `docker-compose.yml` file defines two services:
 
 ```yaml
-name: zerostarter
-
 services:
   api:
     build:


### PR DESCRIPTION
Removes hardcoded `nrjdalal/zerostarter` identity in a few places so a fork isn't pinned to the upstream repo.

## Changes
- **`.github/scripts/changelog-manager.ts`** — it read `GITHUB_REPOSITORY_NAME`, which is **not** a real GitHub Actions variable, so `repoName` always fell back to the hardcoded `"zerostarter"`. A fork's changelog compare links and contributor lookups would point at `nrjdalal/zerostarter`. Now derives both owner and name from `GITHUB_REPOSITORY` (always set in CI), no fallback.
- **`.github/rulesets/{main,canary}.json`** — drop `"source": "nrjdalal/zerostarter"`. `source`/`source_type` are export-only fields; the ruleset create/import API ignores them, so this is inert and makes the files fork-portable.
- **`docker-compose.yml`** — drop `name: zerostarter`. Compose derives the project name from the directory; nothing references the literal name (no `container_name`, `COMPOSE_PROJECT_NAME`, or `zerostarter_*` volumes/networks).
- **`web/next/content/docs/deployment/docker.mdx`** — sync the compose example to match (docs-sync rule).

## Note
This trims surface that the `feat/cli` init (#505) currently plans to repoint (compose name, ruleset `source`). After this lands, the CLI's convert step has less to rewrite — reconcile `convert.ts` on that branch accordingly.