### PR TITLE
feat(api): type and document the { data | error } response shape

### DIFF
--- a/.github/audit/2026-06-22-api-data-error-response-shape.md
+++ b/.github/audit/2026-06-22-api-data-error-response-shape.md
@@ -1,0 +1,185 @@
+# API `{ data } | { error }` Response Shape — Design & Implementation Plan
+
+Date: 2026-06-22
+Branch: `refactor/api-result-convention` (off `canary`)
+Status: design approved in principle; ready to execute.
+
+## 1. Goal
+
+Every API response is a discriminated union — **`{ data: T }` on success, `{ error: { code, message } }` on failure** — that is:
+
+1. **Owned by the server** (the server declares the shape once; the client never hand-writes it).
+2. **Typed end to end** (the typed client knows both arms of the union for every route).
+3. **Documented** (the OpenAPI / Scalar reference advertises the error responses, not just `200`).
+4. **Consumed cleanly** on the frontend as `{ data, error }` via React Query, with **no `parseResponse`, no hand-rolled `unwrap`/`result` helper**.
+
+A whole-codebase refactor of the client consumption sites is acceptable; the result should be one consistent convention.
+
+## 2. Where we are today (canary)
+
+The runtime envelope already exists and is correct:
+
+- `api/hono/src/lib/error.ts` — `jsonError(c, status, code, message, extra?)` returns `c.json({ error: { code, message, ...extra } }, status)`; `errorHandler` maps `ZodError → 400 VALIDATION_ERROR` and anything else → `500 INTERNAL_SERVER_ERROR`.
+- `api/hono/src/index.ts` — `app.onError(errorHandler)`, `app.notFound(... jsonError ...)`, success handlers return `c.json({ data })`.
+- Documented in `web/next/content/docs/manage/api-conventions.mdx`.
+
+**The gap is not runtime, it is the type and the docs:**
+
+- The typed client (`hc<AppType>`) only knows each route's **declared `200`** body. The error envelope is produced by the _global_ `onError` / `notFound` / validator hooks, which are **not part of `AppType`**, so `res.json()` is typed as success-only and the client cannot see/narrow the error.
+- The OpenAPI document is generated from each route's `describeRoute({ responses })`, which only declares `200`. So the Scalar docs at `/api/docs` **do not show any error responses** — the user's concrete complaint: "I only get the responses I give."
+
+## 3. The core constraint (why this needed exploration)
+
+Three things collide:
+
+- **`fetch` / `hc` resolve on HTTP 4xx/5xx.** A non-2xx is a _successful_ promise with `res.ok === false`; fetch only rejects on a network-level failure.
+- **React Query (`useQuery`/`useMutation`) flips to `error` only when the fn throws.** It never inspects HTTP status.
+- Therefore a non-2xx must be converted, **on the client**, into either a thrown error or a discriminated-union read. The server cannot make the client throw — that is inherently a client concern.
+
+This is why "just let the server own it" does not, by itself, remove a small amount of client glue: the glue is the fetch ↔ React-Query bridge, not a server deficiency.
+
+## 4. Options considered
+
+| #   | Option                                                                  | Verdict                                                                                                                                                                                                                                       |
+| --- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Hand-rolled `unwrap`/`result` helper returning `{ data, error }`        | Rejected — reinvents response parsing; the team found it unsatisfying ("sad").                                                                                                                                                                |
+| 2   | Hono built-in `parseResponse` + `DetailedError`                         | Works and is official, but **throw-based** and buries the structured envelope in `DetailedError.detail.data` (typed `any`). Not the `{ data, error }` shape; awkward for surfacing the server's message. Rejected as the consumption surface. |
+| 3   | `neverthrow` `Result<Ok, Err>`                                          | Adds a dependency + FP ceremony; fights React Query's throw model. Rejected.                                                                                                                                                                  |
+| 4   | `better-fetch` / `ofetch` / `ky`                                        | Do not compose with `hc`'s typed `ClientResponse` (Hono [#4560]). Rejected.                                                                                                                                                                   |
+| 5   | Switch to **oRPC / tRPC** (native safe `{ data, error }` client)        | A framework migration; zerostarter is built on Hono RPC. Rejected.                                                                                                                                                                            |
+| 6   | Server always returns **HTTP 200** with `{ data, error }` body          | Breaks HTTP semantics, the OpenAPI docs, caching, monitoring, the `429`/rate-limit story — and React Query _still_ needs a throw. Anti-pattern. Rejected.                                                                                     |
+| 7   | Re-export `parseResponse` / auto-parsing client                         | Auto-parse needs a recursive re-typing of the whole `hc` client and fights the fetch coupling (Hono [#3894]/[#4560]). Not worth it. Rejected.                                                                                                 |
+| 8   | \*\*Server declares the envelope once; client reads the typed `{ data } | { error }`union via React Query with plain`res.json()`+`if ("error" in body)`\*\*                                                                                                                                                             | **Chosen.** No helper, no `parseResponse`. Matches Hono's own React (SWR) example, whose fetcher is a plain `res.json()`. |
+
+## 5. Final design
+
+**One source of truth → three layers, all derived from it.**
+
+```
+errorEnvelope (zod schema, api/hono/src/lib/error.ts)
+   ├─ runtime  →  jsonError / errorHandler already emit this shape   (unchanged)
+   ├─ types    →  AppType = ApplyGlobalResponse<routes, { 4xx/5xx: errorEnvelope }>
+   └─ docs     →  openAPIRouteHandler defaultOptions = errorResponses(errorEnvelope)
+```
+
+- `jsonError` / `errorHandler` are **kept as-is** — they are the runtime producer and are correct.
+- `ApplyGlobalResponse` (a `hono/client` type helper) merges the error responses into every route's type, so `res.json()` is `{ data } | { error }`.
+- `defaultOptions` (a `hono-openapi` `openAPIRouteHandler` option, keyed by HTTP method, merged into each route's `responses`) makes the Scalar docs list the error responses.
+- The client reads the union and narrows with `if ("error" in body)`. React Query provides the `{ data, error, isPending/isError }` surface.
+
+This was prototyped end-to-end during design and **type-checked clean (`api/hono` + `web/next`, 7/7 tasks)**, and the generated OpenAPI spec was verified to list `200, 400, 401, 403, 404, 429, 500` on every route.
+
+## 6. Implementation plan (file by file)
+
+### Server
+
+**`api/hono/src/lib/error.ts`** — add one schema next to `jsonError` (runtime untouched):
+
+```ts
+import { z } from "zod"
+
+export const errorEnvelope = z.object({
+  error: z.object({ code: z.string(), message: z.string() }),
+})
+```
+
+**`api/hono/src/index.ts`** — derive types + docs from that schema:
+
+```ts
+import type { ApplyGlobalResponse } from "hono/client"
+import { errorEnvelope, errorHandler, jsonError } from "@/lib/error"
+
+const errorResponses = Object.fromEntries(
+  [400, 401, 403, 404, 429, 500].map((s) => [
+    s,
+    { description: "Error", content: { "application/json": { schema: resolver(errorEnvelope) } } },
+  ]),
+)
+
+// ...openAPIRouteHandler(app, {
+//   documentation: { ... },
+//   defaultOptions: { GET: { responses: errorResponses }, POST: { responses: errorResponses } },
+// })
+
+export type AppType = ApplyGlobalResponse<
+  typeof routes,
+  Record<400 | 401 | 403 | 404 | 429 | 500, { json: z.infer<typeof errorEnvelope> }>
+>
+```
+
+### Client — the one canonical pattern
+
+Read the union, narrow with `if ("error" in body)`. No `parseResponse`, no helper.
+
+```ts
+// read that should surface failure (api-status health, auth providers): throw → React Query isError
+const res = await apiClient.health.$get()
+const body = await res.json()
+if ("error" in body) throw new Error("Systems are facing issues")
+return body.data
+
+// soft read (waitlist count): swallow → hide the badge
+const res = await apiClient.waitlist.$get()
+const body = await res.json()
+if ("error" in body) return null
+return body.data.count
+
+// mutation (waitlist submit): useMutation; discriminate in onSuccess; isPending drives the button
+const joinWaitlist = useMutation({
+  mutationFn: async (value: { email: string; subject: string }) => {
+    const res = await apiClient.waitlist.$post({ json: value })
+    return res.json()
+  },
+  onSuccess: (body) => {
+    if ("error" in body) {
+      toast.error(body.error.message)
+      return
+    }
+    setJoined(true)
+    toast.success("You're on the waitlist!")
+    queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
+  },
+})
+```
+
+Call sites to convert (all current Hono RPC consumers):
+
+- `web/next/src/components/api-status.tsx` — health GET (throw on error).
+- `web/next/src/components/access.tsx` — auth providers GET (throw on error).
+- `web/next/src/app/waitlist/page.tsx` — count GET (return null on error) + submit (`useMutation`, drops the manual `loading` state).
+
+**Out of scope:** the Better Auth calls (`authClient.signIn.magicLink` / `.social`, `authClient.organization.create`) are a _different_ client that already returns `{ data, error }` natively. They are left as-is.
+
+### Docs (keep the convention self-documenting)
+
+Update to the `res.json()` + `if ("error" in body)` pattern and note that the server declares the envelope via `ApplyGlobalResponse`:
+
+- `web/next/content/docs/getting-started/type-safe-api.mdx`
+- `web/next/content/docs/manage/api-conventions.mdx`
+- `README.md` and the homepage code sample in `web/next/src/app/page.tsx`
+- OpenAPI `x-codeSamples` in `api/hono/src/index.ts`, `routers/waitlist.ts`, `routers/v1.ts`
+
+## 7. Verification
+
+- `bunx turbo run check-types --filter=@api/hono --filter=@web/next` → clean.
+- `bun run lint` + `bunx oxfmt` on the touched files → clean.
+- Generate the OpenAPI spec and confirm error codes appear on representative routes (done in design via in-process `app.fetch("/api/openapi.json")`).
+- Browser smoke on the running stack: waitlist submit (success + forced error), the API-status badge, and the Scalar docs at `/api/docs` showing the error responses.
+
+## 8. Rollout
+
+- One coherent commit on `refactor/api-result-convention`; PR into `canary`.
+- This branch and PR #533 (TanStack Form parity) both touch `web/next/src/app/waitlist/page.tsx`; expect a small merge reconciliation on whichever lands second.
+
+## 9. Notes / non-goals
+
+- `jsonError`'s optional `extra` (e.g. validation `issues`) is route-specific and intentionally not part of the global `errorEnvelope` type.
+- The 1-line `if ("error" in body)` per call site is the irreducible fetch ↔ React-Query bridge; it is not removable without an anti-pattern (always-200) or a framework swap (oRPC/tRPC).
+
+## Appendix — sources
+
+- Hono RPC guide: <https://hono.dev/docs/guides/rpc> (`parseResponse`, `DetailedError`, `ApplyGlobalResponse`, `InferResponseType`; the only React example is SWR with a plain `res.json()` fetcher)
+- Hono RFC: type helpers for typed RPC error handling — <https://github.com/honojs/hono/issues/4270>
+- Hono issue: RPC client response parsing option — <https://github.com/honojs/hono/issues/3894>
+- Hono issue: `ClientResponse` coupled to native fetch (why ofetch/ky/better-fetch do not compose) — <https://github.com/honojs/hono/issues/4560>
+- Verified locally against `hono@4.12.26` and `hono-openapi@1.3.0`.

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ ZeroStarter uses [Hono RPC](https://hono.dev/docs/guides/rpc) for end-to-end typ
 ```ts
 import { apiClient } from "@/lib/api/client"
 
-// Fully typed request and response
+// Fully typed { data } | { error } union
 const res = await apiClient.health.$get()
-const { data } = await res.json()
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)
+// body.data is fully typed
 ```
 
 ## 🔥 Why ZeroStarter?

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -4,11 +4,12 @@ import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
+import type { ApplyGlobalResponse } from "hono/client"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 import { z } from "zod"
 
-import { errorHandler, jsonError } from "@/lib/error"
+import { errorEnvelope, errorHandler, jsonError } from "@/lib/error"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
@@ -32,6 +33,14 @@ app.use(
 
 app.onError(errorHandler)
 app.notFound((c) => jsonError(c, 404, "NOT_FOUND", "Not Found"))
+
+// The standard error envelope, surfaced on every documented route in the OpenAPI docs.
+const errorResponses = Object.fromEntries(
+  [400, 401, 403, 404, 429, 500].map((status) => [
+    status,
+    { description: "Error", content: { "application/json": { schema: resolver(errorEnvelope) } } },
+  ]),
+)
 
 const routes = app
   .get("/", (c) => {
@@ -58,8 +67,9 @@ const routes = app
             label: "hono/client",
             source: `import { apiClient } from "@/lib/api/client"
 
-const response = await apiClient.health.$get()
-const { data } = await response.json()`,
+const res = await apiClient.health.$get()
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`,
           },
         ],
       } as object),
@@ -103,6 +113,10 @@ const { data } = await response.json()`,
           description: site.apiReferenceDescription,
         },
       },
+      defaultOptions: {
+        GET: { responses: errorResponses },
+        POST: { responses: errorResponses },
+      },
     }),
   )
   .get(
@@ -119,7 +133,11 @@ const { data } = await response.json()`,
     }),
   )
 
-export type AppType = typeof routes
+// The server owns the response shape: ApplyGlobalResponse adds the error envelope to every route's type.
+export type AppType = ApplyGlobalResponse<
+  typeof routes,
+  Record<400 | 401 | 403 | 404 | 429 | 500, { json: z.infer<typeof errorEnvelope> }>
+>
 
 export default {
   port: env.HONO_PORT,

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -4,6 +4,11 @@ import type { Context } from "hono"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { z } from "zod"
 
+// Single source of the API error shape: the runtime (jsonError), the typed client, and the OpenAPI docs all derive from this.
+export const errorEnvelope = z.object({
+  error: z.object({ code: z.string(), message: z.string() }),
+})
+
 export function jsonError<S extends ContentfulStatusCode>(
   c: Context,
   status: S,

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -42,8 +42,9 @@ export const v1Router = new Hono<{
             label: "hono/client",
             source: `import { apiClient } from "@/lib/api/client"
 
-const response = await apiClient.v1.session.$get()
-const { data } = await response.json()`,
+const res = await apiClient.v1.session.$get()
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`,
           },
         ],
       } as object),
