### PR TITLE
ci(cli): npm release workflow (gitpick-style) + bump to 0.0.7

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -47,7 +47,7 @@ jobs:
     if: |
       always() && !failure() && !cancelled() && (
         github.event_name == 'push' ||
-        github.event_name == 'issue_comment' && github.event.comment.user.login == github.repository_owner && contains(github.event.comment.body, 'release')
+        github.event_name == 'issue_comment' && github.event.comment.user.login == github.repository_owner && startsWith(github.event.comment.body, '/release')
       )
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,122 @@
+name: Release Package
+
+on:
+  push:
+    branches:
+      - canary
+      - main
+    paths:
+      - "packages/cli/**"
+  issue_comment:
+    types: [created]
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  id-token: write
+  contents: write
+  statuses: write
+  pull-requests: write
+
+jobs:
+  test:
+    if: github.event_name == 'push'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun run test
+
+  release:
+    if: |
+      always() && !failure() && !cancelled() && (
+        github.event_name == 'push' ||
+        github.event_name == 'issue_comment' && github.event.comment.user.login == github.repository_owner && contains(github.event.comment.body, 'release')
+      )
+    needs: [test]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Release Package
+        run: |
+          PACKAGE_NAME=$(bunx json -f package.json -a name)
+          npm view "$PACKAGE_NAME" 2>/dev/null || { echo "$PACKAGE_NAME does not exist in the npm registry. Skipping publish."; exit 0; }
+          PACKAGE_VERSION=$(bunx json -f package.json -a version)
+          VERSIONS=$(npm view $PACKAGE_NAME dist-tags --json)
+          LATEST_VERSION=$(echo $VERSIONS | bunx json latest)
+          if [[ $GITHUB_EVENT_NAME == 'issue_comment' ]]; then
+            PR_NUMBER=$(echo "${{ github.event.issue.pull_request.url }}" | grep -o '[0-9]*$')
+            LATEST_COMMIT_SHA=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" | bunx json -a sha | tail -n 1)
+            git checkout $LATEST_COMMIT_SHA
+            TAG="test"
+            RELEASE_VERSION="0.0.0-${LATEST_COMMIT_SHA:0:7}"
+          elif [[ $PACKAGE_VERSION != $LATEST_VERSION ]]; then
+            RELEASE_VERSION=$PACKAGE_VERSION
+            HAS_TAG=$(echo $PACKAGE_VERSION | grep -o '[a-zA-Z]*' | head -n 1)
+            TAG=$([[ -n "$HAS_TAG" ]] && echo $HAS_TAG || echo "latest")
+          else
+            TAG="canary"
+            RELEASE_VERSION=$(bunx semver $LATEST_VERSION -i minor)
+            TAGGED_VERSION=$(echo $VERSIONS | bunx json $TAG)
+            RELEASE_VERSION=$([[ $TAGGED_VERSION == $RELEASE_VERSION* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $RELEASE_VERSION-$TAG.0)
+          fi
+
+          bunx json -I -f package.json -e "this.version=\"$RELEASE_VERSION\""
+          bun install --frozen-lockfile
+          bun run build
+          bunx json -I -f package.json -e 'delete this.scripts'
+          bunx json -I -f package.json -e 'delete this.commitlint'
+          bunx json -I -f package.json -e 'delete this.devDependencies'
+          npm publish --provenance --access public --no-git-checks --tag $TAG
+
+          PACKAGE_URL="https://www.npmjs.com/package/$PACKAGE_NAME/v/$RELEASE_VERSION"
+          if [[ $GITHUB_EVENT_NAME == 'issue_comment' ]]; then
+            curl -fsSL -X DELETE -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}" >/dev/null \
+              && echo "🟢 Releasing comment deleted!" || echo "🔴 Failed to delete releasing comment."
+            curl -fsSL -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              -d "{\"body\": \"Test package released - [\`$PACKAGE_NAME@$RELEASE_VERSION\`]($PACKAGE_URL)\"}" >/dev/null \
+              && echo "🟢 Release comment to PR added!" || echo "🔴 Failed to add release comment to PR."
+          else
+            curl -fsSL -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments" \
+              -d "{\"body\": \"Package released - [\`$PACKAGE_NAME@$RELEASE_VERSION\`]($PACKAGE_URL)\"}" >/dev/null \
+              && echo "🟢 Release comment added!" || echo "🔴 Failed to add release comment."
+            curl -fsSL -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+              -d "{\"state\": \"success\", \"context\": \"Package released\", \"description\": \"$PACKAGE_NAME@$RELEASE_VERSION\", \"target_url\": \"$PACKAGE_URL\"}" >/dev/null \
+              && echo "🟢 Release status updated!" || echo "🔴 Failed to update release status."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.0",
+  "version": "0.0.7",
   "description": "Scaffold a clean product from the zerostarter SaaS starter, and keep forks in sync with upstream.",
   "keywords": [
     "cli",

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -35,6 +35,7 @@ const IGNORED_DIRS = [
 // Author pages, dev-meta, starter tooling, and resume-only fonts a fork does not ship.
 const REMOVE_PATHS = [
   "packages/cli",
+  ".github/workflows/cli-release.yml",
   ".github/audit",
   ".github/reviews",
   ".infisical.json",


### PR DESCRIPTION
## What

Sets up CLI npm publishing using the **exact `Release Package` script from `gitpick`/`inscope`**, and cuts the first real CLI release at **`0.0.7`** (0.0.6 was the placeholder name-grab).

## Changes

- **`.github/workflows/cli-release.yml`** — gitpick's `Release Package` job, **bash script byte-for-byte**. The only adaptations are config, not script:
  - **Trigger scoped to `branches: [canary, main]`** (your "at canary and also main") + **`paths: ['packages/cli/**']`** — so it only runs on CLI changes to the release branches, never on unrelated monorepo pushes or feature branches.
  - **`defaults.run.working-directory: packages/cli`** on both jobs — the script reads/builds/publishes the CLI, not the `private: true` repo root (which would refuse to publish).
- **`packages/cli/package.json`** → `version: 0.0.7` (tracking the real version in package.json, per our decision).
- **`packages/cli/src/convert.ts`** → adds `.github/workflows/cli-release.yml` to `REMOVE_PATHS`, so scaffolded forks don't inherit it (a fork has no `packages/cli` and must never publish to the `zerostarter` npm name).

## How the release works (gitpick's logic, unchanged)

The dist-tag is derived from the **version string**:
- plain `0.0.7` → published as **`latest`**
- pre-tagged `0.0.7-canary.0` → published under that tag (**`canary`**)
- pushed with no version change → auto **`canary`** prerelease (`next-minor -canary.N`)

Auth via `NPM_TOKEN`; `npm publish --provenance --access public` (repo is public, so provenance works).

## ⚠️ Merging this PR publishes `zerostarter@0.0.7`

This PR's feature-branch push published **nothing** (trigger is `[canary, main]` only — that's why you can review it safely). But **merging to canary will trigger the workflow and publish `zerostarter@0.0.7` as `latest`** (version `0.0.7` ≠ npm-latest `0.0.6`). Review the workflow here first; merge when you're happy.

## Notes

- The workflow strips `scripts`/`commitlint`/`devDependencies` before publish, so the dead `@packages/config` devDep never reaches the published package.
- Verified locally: CLI build, `check-types`, lint, and 4 tests all pass; `bun install` reports the lock unchanged (frozen-install in CI will pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped CLI version to `0.0.7`.
  * Added automated release workflow for CLI package deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->