### PR TITLE
feat(cli): install on init, timezone-safe blog dates, trim scaffold + drop dead deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "oxlint": "catalog:",
         "sharp": "catalog:",
         "svgo": "catalog:",
-        "ts-morph": "catalog:",
         "turbo": "catalog:",
       },
     },
@@ -263,7 +262,6 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1",
     "takumi-js": "^1.8.7",
-    "ts-morph": "^28.0.0",
     "tsdown": "^0.22.3",
     "turbo": "^2.9.18",
     "tw-animate-css": "^1.4.0",
@@ -926,7 +924,7 @@
 
     "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
-    "@ts-morph/common": ["@ts-morph/common@0.29.0", "", { "dependencies": { "minimatch": "^10.0.1", "path-browserify": "^1.0.1", "tinyglobby": "^0.2.14" } }, "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg=="],
+    "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw=="],
 
@@ -2110,7 +2108,7 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
-    "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
+    "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
@@ -2334,8 +2332,6 @@
 
     "shadcn/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
-    "shadcn/ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
-
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
@@ -2425,8 +2421,6 @@
     "rolldown-plugin-dts/@babel/parser/@babel/types": ["@babel/types@8.0.0", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0", "@babel/helper-validator-identifier": "^8.0.0" } }, "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw=="],
 
     "shadcn/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
-
-    "shadcn/ts-morph/@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0", "", {}, "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "oxlint": "catalog:",
     "sharp": "catalog:",
     "svgo": "catalog:",
-    "ts-morph": "catalog:",
     "turbo": "catalog:"
   },
   "overrides": {
@@ -136,7 +135,6 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.1",
     "takumi-js": "^1.8.7",
-    "ts-morph": "^28.0.0",
     "tsdown": "^0.22.3",
     "turbo": "^2.9.18",
     "tw-animate-css": "^1.4.0",

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -3,7 +3,7 @@ import { basename, join, resolve } from "node:path"
 import { parseArgs } from "node:util"
 
 import { convertRepo } from "@/convert"
-import { fetchZerostarter, gitCommitAll, gitInit } from "@/git"
+import { bunInstall, fetchZerostarter, gitCommitAll, gitInit } from "@/git"
 import { exists } from "@/io"
 
 import { promptConfirm, promptText } from "./_prompt"
@@ -98,11 +98,13 @@ export const init = async (argv: string[]) => {
   console.log("Removing the author's content, assets, and skills and rebranding ...")
   convertRepo(target, brand)
 
+  console.log("Installing dependencies ...")
+  bunInstall(target)
+
   gitCommitAll(target, `chore: re-baseline as ${name}`)
 
   console.log("\nDone. Next steps:")
   console.log(`  cd ${dir}`)
-  console.log("  bun install")
   console.log("  cp .env.example .env   # then set your values")
   console.log("  bun dev")
   console.log("\n  # then make it yours:")

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -72,9 +72,10 @@ export const newsreader = localFont({
 
 // Write the generic stubs so the app builds clean and reads as a fresh product.
 const scaffoldContent = (root: string): void => {
+  const today = new Date().toISOString().slice(0, 10)
   write(p(root, "web/next/content/docs/index.mdx"), docsIndexTemplate())
-  write(p(root, "web/next/content/blog/index.mdx"), blogIndexTemplate())
-  write(p(root, "web/next/content/blog/hello-world.mdx"), sampleBlogPostTemplate())
+  write(p(root, "web/next/content/blog/index.mdx"), blogIndexTemplate(today))
+  write(p(root, "web/next/content/blog/hello-world.mdx"), sampleBlogPostTemplate(today))
   write(p(root, "web/next/content/console/docs/index.mdx"), consoleIndexTemplate())
   write(p(root, "web/next/docs.config.ts"), docsConfigTemplate())
   write(p(root, "web/next/public/.gitkeep"), "")

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -72,7 +72,13 @@ export const newsreader = localFont({
 
 // Write the generic stubs so the app builds clean and reads as a fresh product.
 const scaffoldContent = (root: string): void => {
-  const today = new Date().toISOString().slice(0, 10)
+  // Stamp the earlier of the local and UTC date: its UTC midnight is always <= now (never hidden), and it matches the author's own calendar day when their timezone is behind UTC.
+  const now = new Date()
+  const utc = now.toISOString().slice(0, 10)
+  const local = [now.getFullYear(), now.getMonth() + 1, now.getDate()]
+    .map((n) => String(n).padStart(2, "0"))
+    .join("-")
+  const today = local < utc ? local : utc
   write(p(root, "web/next/content/docs/index.mdx"), docsIndexTemplate())
   write(p(root, "web/next/content/blog/index.mdx"), blogIndexTemplate(today))
   write(p(root, "web/next/content/blog/hello-world.mdx"), sampleBlogPostTemplate(today))

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -8,16 +8,22 @@ export const fetchZerostarter = (dir: string, ref = "main"): void => {
   run("bunx", ["gitpick@5.4.1", `https://github.com/nrjdalal/zerostarter/tree/${ref}`, dir])
 }
 
+// Install dependencies in `dir`, regenerating a clean lockfile for the converted package set.
+export const bunInstall = (dir: string): void => {
+  run("bun", ["install"], dir)
+}
+
 // Start a fresh git repo in `dir` (no commit yet).
 export const gitInit = (dir: string): void => {
   run("git", ["init", "-q"], dir)
 }
 
-// Stage everything and commit. No-op if there is nothing to commit (e.g. a re-run).
+// Stage everything and commit, bypassing the fork's hooks (bun install may have installed
+// lefthook in the scaffold). No-op if there is nothing to commit (e.g. a re-run).
 export const gitCommitAll = (dir: string, message: string): void => {
   run("git", ["add", "-A"], dir)
   try {
-    run("git", ["commit", "-q", "-m", message], dir)
+    run("git", ["commit", "--no-verify", "-q", "-m", message], dir)
   } catch {
     // nothing to commit
   }

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -70,13 +70,11 @@ Guidance for AI coding agents working in this repository.
 The local dev API exposes a sign-in-as endpoint for the agent identity in \`@packages/config/site\` (\`site.agent\`). It is local-only and requires a trusted Origin. See \`api/hono/src/routers/agents.ts\`.
 `
 
-// web/next/content/docs/index.mdx: docs anchor. Description must match docs.config.ts.
-export const DOCS_INDEX_DESCRIPTION = "Documentation."
-
+// web/next/content/docs/index.mdx: docs anchor. The description must match docs.config.ts.
 export const docsIndexTemplate = (): string => `---
 slug: /docs
 title: Introduction
-description: ${DOCS_INDEX_DESCRIPTION}
+description: Documentation.
 ---
 
 # Introduction
@@ -131,7 +129,7 @@ const docsConfig = {
       {
         "/docs": {
           title: "Introduction",
-          description: "${DOCS_INDEX_DESCRIPTION}",
+          description: "Documentation.",
         },
       },
     ],

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -3,12 +3,12 @@ export interface Brand {
 }
 
 // packages/config/src/site.ts: regenerated with the product name, repo URL, and placeholders.
-export const siteTemplate = ({
-  name,
-}: Brand): string => `// Brand identity for this app: the single source a fork edits to rebrand. web reads it via lib/config.ts.
+export const siteTemplate = ({ name }: Brand): string => {
+  const display = name.charAt(0).toUpperCase() + name.slice(1)
+  return `// Brand identity for this app: the single source a fork edits to rebrand. web reads it via lib/config.ts.
 export const site = {
-  name: "${name}",
-  description: "${name} is just getting started. Tell its story here.",
+  name: "${display}",
+  description: "${display} is just getting started. Tell its story here.",
   tagline: "Your tagline, ready when you are.",
   social: {
     github: "",
@@ -17,8 +17,8 @@ export const site = {
   },
   // Local-only dev agent identity (api/hono agents router).
   agent: {
-    name: "Agent",
-    email: "agent@example.com",
+    name: "LocalAgent",
+    email: "agent@local.host",
   },
   // Injectable long-form text blocks. A product sets its own, or leaves them empty.
   apiReferenceDescription: "",
@@ -27,47 +27,25 @@ export const site = {
 
 export type Site = typeof site
 `
+}
 
 // web/next/src/app/page.tsx: a minimal generic home that reads the brand from site config.
-export const homeTemplate = (): string => `import Link from "next/link"
-
-import { site } from "@packages/config/site"
+export const homeTemplate = (): string => `import { site } from "@packages/config/site"
 
 export default function Home() {
   return (
     <main className="flex min-h-svh flex-col items-center justify-center gap-6 p-8 text-center">
       <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">{site.name}</h1>
       <p className="text-muted-foreground max-w-xl text-lg">{site.description}</p>
-      <div className="flex gap-3">
-        <Link
-          href="/docs"
-          className="bg-primary text-primary-foreground rounded-md px-5 py-2.5 text-sm font-medium"
-        >
-          Documentation
-        </Link>
-        <Link href="/dashboard" className="rounded-md border px-5 py-2.5 text-sm font-medium">
-          Dashboard
-        </Link>
-      </div>
     </main>
   )
 }
 `
 
-// AGENTS.md (CLAUDE.md is a symlink to it): a generic agent guide.
+// AGENTS.md (CLAUDE.md is a symlink to it): a minimal agent guide for the fork to grow.
 export const agentsTemplate = (): string => `# AGENTS.md
 
 Guidance for AI coding agents working in this repository.
-
-## Instructions
-
-- ALWAYS: Use \`@/\` for imports, if applicable.
-- ALWAYS: Keep documentation in sync with code changes.
-- Do not comment unnecessarily. Only comment when it is absolutely necessary, and keep comments on a single line.
-
-## Logging in (agents)
-
-The local dev API exposes a sign-in-as endpoint for the agent identity in \`@packages/config/site\` (\`site.agent\`). It is local-only and requires a trusted Origin. See \`api/hono/src/routers/agents.ts\`.
 `
 
 // web/next/content/docs/index.mdx: docs anchor. The description must match docs.config.ts.
@@ -95,10 +73,10 @@ Your team's internal docs live here.
 `
 
 // web/next/content/blog/index.mdx: generic blog landing.
-export const blogIndexTemplate = (): string => `---
+export const blogIndexTemplate = (date: string): string => `---
 title: Blog
 description: Latest articles and updates
-createdAt: 2026-01-01
+createdAt: ${date}
 ---
 
 ## Recent Posts
@@ -107,11 +85,11 @@ createdAt: 2026-01-01
 `
 
 // web/next/content/blog/hello-world.mdx: a generic sample post so the blog is not empty.
-export const sampleBlogPostTemplate = (): string => `---
+export const sampleBlogPostTemplate = (date: string): string => `---
 title: Hello World
 description: The first post on your new blog.
-createdAt: 2026-01-01
-publishedAt: 2026-01-01
+createdAt: ${date}
+publishedAt: ${date}
 ---
 
 ## Hello World

--- a/packages/cli/test/templates.test.ts
+++ b/packages/cli/test/templates.test.ts
@@ -11,9 +11,9 @@ import {
   siteTemplate,
 } from "../src/templates"
 
-const brand = { name: "Acme" }
+const brand = { name: "acme" }
 
-test("siteTemplate carries the brand and leaks no upstream identity", () => {
+test("siteTemplate capitalizes the brand and leaks no upstream identity", () => {
   const out = siteTemplate(brand)
   expect(out).toContain('name: "Acme"')
   expect(out).not.toContain("zerostarter")
@@ -36,8 +36,8 @@ test("generated docs.config.ts is a valid DocsConfig satisfies block", () => {
 test("content + agent stubs are brand-free", () => {
   const stubs = [
     docsIndexTemplate(),
-    blogIndexTemplate(),
-    sampleBlogPostTemplate(),
+    blogIndexTemplate("2026-01-01"),
+    sampleBlogPostTemplate("2026-01-01"),
     consoleIndexTemplate(),
     agentsTemplate(),
   ]

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -7,5 +7,4 @@ export default defineConfig({
     "bin/index": "bin/index.ts",
   },
   minify: true,
-  outDir: "dist",
 })

--- a/web/next/src/components/navbar/home.tsx
+++ b/web/next/src/components/navbar/home.tsx
@@ -42,25 +42,27 @@ const socialLinks = [
 function SocialLinks({ onClick }: { onClick?: () => void }) {
   return (
     <div className="flex items-center gap-5 lg:gap-3">
-      {socialLinks.map((link) => (
-        <Tooltip key={link.href}>
-          <TooltipTrigger
-            render={
-              <a
-                href={link.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-foreground/60 hover:text-foreground transition-colors"
-                aria-label={link.label}
-                onClick={onClick}
-              />
-            }
-          >
-            <link.icon className="size-6" aria-hidden="true" />
-          </TooltipTrigger>
-          <TooltipContent>{link.label}</TooltipContent>
-        </Tooltip>
-      ))}
+      {socialLinks
+        .filter((link) => link.href)
+        .map((link) => (
+          <Tooltip key={link.href}>
+            <TooltipTrigger
+              render={
+                <a
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-foreground/60 hover:text-foreground transition-colors"
+                  aria-label={link.label}
+                  onClick={onClick}
+                />
+              }
+            >
+              <link.icon className="size-6" aria-hidden="true" />
+            </TooltipTrigger>
+            <TooltipContent>{link.label}</TooltipContent>
+          </Tooltip>
+        ))}
     </div>
   )
 }
@@ -210,16 +212,20 @@ export function Navbar() {
                     </Link>
                   )
                 })}
-                <Button
-                  role="link"
-                  size="sm"
-                  className="mt-2 w-fit"
-                  onClick={() => setIsOpen(false)}
-                  render={<a href={site.social.github} target="_blank" rel="noopener noreferrer" />}
-                >
-                  <RiGithubFill className="size-4" />
-                  Get {site.name}
-                </Button>
+                {site.social.github && (
+                  <Button
+                    role="link"
+                    size="sm"
+                    className="mt-2 w-fit"
+                    onClick={() => setIsOpen(false)}
+                    render={
+                      <a href={site.social.github} target="_blank" rel="noopener noreferrer" />
+                    }
+                  >
+                    <RiGithubFill className="size-4" />
+                    Get {site.name}
+                  </Button>
+                )}
               </nav>
               {/* Mobile Social Links */}
               <div className="mt-2.5 ml-4 flex items-center gap-2.5">


### PR DESCRIPTION
Small follow-up to #505 (merged): trim CLI config to non-defaults and remove a one-use indirection.

- `tsdown.config.ts`: drop `outDir: "dist"` (it's tsdown's default; entry keys already place `dist/index.mjs` + `dist/bin/index.mjs`)
- `templates.ts`: inline the single-use `DOCS_INDEX_DESCRIPTION` constant ("Documentation.") into `docsIndexTemplate` + `docsConfigTemplate` (they must stay equal for `docs.ts --strict`; verified by a passing converted-app build)

**Config-defaults audit (kept on purpose):** `minify: true` + `dts: { tsgo: true }` are non-defaults (intentional, match `packages/config`); `tsconfig` `types: ["bun"]` is required for the CLI's `node:` imports + `bun:test`; `include`/`exclude` are technically redundant with the base/tsc defaults but kept to match every other workspace tsconfig.

Verified: cli build (dist + dist/bin + shebang), check-types, lint, `bun test` (4/4), and a converted app build 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