@@ -75,8 +76,9 @@ const { data } = await response.json()`,
             label: "hono/client",
             source: `import { apiClient } from "@/lib/api/client"
 
-const response = await apiClient.v1.user.$get()
-const { data } = await response.json()`,
+const res = await apiClient.v1.user.$get()
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`,
           },
         ],
       } as object),

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -30,8 +30,9 @@ export const waitlistRouter = new Hono()
             label: "hono/client",
             source: `import { apiClient } from "@/lib/api/client"
 
-const response = await apiClient.waitlist.$get()
-const { data } = await response.json()`,
+const res = await apiClient.waitlist.$get()
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`,
           },
         ],
       } as object),
@@ -66,8 +67,9 @@ const { data } = await response.json()`,
             label: "hono/client",
             source: `import { apiClient } from "@/lib/api/client"
 
-const response = await apiClient.waitlist.$post({ json: { email: "you@example.com" } })
-const { data } = await response.json()`,
+const res = await apiClient.waitlist.$post({ json: { email: "you@example.com" } })
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`,
           },
         ],
       } as object),

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -19,13 +19,15 @@ This starter utilizes [Hono RPC](https://hono.dev/docs/guides/rpc) to provide en
 
 ### Basic Request
 
+`res.json()` returns a `{ data } | { error }` union — the error arm is declared on the server via `ApplyGlobalResponse`. Narrow it with `"error" in body`:
+
 ```ts
 import { apiClient } from "@/lib/api/client"
 
