### PR TITLE
feat(auth): make GitHub and Google OAuth optional; UI shows only configured providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,11 @@ HONO_RATE_LIMIT_WINDOW_MS=60000 # 1 minute (default)
 # Generate using `openssl rand -base64 32`
 BETTER_AUTH_SECRET=
 
-# Generate at `https://github.com/settings/developers`
+# Optional: GitHub OAuth (`https://github.com/settings/developers`). Leave blank to hide the button.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
-# Generate at `https://console.cloud.google.com/apis/credentials`
+# Optional: Google OAuth (`https://console.cloud.google.com/apis/credentials`). Leave blank to hide the button.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,6 +1,7 @@
-import { auth } from "@packages/auth"
+import { auth, enabledSocialProviders } from "@packages/auth"
 import { Hono } from "hono"
 
 export const authRouter = new Hono()
+  .get("/providers", (c) => c.json({ data: { providers: enabledSocialProviders } }))
   .get("/get-session", (c) => auth.handler(c.req.raw))
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -2,6 +2,6 @@ import { auth, enabledSocialProviders } from "@packages/auth"
 import { Hono } from "hono"
 
 export const authRouter = new Hono()
-  .get("/providers", (c) => c.json({ data: { providers: enabledSocialProviders } }))
   .get("/get-session", (c) => auth.handler(c.req.raw))
+  .get("/providers", (c) => c.json({ data: { providers: enabledSocialProviders } }))
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -24,6 +24,14 @@ import { getCookieDomain, getCookiePrefix } from "@/lib/utils"
 const cookieDomain = getCookieDomain(env.HONO_APP_URL)
 const cookiePrefix = getCookiePrefix(env.HONO_APP_URL)
 
