### PR TITLE
feat(auth): gate the magic-link email field on the plugin being enabled

### DIFF
--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,7 +1,9 @@
-import { auth, enabledSocialProviders } from "@packages/auth"
+import { auth, enabledSocialProviders, magicLinkEnabled } from "@packages/auth"
 import { Hono } from "hono"
 
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
-  .get("/providers", (c) => c.json({ data: { providers: enabledSocialProviders } }))
+  .get("/providers", (c) =>
+    c.json({ data: { providers: enabledSocialProviders, magicLink: magicLinkEnabled } }),
+  )
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,9 +1,7 @@
-import { auth, enabledSocialProviders, magicLinkEnabled } from "@packages/auth"
+import { auth, enabledProviders } from "@packages/auth"
 import { Hono } from "hono"
 
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
-  .get("/providers", (c) =>
-    c.json({ data: { providers: enabledSocialProviders, magicLink: magicLinkEnabled } }),
-  )
+  .get("/providers", (c) => c.json({ data: { providers: enabledProviders } }))
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -25,6 +25,7 @@ const cookieDomain = getCookieDomain(env.HONO_APP_URL)
 const cookiePrefix = getCookiePrefix(env.HONO_APP_URL)
 
 export type SocialProvider = "github" | "google"
+export type AuthProvider = SocialProvider | "magic-link"
 
 // A provider is enabled only when both of its OAuth credentials are set; a fork can ship with any subset (or none, relying on magic link).
 export const enabledSocialProviders: SocialProvider[] = [
@@ -88,5 +89,11 @@ export const auth = betterAuth({
 export const magicLinkEnabled = (auth.options.plugins ?? []).some(
   (p) => (p.id as string) === "magic-link",
 )
+
+// The unified list of enabled sign-in providers the UI reads: social providers plus magic link when its server plugin is registered.
+export const enabledProviders: AuthProvider[] = [
+  ...enabledSocialProviders,
+  ...(magicLinkEnabled ? (["magic-link"] as const) : []),
+]
 
 export type Session = typeof auth.$Infer.Session

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -84,4 +84,9 @@ export const auth = betterAuth({
   },
 })
 
+// Magic-link sign-in shows in the UI only when its server plugin is registered; add `magicLink({ sendMagicLink })` to the plugins above (and implement the sender) to enable it.
+export const magicLinkEnabled = (auth.options.plugins ?? []).some(
+  (p) => (p.id as string) === "magic-link",
+)
+
 export type Session = typeof auth.$Infer.Session

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -13,7 +13,7 @@ ZeroStarter uses [Better Auth](https://better-auth.com) for authentication, conf
 
 ### Magic Link
 
-The sign-in UI can show an email magic-link flow (`authClient.signIn.magicLink`, registered via the `magicLinkClient()` plugin in `web/next/src/lib/auth/client.ts`). The server-side `magicLink` plugin and its email sender are not enabled by default, so the email field is **hidden** until you wire it up rather than shown as a dead control: `packages/auth/src/index.ts` derives `magicLinkEnabled` from whether the `magicLink` plugin is registered, the public `GET /api/auth/providers` route reports it, and `web/next/src/components/access.tsx` renders the email field only when it is true. To turn it on, add the `magicLink` plugin to the `plugins` array in `packages/auth/src/index.ts` (which flips `magicLinkEnabled` automatically) and implement `sendMagicLink` to deliver the email.
+The sign-in UI can show an email magic-link flow (`authClient.signIn.magicLink`, registered via the `magicLinkClient()` plugin in `web/next/src/lib/auth/client.ts`). The server-side `magicLink` plugin and its email sender are not enabled by default, so the email field is **hidden** until you wire it up rather than shown as a dead control: `packages/auth/src/index.ts` derives `magicLinkEnabled` from whether the `magicLink` plugin is registered, the public `GET /api/auth/providers` route lists `magic-link` among the enabled providers when it is, and `web/next/src/components/access.tsx` renders the email field only when `magic-link` is present. To turn it on, add the `magicLink` plugin to the `plugins` array in `packages/auth/src/index.ts` (which flips `magicLinkEnabled` automatically) and implement `sendMagicLink` to deliver the email.
 
 ### OAuth Providers
 
@@ -22,7 +22,7 @@ Two social providers are supported, and each is **optional**: a provider registe
 - **GitHub**: set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
 - **Google**: set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
 
-`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns that list (plus a `magicLink` flag, see above), and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Toggling either built-in provider is therefore just an env change; the UI follows automatically. Adding a brand-new provider also takes a small code change (see below).
+`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured) plus `enabledProviders` (those plus `magic-link` when enabled). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns `enabledProviders`, and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Toggling either built-in provider is therefore just an env change; the UI follows automatically. Adding a brand-new provider also takes a small code change (see below).
 
 The auth config does not set a redirect for the social providers. The post-authentication redirect is driven by the `callbackURL` passed to the client sign-in call.
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -13,7 +13,7 @@ ZeroStarter uses [Better Auth](https://better-auth.com) for authentication, conf
 
 ### Magic Link
 
-The sign-in UI includes an email magic-link flow (`authClient.signIn.magicLink`, registered via the `magicLinkClient()` plugin in `web/next/src/lib/auth/client.ts`). The matching server-side `magicLink` plugin and email sender are not enabled by default, so the flow is not functional out of the box. To turn it on, add the `magicLink` plugin to `packages/auth/src/index.ts` and implement `sendMagicLink` to deliver the email.
+The sign-in UI can show an email magic-link flow (`authClient.signIn.magicLink`, registered via the `magicLinkClient()` plugin in `web/next/src/lib/auth/client.ts`). The server-side `magicLink` plugin and its email sender are not enabled by default, so the email field is **hidden** until you wire it up rather than shown as a dead control: `packages/auth/src/index.ts` derives `magicLinkEnabled` from whether the `magicLink` plugin is registered, the public `GET /api/auth/providers` route reports it, and `web/next/src/components/access.tsx` renders the email field only when it is true. To turn it on, add the `magicLink` plugin to the `plugins` array in `packages/auth/src/index.ts` (which flips `magicLinkEnabled` automatically) and implement `sendMagicLink` to deliver the email.
 
 ### OAuth Providers
 
@@ -22,7 +22,7 @@ Two social providers are supported, and each is **optional**: a provider registe
 - **GitHub**: set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
 - **Google**: set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
 
-`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns that list, and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Toggling either built-in provider is therefore just an env change; the UI follows automatically. Adding a brand-new provider also takes a small code change (see below).
+`packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns that list (plus a `magicLink` flag, see above), and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Toggling either built-in provider is therefore just an env change; the UI follows automatically. Adding a brand-new provider also takes a small code change (see below).
 
 The auth config does not set a redirect for the social providers. The post-authentication redirect is driven by the `callbackURL` passed to the client sign-in call.
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -24,6 +24,8 @@ Two social providers are supported, and each is **optional**: a provider registe
 
 `packages/auth/src/index.ts` builds `socialProviders` conditionally from those env vars and exports `enabledSocialProviders` (the providers that are actually configured) plus `enabledProviders` (those plus `magic-link` when enabled). The public `GET /api/auth/providers` route (`api/hono/src/routers/auth.ts`) returns `enabledProviders`, and the sign-in UI (`web/next/src/components/access.tsx`) fetches it to render only the buttons for configured providers. Toggling either built-in provider is therefore just an env change; the UI follows automatically. Adding a brand-new provider also takes a small code change (see below).
 
+Note: if a deployed fork configures no OAuth providers and does not enable magic link, the sign-in dialog renders a "No sign-in options are configured yet." message (the local-only agent sign-in is hidden in production). Configure at least one provider, or wire up magic link, before shipping a login surface.
+
 The auth config does not set a redirect for the social providers. The post-authentication redirect is driven by the `callbackURL` passed to the client sign-in call.
 
 ### Agent Sign-In (local only)

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -35,22 +35,22 @@ export function Access() {
   // "production" for any `next build`. Auto-hides in deployments.
   const isDev = process.env.NODE_ENV === "development"
 
-  // Render only the sign-in methods the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
-  const { data: methods } = useQuery({
-    queryKey: ["auth-methods"],
+  // Render only the sign-in providers the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
+  const { data: providers } = useQuery({
+    queryKey: ["auth-providers"],
     staleTime: Infinity,
     queryFn: async () => {
       const res = await apiClient.auth.providers.$get()
-      if (!res.ok) throw new Error("Failed to load auth methods")
+      if (!res.ok) throw new Error("Failed to load auth providers")
       const { data } = await res.json()
-      return data
+      return data.providers
     },
   })
-  const githubEnabled = methods?.providers.includes("github") ?? false
-  const googleEnabled = methods?.providers.includes("google") ?? false
-  const magicLinkEnabled = methods?.magicLink ?? false
+  const githubEnabled = providers?.includes("github") ?? false
+  const googleEnabled = providers?.includes("google") ?? false
+  const magicLinkEnabled = providers?.includes("magic-link") ?? false
   const hasSocial = isDev || githubEnabled || googleEnabled
-  const hasNoMethods = !magicLinkEnabled && !hasSocial
+  const hasNoProviders = !magicLinkEnabled && !hasSocial
 
   useEffect(() => {
     setLoader(null)
@@ -222,9 +222,9 @@ export function Access() {
               </div>
             </div>
           )}
-          {hasNoMethods && (
+          {hasNoProviders && (
             <p className="text-muted-foreground text-center text-sm">
-              No sign-in methods are configured yet.
+              No sign-in options are configured yet.
             </p>
           )}
         </div>

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -49,8 +49,8 @@ export function Access() {
   const githubEnabled = providers?.includes("github") ?? false
   const googleEnabled = providers?.includes("google") ?? false
   const magicLinkEnabled = providers?.includes("magic-link") ?? false
-  const hasSocial = isDev || githubEnabled || googleEnabled
-  const hasNoProviders = !magicLinkEnabled && !hasSocial
+  const hasAlternatives = isDev || githubEnabled || googleEnabled
+  const hasNoProviders = !magicLinkEnabled && !hasAlternatives
 
   useEffect(() => {
     setLoader(null)
@@ -148,14 +148,14 @@ export function Access() {
               </Button>
             </form>
           )}
-          {magicLinkEnabled && hasSocial && (
+          {magicLinkEnabled && hasAlternatives && (
             <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
               <span className="bg-popover text-muted-foreground relative z-10 px-2 text-xs">
                 OR
               </span>
             </div>
           )}
-          {hasSocial && (
+          {hasAlternatives && (
             <div className="grid gap-4">
               {isDev && (
                 <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -35,20 +35,22 @@ export function Access() {
   // "production" for any `next build`. Auto-hides in deployments.
   const isDev = process.env.NODE_ENV === "development"
 
-  // Render only the buttons for configured providers (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final list with no flash.
-  const { data: providers } = useQuery({
-    queryKey: ["auth-providers"],
+  // Render only the sign-in methods the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
+  const { data: methods } = useQuery({
+    queryKey: ["auth-methods"],
     staleTime: Infinity,
     queryFn: async () => {
       const res = await apiClient.auth.providers.$get()
-      if (!res.ok) throw new Error("Failed to load auth providers")
+      if (!res.ok) throw new Error("Failed to load auth methods")
       const { data } = await res.json()
-      return data.providers
+      return data
     },
   })
-  const githubEnabled = providers?.includes("github") ?? false
-  const googleEnabled = providers?.includes("google") ?? false
-  const hasAlternatives = isDev || githubEnabled || googleEnabled
+  const githubEnabled = methods?.providers.includes("github") ?? false
+  const googleEnabled = methods?.providers.includes("google") ?? false
+  const magicLinkEnabled = methods?.magicLink ?? false
+  const hasSocial = isDev || githubEnabled || googleEnabled
+  const hasNoMethods = !magicLinkEnabled && !hasSocial
 
   useEffect(() => {
     setLoader(null)
@@ -100,123 +102,130 @@ export function Access() {
             </div>
             <h1 className="text-xl font-semibold">Welcome to {site.name}</h1>
           </div>
-          <form
-            id="email"
-            className="space-y-4"
-            onSubmit={(e) => {
-              e.preventDefault()
-              form.handleSubmit()
-            }}
-          >
-            <FieldGroup>
-              <form.Field name="email">
-                {(field) => {
-                  const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
-                  return (
-                    <Field data-invalid={isInvalid}>
-                      <FieldLabel htmlFor={field.name}>Email</FieldLabel>
-                      <Input
-                        id={field.name}
-                        type="email"
-                        name={field.name}
-                        className="focus:placeholder:opacity-0"
-                        value={field.state.value}
-                        onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(e.target.value)}
-                        aria-invalid={isInvalid}
-                        placeholder="you@example.com"
-                        disabled={loader === "email"}
-                      />
-                      {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                    </Field>
-                  )
-                }}
-              </form.Field>
-            </FieldGroup>
-            <Button
-              form="email"
-              type="submit"
-              variant="secondary"
-              className="w-full cursor-pointer"
-              disabled={loader === "email"}
+          {magicLinkEnabled && (
+            <form
+              id="email"
+              className="space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                form.handleSubmit()
+              }}
             >
-              {loader === "email" ? <RiLoaderLine className="size-5 animate-spin" /> : null}
-              Sign in/up
-            </Button>
-          </form>
-          {hasAlternatives && (
-            <>
-              <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
-                <span className="bg-popover text-muted-foreground relative z-10 px-2 text-xs">
-                  OR
-                </span>
-              </div>
-              <div className="grid gap-4">
-                {isDev && (
-                  <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
-                    <Button type="submit" variant="outline" className="w-full cursor-pointer">
-                      Login (agents)
-                    </Button>
-                  </form>
-                )}
-                {githubEnabled && (
-                  <Button
-                    variant="outline"
-                    type="button"
-                    className="w-full cursor-pointer"
-                    onClick={async () => {
-                      setLoader("github")
-                      const res = await authClient.signIn.social({
-                        provider: "github",
-                        callbackURL: `${config.app.url}/dashboard`,
-                      })
-                      if (res.error) {
-                        toast.error(res.error.message)
-                        setLoader(null)
-                      }
-                    }}
-                    disabled={loader === "github"}
-                  >
-                    {loader === "github" ? (
-                      <RiLoaderLine className="size-5 animate-spin" />
-                    ) : (
-                      <RiGithubFill className="size-5" />
-                    )}
-                    Continue with Github
+              <FieldGroup>
+                <form.Field name="email">
+                  {(field) => {
+                    const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Email</FieldLabel>
+                        <Input
+                          id={field.name}
+                          type="email"
+                          name={field.name}
+                          className="focus:placeholder:opacity-0"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          aria-invalid={isInvalid}
+                          placeholder="you@example.com"
+                          disabled={loader === "email"}
+                        />
+                        {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                      </Field>
+                    )
+                  }}
+                </form.Field>
+              </FieldGroup>
+              <Button
+                form="email"
+                type="submit"
+                variant="secondary"
+                className="w-full cursor-pointer"
+                disabled={loader === "email"}
+              >
+                {loader === "email" ? <RiLoaderLine className="size-5 animate-spin" /> : null}
+                Sign in/up
+              </Button>
+            </form>
+          )}
+          {magicLinkEnabled && hasSocial && (
+            <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
+              <span className="bg-popover text-muted-foreground relative z-10 px-2 text-xs">
+                OR
+              </span>
+            </div>
+          )}
+          {hasSocial && (
+            <div className="grid gap-4">
+              {isDev && (
+                <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
+                  <Button type="submit" variant="outline" className="w-full cursor-pointer">
+                    Login (agents)
                   </Button>
-                )}
-                {googleEnabled && (
-                  <Button
-                    variant="outline"
-                    type="button"
-                    className="w-full cursor-pointer"
-                    onClick={async () => {
-                      setLoader("google")
-                      const res = await authClient.signIn.social({
-                        provider: "google",
-                        callbackURL: `${config.app.url}/dashboard`,
-                      })
-                      if (res.error) {
-                        toast.error(res.error.message)
-                        setLoader(null)
-                      }
-                    }}
-                    disabled={loader === "google"}
-                  >
-                    {loader === "google" ? (
-                      <RiLoaderLine className="size-5 animate-spin" />
-                    ) : (
-                      <RiGoogleFill className="size-5" />
-                    )}
-                    Continue with Google
-                  </Button>
-                )}
-                <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
-                  By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
-                  <a href="#">Privacy Policy</a>.
-                </div>
+                </form>
+              )}
+              {githubEnabled && (
+                <Button
+                  variant="outline"
+                  type="button"
+                  className="w-full cursor-pointer"
+                  onClick={async () => {
+                    setLoader("github")
+                    const res = await authClient.signIn.social({
+                      provider: "github",
+                      callbackURL: `${config.app.url}/dashboard`,
+                    })
+                    if (res.error) {
+                      toast.error(res.error.message)
+                      setLoader(null)
+                    }
+                  }}
+                  disabled={loader === "github"}
+                >
+                  {loader === "github" ? (
+                    <RiLoaderLine className="size-5 animate-spin" />
+                  ) : (
+                    <RiGithubFill className="size-5" />
+                  )}
+                  Continue with Github
+                </Button>
+              )}
+              {googleEnabled && (
+                <Button
+                  variant="outline"
+                  type="button"
+                  className="w-full cursor-pointer"
+                  onClick={async () => {
+                    setLoader("google")
+                    const res = await authClient.signIn.social({
+                      provider: "google",
+                      callbackURL: `${config.app.url}/dashboard`,
+                    })
+                    if (res.error) {
+                      toast.error(res.error.message)
+                      setLoader(null)
+                    }
+                  }}
+                  disabled={loader === "google"}
+                >
+                  {loader === "google" ? (
+                    <RiLoaderLine className="size-5 animate-spin" />
+                  ) : (
+                    <RiGoogleFill className="size-5" />
+                  )}
+                  Continue with Google
+                </Button>
+              )}
+              <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
+                By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
+                <a href="#">Privacy Policy</a>.
               </div>
-            </>
+            </div>
+          )}
+          {hasNoMethods && (
+            <p className="text-muted-foreground text-center text-sm">
+              No sign-in methods are configured yet.
+            </p>
           )}
         </div>
       </DialogContent>


### PR DESCRIPTION
## What

Follow-up to #530. The email/magic-link field in the sign-in dialog rendered unconditionally, even though the server-side `magicLink` plugin is **not** registered by default. Out of the box it was a dead control: submitting an email just errored. This gates it the same way social providers are gated, so the dialog only shows providers that actually work.

## How

Single source of truth = which providers/plugins are configured on the API. `GET /api/auth/providers` returns one unified list, e.g. `["github","google","magic-link"]`.

- `packages/auth/src/index.ts`: `magicLinkEnabled` is derived from the constructed instance (`auth.options.plugins`), so registering the `magicLink` plugin flips it automatically (no separate flag to keep in sync). Plugins stay inline in `betterAuth()` to preserve the `$Infer.Session` augmentations. `enabledProviders` = `enabledSocialProviders` + `magic-link` (when enabled).
- `api/hono/src/routers/auth.ts`: the route returns `{ providers: enabledProviders }` — one array typed `AuthProvider = "github" | "google" | "magic-link"`, rather than a providers array plus a separate `magicLink` boolean.
- `web/next/src/components/access.tsx`: reads the one list via `includes()`; the email form renders only when `magic-link` is present, the "OR" divider shows only when both an email method and social/agents methods exist (no orphan divider), and a small "No sign-in options are configured yet." note shows when nothing is enabled.
- Docs (`manage/authentication`) updated.

## Verification

- `oxfmt`, `oxlint`, and all 12 `check-types` tasks pass (incl. `@web/next` — Session inference and the `AuthProvider[]` RPC type both resolve).
- Runtime: `auth.options.plugins` → `["open-api","organization","admin"]` (no `magic-link`); `GET /api/auth/providers` → `{"data":{"providers":["github","google"]}}`.
- Browser (agent-browser, `next dev`): with magic link off, the dialog shows social buttons + dev agents-login and **no email field and no "OR" divider** (screenshot captured). The reverse ("email appears once the plugin is registered") follows from the runtime-confirmed derive plus the trivial `includes("magic-link")` gate; not exercised live since wiring the plugin (a `sendMagicLink` sender) is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added magic-link sign-in option, conditionally available when configured on the server.

* **Documentation**
  * Updated authentication configuration guide to clarify magic-link setup and provider detection.

* **Refactor**
  * Improved dynamic detection and rendering of available authentication providers in the login interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->