-// Fully typed request and response
 const res = await apiClient.health.$get()
-const { data } = await res.json()
-// data: { message: string; version: string; environment: "local" | "development" | "test" | "staging" | "production" }
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)
+// body.data: { message: string; version: string; environment: "local" | "development" | "test" | "staging" | "production" }
 ```
 
 ### Authenticated Requests
@@ -37,12 +39,9 @@ import { apiClient } from "@/lib/api/client"
 
 // Protected route - requires authentication
 const res = await apiClient.v1.session.$get()
-const { data } = await res.json()
-// data is typed as Session, or error contains { code: string, message: string }
-
-// Get the current user (also requires authentication)
-const userRes = await apiClient.v1.user.$get()
-const { data: user } = await userRes.json()
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)
+// body.data is typed as Session
 ```
 
 ### Session Data

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -31,7 +31,25 @@ All API responses use a standardized JSON envelope:
 }
 ```
 
-This envelope is produced by the `jsonError(c, status, code, message, extra?)` helper in `api/hono/src/lib/error.ts`, which is the standard way routers and middleware emit errors.
+This envelope is produced by the `jsonError(c, status, code, message, extra?)` helper in `api/hono/src/lib/error.ts`, which is the standard way routers and middleware emit errors. The shape lives once as the `errorEnvelope` schema in that file; the typed client and the OpenAPI docs both derive from it.
+
+### Consuming responses on the client
+
+The typed client returns `res.json()` as a `{ data } | { error }` union — `AppType` (in `api/hono/src/index.ts`) wraps the routes with `ApplyGlobalResponse` so the error envelope is part of every route's type. Narrow it with `"error" in body`:
+
+```ts
+import { apiClient } from "@/lib/api/client"
+
+const res = await apiClient.waitlist.$get()
+const body = await res.json()
+if ("error" in body) {
+  // body.error: { code, message }
+} else {
+  // body.data
+}
+```
+
+With TanStack Query, throw on the error arm and the query surfaces it through `isError`.
 
 ### Error Codes
 
@@ -194,7 +212,8 @@ describeRoute({
       lang: "typescript",
       label: "hono/client",
       source: `const res = await apiClient.v1.session.$get()