+export type SocialProvider = "github" | "google"
+
+// A provider is enabled only when both of its OAuth credentials are set; a fork can ship with any subset (or none, relying on magic link).
+export const enabledSocialProviders: SocialProvider[] = [
+  ...(env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET ? (["github"] as const) : []),
+  ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET ? (["google"] as const) : []),
+]
+
 export const auth = betterAuth({
   baseURL: env.HONO_APP_URL,
   trustedOrigins: env.HONO_TRUSTED_ORIGINS,
@@ -58,14 +66,12 @@ export const auth = betterAuth({
     adminPlugin(),
   ],
   socialProviders: {
-    github: {
-      clientId: env.GITHUB_CLIENT_ID,
-      clientSecret: env.GITHUB_CLIENT_SECRET,
-    },
-    google: {
-      clientId: env.GOOGLE_CLIENT_ID,
-      clientSecret: env.GOOGLE_CLIENT_SECRET,
-    },
+    ...(env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET
+      ? { github: { clientId: env.GITHUB_CLIENT_ID, clientSecret: env.GITHUB_CLIENT_SECRET } }
+      : {}),
+    ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+      ? { google: { clientId: env.GOOGLE_CLIENT_ID, clientSecret: env.GOOGLE_CLIENT_SECRET } }
+      : {}),
   },
   advanced: {
     ...(cookiePrefix && { cookiePrefix }),

--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -8,10 +8,10 @@ export const env = createEnv({
   server: {
     NODE_ENV,
     BETTER_AUTH_SECRET: z.string().min(1),
-    GITHUB_CLIENT_ID: z.string().min(1),
-    GITHUB_CLIENT_SECRET: z.string().min(1),
-    GOOGLE_CLIENT_ID: z.string().min(1),
-    GOOGLE_CLIENT_SECRET: z.string().min(1),
+    GITHUB_CLIENT_ID: z.string().min(1).optional(),
+    GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
+    GOOGLE_CLIENT_ID: z.string().min(1).optional(),
+    GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
     HONO_APP_URL: z.url(),
     HONO_TRUSTED_ORIGINS: z
       .string()

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -35,7 +35,7 @@ For local development and AI agents, `POST /api/agents/sign-in-as` signs in as a
 1. Create OAuth credentials with the provider
 2. Add the client ID and secret to your `.env` file
 3. Add the variables to `packages/env/src/auth.ts` as `.optional()` (so the app still boots without them)
-4. Register the provider conditionally in `packages/auth/src/index.ts`, and add it to `enabledSocialProviders` so the UI knows to show it:
+4. Register the provider conditionally in `packages/auth/src/index.ts`, extend the `SocialProvider` union with its key, and add it to `enabledSocialProviders` so the route advertises it:
 
 ```ts
 socialProviders: {
@@ -47,6 +47,8 @@ socialProviders: {
     : {}),
 },
 ```
+
+5. Add a button for it in `web/next/src/components/access.tsx`, gated on the provider appearing in the fetched list (copy the GitHub/Google blocks and swap the icon). Skipping this leaves the provider enabled server-side with no button to trigger it.
 
 ## Console Access
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -17,12 +17,14 @@ The sign-in UI includes an email magic-link flow (`authClient.signIn.magicLink`,
 
 ### OAuth Providers
 
-Two social providers are configured:
+Two social providers are supported, and each is **optional**: a provider registers only when both of its credentials are present, so a fork can ship with GitHub, Google, both, or neither (relying on magic link).
 
-- **GitHub**: Requires `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
-- **Google**: Requires `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+- **GitHub**: set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
+- **Google**: set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
 
-The auth config (`packages/auth/src/index.ts`) does not set a redirect for the social providers. The post-authentication redirect is driven by the `callbackURL` passed to the client sign-in call.
+`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns that list, and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Adding or removing a provider is therefore just an env change; the UI follows automatically.
+
+The auth config does not set a redirect for the social providers. The post-authentication redirect is driven by the `callbackURL` passed to the client sign-in call.
 
 ### Agent Sign-In (local only)
 
@@ -32,22 +34,19 @@ For local development and AI agents, `POST /api/agents/sign-in-as` signs in as a
 
 1. Create OAuth credentials with the provider
 2. Add the client ID and secret to your `.env` file
-3. Configure the provider in `packages/auth/src/index.ts`:
+3. Add the variables to `packages/env/src/auth.ts` as `.optional()` (so the app still boots without them)
+4. Register the provider conditionally in `packages/auth/src/index.ts`, and add it to `enabledSocialProviders` so the UI knows to show it:
 
 ```ts
 socialProviders: {
-  github: {
-    clientId: env.GITHUB_CLIENT_ID,
-    clientSecret: env.GITHUB_CLIENT_SECRET,
-  },
-  google: {
-    clientId: env.GOOGLE_CLIENT_ID,
-    clientSecret: env.GOOGLE_CLIENT_SECRET,
-  },
+  ...(env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET
+    ? { github: { clientId: env.GITHUB_CLIENT_ID, clientSecret: env.GITHUB_CLIENT_SECRET } }
+    : {}),
+  ...(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+    ? { google: { clientId: env.GOOGLE_CLIENT_ID, clientSecret: env.GOOGLE_CLIENT_SECRET } }
+    : {}),
 },
 ```
-
-4. Add the environment variables to `packages/env/src/auth.ts`
 
 ## Console Access
 
@@ -157,9 +156,9 @@ Authenticated requests use a per-user limiter set to twice the configured limit 
 | Variable               | Description                                               |
 | ---------------------- | --------------------------------------------------------- |
 | `BETTER_AUTH_SECRET`   | Secret key for signing tokens (`openssl rand -base64 32`) |
-| `GITHUB_CLIENT_ID`     | GitHub OAuth app client ID                                |
-| `GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret                            |
-| `GOOGLE_CLIENT_ID`     | Google OAuth client ID                                    |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret                                |
+| `GITHUB_CLIENT_ID`     | GitHub OAuth app client ID (optional)                     |
+| `GITHUB_CLIENT_SECRET` | GitHub OAuth app client secret (optional)                 |
+| `GOOGLE_CLIENT_ID`     | Google OAuth client ID (optional)                         |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (optional)                     |
 | `HONO_APP_URL`         | Backend URL (used as Better Auth base URL)                |
 | `HONO_TRUSTED_ORIGINS` | Allowed CORS origins                                      |

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -22,7 +22,7 @@ Two social providers are supported, and each is **optional**: a provider registe
 - **GitHub**: set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
 - **Google**: set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
 
-`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns that list, and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Adding or removing a provider is therefore just an env change; the UI follows automatically.
+`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns that list, and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Toggling either built-in provider is therefore just an env change; the UI follows automatically. Adding a brand-new provider also takes a small code change (see below).
 
 The auth config does not set a redirect for the social providers. The post-authentication redirect is driven by the `callbackURL` passed to the client sign-in call.
 

--- a/web/next/content/docs/manage/environment.mdx
+++ b/web/next/content/docs/manage/environment.mdx
@@ -32,7 +32,7 @@ All environment variables are stored in a single `.env` file at the project root
 Each package defines only the environment variables it needs:
 
 - **`api-hono`**: `HONO_APP_URL`, `HONO_PORT`, `HONO_RATE_LIMIT`, `HONO_RATE_LIMIT_WINDOW_MS`, `HONO_TRUSTED_ORIGINS`
-- **`auth`**: `BETTER_AUTH_SECRET`, `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `HONO_APP_URL`, `HONO_TRUSTED_ORIGINS`
+- **`auth`**: `BETTER_AUTH_SECRET`, `HONO_APP_URL`, `HONO_TRUSTED_ORIGINS`, plus the optional OAuth pairs `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET` and `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` (a provider registers only when both halves of its pair are set)
 - **`db`**: `POSTGRES_URL`. When `INTERNAL_API_URL` is set, the `db` package rewrites `localhost` in `POSTGRES_URL` to `host.docker.internal` so containers can reach a database on the host.
 - **`web-next`**:
   - **Server**: `INTERNAL_API_URL` (server-side only, for internal service-to-service calls)

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -3,6 +3,7 @@
 import { site } from "@packages/config/site"
 import { RiGithubFill, RiGoogleFill, RiLayoutGridFill, RiLoaderLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
+import { useQuery } from "@tanstack/react-query"
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -18,6 +19,7 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { apiClient } from "@/lib/api/client"
 import { authClient } from "@/lib/auth/client"
 import { config } from "@/lib/config"
 
@@ -32,6 +34,20 @@ export function Access() {
   // Next inlines NODE_ENV at build time: "development" only under `next dev`,
   // "production" for any `next build`. Auto-hides in deployments.
   const isDev = process.env.NODE_ENV === "development"
+
+  // Render only the social buttons for providers the API actually has configured (GET /api/auth/providers).
+  const { data: providers } = useQuery({
+    queryKey: ["auth-providers"],
+    queryFn: async () => {
+      const res = await apiClient.auth.providers.$get()
+      if (!res.ok) return [] as ("github" | "google")[]
+      const { data } = await res.json()
+      return data.providers
+    },
+  })
+  const githubEnabled = providers?.includes("github") ?? false
+  const googleEnabled = providers?.includes("google") ?? false
+  const hasAlternatives = isDev || githubEnabled || googleEnabled
 
   useEffect(() => {
     setLoader(null)
@@ -127,70 +143,80 @@ export function Access() {
               Sign in/up
             </Button>
           </form>
-          <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
-            <span className="bg-popover text-muted-foreground relative z-10 px-2 text-xs">OR</span>
-          </div>
-          <div className="grid gap-4">
-            {isDev && (
-              <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
-                <Button type="submit" variant="outline" className="w-full cursor-pointer">
-                  Login (agents)
-                </Button>
-              </form>
-            )}
-            <Button
-              variant="outline"
-              type="button"
-              className="w-full cursor-pointer"
-              onClick={async () => {
-                setLoader("github")
-                const res = await authClient.signIn.social({
-                  provider: "github",
-                  callbackURL: `${config.app.url}/dashboard`,
-                })
-                if (res.error) {
-                  toast.error(res.error.message)
-                  setLoader(null)
-                }
-              }}
-              disabled={loader === "github"}
-            >
-              {loader === "github" ? (
-                <RiLoaderLine className="size-5 animate-spin" />
-              ) : (
-                <RiGithubFill className="size-5" />
-              )}
-              Continue with Github
-            </Button>
-            <Button
-              variant="outline"
-              type="button"
-              className="w-full cursor-pointer"
-              onClick={async () => {
-                setLoader("google")
-                const res = await authClient.signIn.social({
-                  provider: "google",
-                  callbackURL: `${config.app.url}/dashboard`,
-                })
-                if (res.error) {
-                  toast.error(res.error.message)
-                  setLoader(null)
-                }
-              }}
-              disabled={loader === "google"}
-            >
-              {loader === "google" ? (
-                <RiLoaderLine className="size-5 animate-spin" />
-              ) : (
-                <RiGoogleFill className="size-5" />
-              )}
-              Continue with Google
-            </Button>
-            <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
-              By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
-              <a href="#">Privacy Policy</a>.
-            </div>
-          </div>
+          {hasAlternatives && (
+            <>
+              <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
+                <span className="bg-popover text-muted-foreground relative z-10 px-2 text-xs">
+                  OR
+                </span>
+              </div>
+              <div className="grid gap-4">
+                {isDev && (
+                  <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
+                    <Button type="submit" variant="outline" className="w-full cursor-pointer">
+                      Login (agents)
+                    </Button>
+                  </form>
+                )}
+                {githubEnabled && (
+                  <Button
+                    variant="outline"
+                    type="button"
+                    className="w-full cursor-pointer"
+                    onClick={async () => {
+                      setLoader("github")
+                      const res = await authClient.signIn.social({
+                        provider: "github",
+                        callbackURL: `${config.app.url}/dashboard`,
+                      })
+                      if (res.error) {
+                        toast.error(res.error.message)
+                        setLoader(null)
+                      }
+                    }}
+                    disabled={loader === "github"}
+                  >
+                    {loader === "github" ? (
+                      <RiLoaderLine className="size-5 animate-spin" />
+                    ) : (
+                      <RiGithubFill className="size-5" />
+                    )}
+                    Continue with Github
+                  </Button>
+                )}
+                {googleEnabled && (
+                  <Button
+                    variant="outline"
+                    type="button"
+                    className="w-full cursor-pointer"
+                    onClick={async () => {
+                      setLoader("google")
+                      const res = await authClient.signIn.social({
+                        provider: "google",
+                        callbackURL: `${config.app.url}/dashboard`,
+                      })
+                      if (res.error) {
+                        toast.error(res.error.message)
+                        setLoader(null)
+                      }
+                    }}
+                    disabled={loader === "google"}
+                  >
+                    {loader === "google" ? (
+                      <RiLoaderLine className="size-5 animate-spin" />
+                    ) : (
+                      <RiGoogleFill className="size-5" />
+                    )}
+                    Continue with Google
+                  </Button>
+                )}
+                <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
+                  By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
+                  <a href="#">Privacy Policy</a>.
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -35,12 +35,13 @@ export function Access() {
   // "production" for any `next build`. Auto-hides in deployments.
   const isDev = process.env.NODE_ENV === "development"
 
-  // Render only the social buttons for providers the API actually has configured (GET /api/auth/providers).
+  // Render only the buttons for configured providers (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final list with no flash.
   const { data: providers } = useQuery({
     queryKey: ["auth-providers"],
+    staleTime: Infinity,
     queryFn: async () => {
       const res = await apiClient.auth.providers.$get()
-      if (!res.ok) return [] as ("github" | "google")[]
+      if (!res.ok) throw new Error("Failed to load auth providers")
       const { data } = await res.json()
       return data.providers
     },


### PR DESCRIPTION
## What

Make each social OAuth provider independently **optional**, and have the sign-in UI render only the providers that are actually configured. A fresh fork can ship with GitHub, Google, both, or neither (magic link always works) without editing code or hitting env-validation errors.

## Why

An upstream audit of the dalonic forks surfaced this as the one genuinely upstreamable delta: the starter couldn't boot unless both GitHub and Google creds were present, and the login dialog hardcoded both buttons regardless of what was configured.

## How

Single source of truth = the API's env.

- `packages/env/src/auth.ts`: `GITHUB_*` / `GOOGLE_*` are now `.optional()`.
- `packages/auth/src/index.ts`: `socialProviders` is built conditionally (a provider registers only when both of its creds are set), and a derived `enabledSocialProviders` list is exported.
- `api/hono/src/routers/auth.ts`: public `GET /api/auth/providers` (after `get-session`, before the better-auth `/*` catch-all) returns that list, RPC-typed like `apiClient.waitlist`.
- `web/next/src/components/access.tsx`: fetches the list with react-query (`staleTime: Infinity`, prefetched on mount) and renders only the available buttons. The dialog content mounts on open and the list is prefetched, so the buttons paint with the final set on first open (no flash/CLS). A failed fetch throws so react-query retries instead of silently degrading to magic-link-only; the "OR" divider hides in production builds when nothing alternative is available. Magic-link email stays always-on.
- Docs + `.env.example` updated (`manage/authentication`, `manage/environment`), including steps for adding a brand-new provider (extend the `SocialProvider` union + add a gated button in `access.tsx`).

Toggling either built-in provider is just an env change; a brand-new provider also needs the small code change documented above.

## Verification

- `oxfmt`, `oxlint`, and all 12 `check-types` tasks pass (incl. `@web/next` `tsc --noEmit`, confirming the `apiClient.auth.providers.$get()` RPC type resolves).
- Runtime "hide" path exercised end to end (backed up `.env`, toggled creds, restored byte-for-byte with md5 match):

| `.env` state | `GET /api/auth/providers` | Login dialog |
| --- | --- | --- |
| GitHub + Google | `["github","google"]` | both buttons |
| Google blanked | `["github"]` | GitHub only |
| Both blanked | `[]` | no social buttons (email + dev agents-login remain) |
| Restored | `["github","google"]` | both buttons |

- Browser-confirmed in a real Chromium session (agent-browser) for the github-only and none-configured states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OAuth provider credentials for GitHub and Google are now optional; authentication sign-in buttons display only when providers are configured.

* **Documentation**
  * Updated authentication and environment setup guides to clarify optional OAuth configuration and conditional provider button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
