### PR TITLE
fix(db): keep squashed baseline at the original 0000 timestamp

### DIFF
--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -5,7 +5,7 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1782034847399,
+      "when": 1765943437627,
       "tag": "0000_zero_starter",
       "breakpoints": true
     }


### PR DESCRIPTION
Follow-up to #517. The squashed baseline was generated with a fresh timestamp, so `migrate-on-deploy` on the canary deploy tried to re-create already-existing tables on the shared Neon DB and **failed** (the canary API deploy went red; prod/main was unaffected and no data was touched).

## Fix
Pin the single migration's journal `when` to the original `0000` timestamp (`1765943437627`). Since `drizzle-kit migrate` is purely timestamp-gated, any DB whose last-applied migration is newer (the shared DB's is `0004` at `1781966675180`) **skips** the baseline as a no-op, while fresh installs with an empty `__drizzle_migrations` still apply it.

## Verified against the shared DB (read-only + no-op)
- `drizzle.__drizzle_migrations`: 5 rows, max `created_at` = `1781966675180`.
- `1765943437627 > 1781966675180` → `false` → migrate skips.
- Ran `drizzle-kit migrate` with the fix: exit `0`, **no new row inserted**, no DDL, `user` table still 24 rows.

Restores the canary deploy without any destructive DB work; the squash from #517 stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)