-const { data } = await res.json()`,
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`,
     }],
   } as object),
   responses: { ... },

--- a/web/next/src/app/page.tsx
+++ b/web/next/src/app/page.tsx
@@ -180,10 +180,10 @@ export const techStack: Tech[] = [
 export default async function Home() {
   const typescriptCode = `import { apiClient } from "@/lib/api/client"
 
-// Fully typed request and response
-// TypeScript knows exactly what you're getting!
+// Typed { data } | { error } — TypeScript knows exactly what you're getting!
 const res = await apiClient.health.$get()
-const { data } = await res.json()`
+const body = await res.json()
+if ("error" in body) throw new Error(body.error.message)`
 
   const bashCode = `# Clone the template
 bunx gitpick ${site.social.github}/tree/main

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -3,7 +3,7 @@
 import { site } from "@packages/config/site"
 import { RiCheckLine, RiLoaderLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { toast } from "sonner"
 import { z } from "zod"
@@ -26,9 +26,9 @@ function WaitlistCount() {
     queryKey: ["waitlist-count"],
     queryFn: async () => {
       const res = await apiClient.waitlist.$get()
-      if (!res.ok) return null
-      const { data } = await res.json()
-      return data.count
+      const body = await res.json()
+      if ("error" in body) return null
+      return body.data.count
     },
   })
 
@@ -56,9 +56,27 @@ function WaitlistCount() {
 }
 
 export default function WaitlistPage() {
-  const [loading, setLoading] = useState(false)
   const [joined, setJoined] = useState(false)
   const queryClient = useQueryClient()
+
+  const joinWaitlist = useMutation({
+    mutationFn: async (value: { email: string; subject: string }) => {
+      const res = await apiClient.waitlist.$post({ json: value })
+      return res.json()
+    },
+    onSuccess: (body) => {
+      if ("error" in body) {
+        toast.error(body.error.message)
+        return
+      }
+      setJoined(true)
+      toast.success("You're on the waitlist!")
+      queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
+    },
+    onError: () => {
+      toast.error("Something went wrong. Please try again.")
+    },
+  })
 
   const form = useForm({
     // `subject` is a honeypot: humans never see it, bots fill it (dodges browser autofill)
@@ -68,25 +86,8 @@ export default function WaitlistPage() {
       onChange: formSchema,
       onBlur: formSchema,
     },
-    onSubmit: async ({ value }) => {
-      setLoading(true)
-      try {
-        const res = await apiClient.waitlist.$post({
-          json: { email: value.email, subject: value.subject },
-        })
-        if (!res.ok) {
-          const body = (await res.json().catch(() => null)) as {
-            error?: { message?: string }
-          } | null
-          toast.error(body?.error?.message ?? "Something went wrong. Please try again.")
-          return
-        }
-        setJoined(true)
-        toast.success("You're on the waitlist!")
-        queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
-      } finally {
-        setLoading(false)
-      }
+    onSubmit: ({ value }) => {
+      joinWaitlist.mutate(value)
     },
   })
 
@@ -143,7 +144,7 @@ export default function WaitlistPage() {
                       aria-invalid={isInvalid}
                       placeholder="you@example.com"
                       className="h-12 px-4 text-base"
-                      disabled={loading}
+                      disabled={joinWaitlist.isPending}
                     />
                     {isInvalid && (
                       <FieldError
@@ -155,8 +156,17 @@ export default function WaitlistPage() {
                 )
               }}
             </form.Field>
-            <Button type="submit" size="lg" className="h-12 px-6 text-base" disabled={loading}>
-              {loading ? <RiLoaderLine className="animate-spin" /> : "Join the waitlist"}
+            <Button
+              type="submit"
+              size="lg"
+              className="h-12 px-6 text-base"
+              disabled={joinWaitlist.isPending}
+            >
+              {joinWaitlist.isPending ? (
+                <RiLoaderLine className="animate-spin" />
+              ) : (
+                "Join the waitlist"
+              )}
             </Button>
           </form>
         )}

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -41,9 +41,9 @@ export function Access() {
     staleTime: Infinity,
     queryFn: async () => {
       const res = await apiClient.auth.providers.$get()
-      if (!res.ok) throw new Error("Failed to load auth providers")
-      const { data } = await res.json()
-      return data.providers
+      const body = await res.json()
+      if ("error" in body) throw new Error("Failed to load auth providers")
+      return body.data.providers
     },
   })
   const githubEnabled = providers?.includes("github") ?? false

--- a/web/next/src/components/api-status.tsx
+++ b/web/next/src/components/api-status.tsx
@@ -9,10 +9,9 @@ export function ApiStatus() {
     queryKey: ["api-health"],
     queryFn: async () => {
       const res = await apiClient.health.$get()
-      if (!res.ok) {
-        throw new Error("Systems are facing issues")
-      }
-      return res.json()
+      const body = await res.json()
+      if ("error" in body) throw new Error("Systems are facing issues")
+      return body.data
     },
     refetchInterval: 30000,
   })


### PR DESCRIPTION
## Why

Every API response is now a typed `{ data } | { error }` union — **owned by the server, typed end to end, and documented** — consumed on the client via React Query with **no `parseResponse` and no hand-rolled helper**.

Full design write-up: [`.github/audit/2026-06-22-api-data-error-response-shape.md`](.github/audit/2026-06-22-api-data-error-response-shape.md) (problem, the options considered and why, and the final design).

## What

**Server** — one `errorEnvelope` schema drives all three layers:
- `lib/error.ts`: add the `errorEnvelope` zod schema as the single source of the error shape (`jsonError` / `errorHandler` unchanged).
- `index.ts`: `AppType = ApplyGlobalResponse<…>` so the typed client knows the error arm for every route; `openAPIRouteHandler` `defaultOptions` surfaces `400/401/403/404/429/500` on every route in the Scalar docs (previously only `200` was shown).

**Client** — React Query, read the union, narrow with `if ("error" in body)`:
- `api-status.tsx` and `access.tsx` (providers) throw on the error arm → `isError`.
- `waitlist/page.tsx`: count GET returns `null` on error; the submit moves to `useMutation` (drops the manual loading state).
- Better-auth calls untouched (a separate client that already returns `{ data, error }`).

**Docs** — `type-safe-api.mdx`, `api-conventions.mdx`, `README.md`, the homepage sample, and the OpenAPI `x-codeSamples` all show the `res.json()` + `if ("error" in body)` pattern.

## Verification

- `check-types` clean (`api/hono` + `web/next`, 7/7); lint + format clean; pre-commit build passed.
- Live OpenAPI spec verified to list `200, 400, 401, 403, 404, 429, 500` on every route (was `200` only).
- Dev stack runs; `/` and `/waitlist` return 200.

## Note

Touches `web/next/src/app/waitlist/page.tsx`, which PR #533 (TanStack Form parity) also touches — expect a small merge reconciliation on whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API client examples with standardized error handling using type-safe response unions
  * Enhanced error response documentation across guides and API references

* **Refactor**
  * Implemented consistent error envelope format across all API endpoints for unified error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->