### PR TITLE
ci(cli): tag CLI releases by branch (canary -> @canary, main -> @latest)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -84,15 +84,14 @@ jobs:
             git checkout $LATEST_COMMIT_SHA
             TAG="test"
             RELEASE_VERSION="0.0.0-${LATEST_COMMIT_SHA:0:7}"
-          elif [[ $PACKAGE_VERSION != $LATEST_VERSION ]]; then
+          elif [[ $GITHUB_REF_NAME == 'main' ]]; then
+            [[ $PACKAGE_VERSION == $LATEST_VERSION ]] && { echo "No version change on main. Skipping publish."; exit 0; }
             RELEASE_VERSION=$PACKAGE_VERSION
-            HAS_TAG=$(echo $PACKAGE_VERSION | grep -o '[a-zA-Z]*' | head -n 1)
-            TAG=$([[ -n "$HAS_TAG" ]] && echo $HAS_TAG || echo "latest")
+            TAG="latest"
           else
             TAG="canary"
-            RELEASE_VERSION=$(bunx semver $LATEST_VERSION -i minor)
             TAGGED_VERSION=$(echo $VERSIONS | bunx json $TAG)
-            RELEASE_VERSION=$([[ $TAGGED_VERSION == $RELEASE_VERSION* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $RELEASE_VERSION-$TAG.0)
+            RELEASE_VERSION=$([[ $TAGGED_VERSION == $PACKAGE_VERSION-canary* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $PACKAGE_VERSION-canary.0)
           fi
 
           bunx json -I -f package.json -e "this.version=\"$RELEASE_VERSION\""


### PR DESCRIPTION
## What

Makes the CLI release dist-tag follow the **branch** instead of the version string, so pushing to canary publishes to `canary` (not `latest`). This fixes the surprise from #526 where a plain `0.0.7` on canary went to `latest` (gitpick tags by version string, ignoring the branch).

## New logic

- **`main`** push → publish `package.json` version as **`latest`**; skip if the version is unchanged (no spurious re-publish).
- **`canary`** push → publish **`<version>-canary.N`** under the **`canary`** tag (N auto-increments from the current `@canary`).
- **`/release`** PR comment → unchanged throwaway `0.0.0-<sha>` under `test`.

Why prereleases on canary: an npm version is immutable/unique, so the same number can't be published from both branches. Canary therefore cuts `X.Y.Z-canary.N`; the stable `X.Y.Z` comes from main.

## Safe to merge

This touches only `.github/workflows/cli-release.yml`, not `packages/cli/**`, so neither the branch push nor the canary merge matches the workflow's path filter. Merging publishes nothing.

## After merge

`latest` stays `0.0.7`. To work toward the next release, bump `packages/cli/package.json` (e.g. `0.0.8`) on canary, and canary will cut `0.0.8-canary.N`; when that lands on main it publishes `0.0.8` as `latest`.
