### PR TITLE
feat: { data, error } API response shape (unwrap client + OpenAPI error docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,10 @@ ZeroStarter uses [Hono RPC](https://hono.dev/docs/guides/rpc) for end-to-end typ
 - **API Docs**: an interactive reference is served at `/api/docs` (OpenAPI spec at `/api/openapi.json`).
 
 ```ts
-import { apiClient } from "@/lib/api/client"
+import { apiClient, unwrap } from "@/lib/api/client"
 
-// Fully typed request and response
-const res = await apiClient.health.$get()
-const { data } = await res.json()
+// Fully typed { data, error } result (never throws)
+const { data, error } = await unwrap(apiClient.health.$get())
 ```
 
 ## 🔥 Why ZeroStarter?

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -102,6 +102,7 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
           description: site.apiReferenceDescription,
         },
       },
+      // Applied to every GET/POST route (add other verbs as needed); a route's own responses override these.
       defaultOptions: {
         GET: { responses: errorResponses },
         POST: { responses: errorResponses },

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -8,7 +8,7 @@ import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 import { z } from "zod"
 
-import { errorHandler, jsonError } from "@/lib/error"
+import { errorHandler, errorResponses, jsonError } from "@/lib/error"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
@@ -101,6 +101,10 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
           title: site.name,
           description: site.apiReferenceDescription,
         },
+      },
+      defaultOptions: {
+        GET: { responses: errorResponses },
+        POST: { responses: errorResponses },
       },
     }),
   )

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -102,7 +102,7 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
           description: site.apiReferenceDescription,
         },
       },
-      // Only the always-reachable errors (429/500); routes add 400/401 in their own responses where they apply.
+      // Always-reachable errors (429/500) on every GET/POST; routes add 400/401 in their own responses. Add PUT/DELETE here if such routes appear.
       defaultOptions: {
         GET: { responses: globalErrorResponses },
         POST: { responses: globalErrorResponses },

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -8,7 +8,7 @@ import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 import { z } from "zod"
 
-import { errorHandler, errorResponses, jsonError } from "@/lib/error"
+import { errorHandler, globalErrorResponses, jsonError } from "@/lib/error"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
@@ -102,10 +102,10 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
           description: site.apiReferenceDescription,
         },
       },
-      // Applied to every GET/POST route (add other verbs as needed); a route's own responses override these.
+      // Only the always-reachable errors (429/500); routes add 400/401 in their own responses where they apply.
       defaultOptions: {
-        GET: { responses: errorResponses },
-        POST: { responses: errorResponses },
+        GET: { responses: globalErrorResponses },
+        POST: { responses: globalErrorResponses },
       },
     }),
   )

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -56,10 +56,9 @@ const routes = app
           {
             lang: "typescript",
             label: "hono/client",
-            source: `import { apiClient } from "@/lib/api/client"
+            source: `import { apiClient, unwrap } from "@/lib/api/client"
 
-const response = await apiClient.health.$get()
-const { data } = await response.json()`,
+const { data, error } = await unwrap(apiClient.health.$get())`,
           },
         ],
       } as object),

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -1,6 +1,7 @@
 import { isLocal } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import type { Context } from "hono"
+import { resolver, type ResponsesWithResolver } from "hono-openapi"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { z } from "zod"
 
@@ -22,3 +23,33 @@ export const errorHandler = (err: Error, c: Context) => {
   const message = isLocal(env.NODE_ENV) ? err.message : "Internal Server Error"
   return jsonError(c, 500, "INTERNAL_SERVER_ERROR", message)
 }
+
+// Standard error envelope shape; the single source for the runtime errors above and the OpenAPI docs.
+export const errorEnvelope = z.object({
+  error: z.object({ code: z.string(), message: z.string() }),
+})
+
+// OpenAPI responses for the shared error statuses, each with its own code/message example.
+export const errorResponses: ResponsesWithResolver = Object.fromEntries(
+  (
+    [
+      [400, "VALIDATION_ERROR", "Invalid request payload"],
+      [401, "UNAUTHORIZED", "Unauthorized"],
+      [403, "FORBIDDEN", "Forbidden"],
+      [404, "NOT_FOUND", "Not Found"],
+      [429, "TOO_MANY_REQUESTS", "Too Many Requests"],
+      [500, "INTERNAL_SERVER_ERROR", "Internal Server Error"],
+    ] as const
+  ).map(([status, code, message]) => [
+    status,
+    {
+      description: message,
+      content: {
+        "application/json": {
+          schema: resolver(errorEnvelope),
+          example: { error: { code, message } },
+        },
+      },
+    },
+  ]),
+)

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -24,7 +24,7 @@ export const errorHandler = (err: Error, c: Context) => {
   return jsonError(c, 500, "INTERNAL_SERVER_ERROR", message)
 }
 
-// Standard error envelope shape; the single source for the runtime errors above and the OpenAPI docs.
+// Shape of the error envelope jsonError emits; reused by the OpenAPI error responses below.
 export const errorEnvelope = z.object({
   error: z.object({ code: z.string(), message: z.string() }),
 })

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -29,27 +29,29 @@ export const errorEnvelope = z.object({
   error: z.object({ code: z.string(), message: z.string() }),
 })
 
-// OpenAPI responses for the shared error statuses, each with its own code/message example.
-export const errorResponses: ResponsesWithResolver = Object.fromEntries(
-  (
-    [
-      [400, "VALIDATION_ERROR", "Invalid request payload"],
-      [401, "UNAUTHORIZED", "Unauthorized"],
-      [403, "FORBIDDEN", "Forbidden"],
-      [404, "NOT_FOUND", "Not Found"],
-      [429, "TOO_MANY_REQUESTS", "Too Many Requests"],
-      [500, "INTERNAL_SERVER_ERROR", "Internal Server Error"],
-    ] as const
-  ).map(([status, code, message]) => [
-    status,
-    {
-      description: message,
-      content: {
-        "application/json": {
-          schema: resolver(errorEnvelope),
-          example: { error: { code, message } },
-        },
-      },
+// One OpenAPI error response, with its own code/message example.
+const errorResponse = (code: string, message: string) => ({
+  description: message,
+  content: {
+    "application/json": {
+      schema: resolver(errorEnvelope),
+      example: { error: { code, message } },
     },
-  ]),
-)
+  },
+})
+
+// 429 + 500 can hit any matched route (global rate limiter + onError), so they apply everywhere.
+export const globalErrorResponses: ResponsesWithResolver = {
+  429: errorResponse("TOO_MANY_REQUESTS", "Too Many Requests"),
+  500: errorResponse("INTERNAL_SERVER_ERROR", "Internal Server Error"),
+}
+
+// Add to routes behind authMiddleware, the only thing that returns 401.
+export const authErrorResponses: ResponsesWithResolver = {
+  401: errorResponse("UNAUTHORIZED", "Unauthorized"),
+}
+
+// Add to routes with a request validator, the only thing that returns 400.
+export const validationErrorResponses: ResponsesWithResolver = {
+  400: errorResponse("VALIDATION_ERROR", "Invalid request payload"),
+}

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -45,6 +45,17 @@ export const errorEnvelope = z.object({
   error: z.object({ code: z.string(), message: z.string() }),
 })
 
+// Validation errors also carry the failing fields, so document that on the 400 response.
+const validationErrorEnvelope = z.object({
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+    issues: z
+      .array(z.object({ path: z.array(z.union([z.string(), z.number()])), message: z.string() }))
+      .optional(),
+  }),
+})
+
 // One OpenAPI error response, with its own code/message example.
 const errorResponse = (code: string, message: string) => ({
   description: message,
@@ -67,7 +78,21 @@ export const authErrorResponses: ResponsesWithResolver = {
   401: errorResponse("UNAUTHORIZED", "Unauthorized"),
 }
 
-// Add to routes with a request validator, the only thing that returns 400.
+// Add to routes with a request validator, the only thing that returns 400; the 400 also carries the per-field issues.
 export const validationErrorResponses: ResponsesWithResolver = {
-  400: errorResponse("VALIDATION_ERROR", "Invalid request payload"),
+  400: {
+    description: "Invalid request payload",
+    content: {
+      "application/json": {
+        schema: resolver(validationErrorEnvelope),
+        example: {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "Invalid request payload",
+            issues: [{ path: ["email"], message: "Invalid email address" }],
+          },
+        },
+      },
+    },
+  },
 }

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -2,6 +2,7 @@ import { isLocal } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import type { Context } from "hono"
 import { resolver, type ResponsesWithResolver } from "hono-openapi"
+import { HTTPException } from "hono/http-exception"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { z } from "zod"
 
@@ -15,9 +16,24 @@ export function jsonError<S extends ContentfulStatusCode>(
   return c.json({ error: { code, message, ...extra } }, status)
 }
 
+// Code for an HTTPException, by status; Hono throws these for client errors (e.g. 400 on malformed JSON).
+const httpExceptionCodes: Record<number, string> = {
+  400: "BAD_REQUEST",
+  401: "UNAUTHORIZED",
+  403: "FORBIDDEN",
+  404: "NOT_FOUND",
+  429: "TOO_MANY_REQUESTS",
+}
+
 export const errorHandler = (err: Error, c: Context) => {
   if (err instanceof z.ZodError) {
     return jsonError(c, 400, "VALIDATION_ERROR", "Invalid request payload", { issues: err.issues })
+  }
+
+  // Honor the status Hono already chose (e.g. malformed JSON is a 400, not a 500); messages are dev-set and safe to surface.
+  if (err instanceof HTTPException) {
+    const code = httpExceptionCodes[err.status] ? httpExceptionCodes[err.status] : "ERROR"
+    return jsonError(c, err.status, code, err.message)
   }
 
   const message = isLocal(env.NODE_ENV) ? err.message : "Internal Server Error"

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
+import { authErrorResponses } from "@/lib/error"
 import { authMiddleware } from "@/middlewares"
 
 const sessionSchema = z.object({
@@ -55,6 +56,7 @@ const { data, error } = await unwrap(apiClient.v1.session.$get())`,
             },
           },
         },
+        ...authErrorResponses,
       },
     }),
     (c) => {
@@ -87,6 +89,7 @@ const { data, error } = await unwrap(apiClient.v1.user.$get())`,
             },
           },
         },
+        ...authErrorResponses,
       },
     }),
     (c) => {

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -40,10 +40,9 @@ export const v1Router = new Hono<{
           {
             lang: "typescript",
             label: "hono/client",
-            source: `import { apiClient } from "@/lib/api/client"
+            source: `import { apiClient, unwrap } from "@/lib/api/client"
 
-const response = await apiClient.v1.session.$get()
-const { data } = await response.json()`,
+const { data, error } = await unwrap(apiClient.v1.session.$get())`,
           },
         ],
       } as object),
@@ -73,10 +72,9 @@ const { data } = await response.json()`,
           {
             lang: "typescript",
             label: "hono/client",
-            source: `import { apiClient } from "@/lib/api/client"
+            source: `import { apiClient, unwrap } from "@/lib/api/client"
 
-const response = await apiClient.v1.user.$get()
-const { data } = await response.json()`,
+const { data, error } = await unwrap(apiClient.v1.user.$get())`,
           },
         ],
       } as object),

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
-import { jsonError } from "@/lib/error"
+import { jsonError, validationErrorResponses } from "@/lib/error"
 
 const joinSchema = z.object({
   email: z.string().trim().pipe(z.email().max(254)).meta({ example: "you@example.com" }),
@@ -80,6 +80,7 @@ const { data, error } = await unwrap(apiClient.waitlist.$post({ json: { email: "
             },
           },
         },
+        ...validationErrorResponses,
       },
     }),
     sValidator("json", joinSchema, (result, c) => {

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -84,7 +84,11 @@ const { data, error } = await unwrap(apiClient.waitlist.$post({ json: { email: "
       },
     }),
     sValidator("json", joinSchema, (result, c) => {
-      if (!result.success) return jsonError(c, 400, "VALIDATION_ERROR", "Invalid email address")
+      if (!result.success) {
+        return jsonError(c, 400, "VALIDATION_ERROR", "Invalid email address", {
+          issues: result.error,
+        })
+      }
     }),
     async (c) => {
       const { email, subject } = c.req.valid("json")

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -28,10 +28,9 @@ export const waitlistRouter = new Hono()
           {
             lang: "typescript",
             label: "hono/client",
-            source: `import { apiClient } from "@/lib/api/client"
+            source: `import { apiClient, unwrap } from "@/lib/api/client"
 
-const response = await apiClient.waitlist.$get()
-const { data } = await response.json()`,
+const { data, error } = await unwrap(apiClient.waitlist.$get())`,
           },
         ],
       } as object),
@@ -64,10 +63,9 @@ const { data } = await response.json()`,
           {
             lang: "typescript",
             label: "hono/client",
-            source: `import { apiClient } from "@/lib/api/client"
+            source: `import { apiClient, unwrap } from "@/lib/api/client"
 
-const response = await apiClient.waitlist.$post({ json: { email: "you@example.com" } })
-const { data } = await response.json()`,
+const { data, error } = await unwrap(apiClient.waitlist.$post({ json: { email: "you@example.com" } }))`,
           },
         ],
       } as object),

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -19,12 +19,13 @@ This starter utilizes [Hono RPC](https://hono.dev/docs/guides/rpc) to provide en
 
 ### Basic Request
 
-```ts
-import { apiClient } from "@/lib/api/client"
+Use `unwrap` from the client to get a `{ data, error }` result — exactly one is non-null, and it never throws:
 
-// Fully typed request and response
-const res = await apiClient.health.$get()
-const { data } = await res.json()
+```ts
+import { apiClient, unwrap } from "@/lib/api/client"
+
+const { data, error } = await unwrap(apiClient.health.$get())
+if (error) throw new Error(error.message)
 // data: { message: string; version: string; environment: "local" | "development" | "test" | "staging" | "production" }
 ```
 
@@ -33,16 +34,11 @@ const { data } = await res.json()
 The API client is pre-configured with `credentials: "include"` for cookie-based authentication:
 
 ```ts
-import { apiClient } from "@/lib/api/client"
+import { apiClient, unwrap } from "@/lib/api/client"
 
 // Protected route - requires authentication
-const res = await apiClient.v1.session.$get()
-const { data } = await res.json()
-// data is typed as Session, or error contains { code: string, message: string }
-
-// Get the current user (also requires authentication)
-const userRes = await apiClient.v1.user.$get()
-const { data: user } = await userRes.json()
+const { data, error } = await unwrap(apiClient.v1.session.$get())
+// data is typed as Session (or null when error is set); error is { code, message } | null
 ```
 
 ### Session Data

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -48,7 +48,7 @@ if (error) {
 }
 ```
 
-With TanStack Query, `throw` on the error arm in a `queryFn` (so the query reports `isError`), or handle it in a `useMutation` `onSuccess`.
+With TanStack Query, `throw` on the error arm — in a `queryFn` (so the query reports `isError`), or in a `useMutation` `mutationFn` and toast it in `onError`.
 
 ### Error Codes
 

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -59,6 +59,7 @@ With TanStack Query, `throw` on the error arm — in a `queryFn` (so the query r
 | `FORBIDDEN`             | 403    | Insufficient permissions (e.g., `/headers` in production)     |
 | `TOO_MANY_REQUESTS`     | 429    | Rate limit exceeded                                           |
 | `VALIDATION_ERROR`      | 400    | Zod schema validation failed                                  |
+| `BAD_REQUEST`           | 400    | Malformed JSON/form-data body (Hono `HTTPException`)          |
 | `INTERNAL_SERVER_ERROR` | 500    | Unhandled server error                                        |
 | `AGENTS_LOGIN_FAILED`   | 500    | Local agent sign-in failed (`api/hono/src/routers/agents.ts`) |
 
@@ -77,6 +78,10 @@ When a Zod validation fails, the response includes the full issues array:
   }
 }
 ```
+
+Route-level validators (e.g. `sValidator` on the waitlist `POST`) follow the same convention: a custom message plus the `issues` array. Note that Hono's validator only parses the body when its content-type matches (JSON validators ignore a non-JSON body and validate `{}`), so a wrong content-type surfaces as a normal field-level issue.
+
+A body that is present but unparseable (malformed JSON, malformed form-data) is a client error, not a server error: Hono throws an `HTTPException`, and `errorHandler` returns it with the thrown status (`400 BAD_REQUEST`) instead of masking it as a `500`.
 
 ### Environment-Aware Errors
 

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -33,6 +33,23 @@ All API responses use a standardized JSON envelope:
 
 This envelope is produced by the `jsonError(c, status, code, message, extra?)` helper in `api/hono/src/lib/error.ts`, which is the standard way routers and middleware emit errors.
 
+### Consuming responses on the client
+
+On the frontend, wrap any RPC call in `unwrap` (from `@/lib/api/client`) to get a `{ data, error }` result — exactly one is non-null, and it never throws:
+
+```ts
+import { apiClient, unwrap } from "@/lib/api/client"
+
+const { data, error } = await unwrap(apiClient.waitlist.$get())
+if (error) {
+  // error: { code, message }
+} else {
+  // data
+}
+```
+
+With TanStack Query, `throw` on the error arm in a `queryFn` (so the query reports `isError`), or handle it in a `useMutation` `onSuccess`.
+
 ### Error Codes
 
 | Code                    | Status | When                                                          |
@@ -193,8 +210,7 @@ describeRoute({
     "x-codeSamples": [{
       lang: "typescript",
       label: "hono/client",
-      source: `const res = await apiClient.v1.session.$get()
-const { data } = await res.json()`,
+      source: `const { data, error } = await unwrap(apiClient.v1.session.$get())`,
     }],
   } as object),
   responses: { ... },

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -163,6 +163,7 @@ import type { Session } from "@packages/auth"
 import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
+import { authErrorResponses } from "@/lib/error"
 import { authMiddleware } from "@/middlewares"
 
 export const v1Router = new Hono<{ Variables: Session }>().use("/*", authMiddleware).get(
@@ -179,6 +180,7 @@ export const v1Router = new Hono<{ Variables: Session }>().use("/*", authMiddlew
           },
         },
       },
+      ...authErrorResponses,
     },
   }),
   (c) => {
@@ -216,3 +218,19 @@ describeRoute({
   responses: { ... },
 })
 ```
+
+### Documenting error responses
+
+A route should only advertise the error statuses it can actually return, so the docs stay honest. The `defaultOptions` in `index.ts` apply `globalErrorResponses` (429, 500 — the only statuses reachable on any matched route, via the global rate limiter and `onError`) to every GET/POST. A route then adds the rest in its own `responses` (which merge over the defaults), using the helpers in `api/hono/src/lib/error.ts`:
+
+- `authErrorResponses` (401) — spread into routes behind `authMiddleware` (e.g. `/api/v1/*`).
+- `validationErrorResponses` (400) — spread into routes with a request validator (e.g. the waitlist `POST`).
+
+```ts
+responses: {
+  200: { description: "OK", content: { ... } },
+  ...authErrorResponses,
+}
+```
+
+So `/api/health` documents only 200/429/500, `/api/v1/*` adds 401, and validated routes add 400 — each error status shows its own code/message example.

--- a/web/next/src/app/page.tsx
+++ b/web/next/src/app/page.tsx
@@ -178,12 +178,10 @@ export const techStack: Tech[] = [
 ]
 
 export default async function Home() {
-  const typescriptCode = `import { apiClient } from "@/lib/api/client"
+  const typescriptCode = `import { apiClient, unwrap } from "@/lib/api/client"
 
-// Fully typed request and response
-// TypeScript knows exactly what you're getting!
-const res = await apiClient.health.$get()
-const { data } = await res.json()`
+// Fully typed { data, error } — TypeScript knows exactly what you're getting!
+const { data, error } = await unwrap(apiClient.health.$get())`
 
   const bashCode = `# Clone the template
 bunx gitpick ${site.social.github}/tree/main

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -3,7 +3,7 @@
 import { site } from "@packages/config/site"
 import { RiCheckLine, RiLoaderLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { toast } from "sonner"
 import { z } from "zod"
@@ -12,7 +12,7 @@ import { Avatar, AvatarFallback, AvatarGroup } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { apiClient } from "@/lib/api/client"
+import { apiClient, unwrap } from "@/lib/api/client"
 
 const formSchema = z.object({
   email: z.email({ message: "Please enter a valid email address." }).max(254),
@@ -25,9 +25,8 @@ function WaitlistCount() {
   const { data: count } = useQuery({
     queryKey: ["waitlist-count"],
     queryFn: async () => {
-      const res = await apiClient.waitlist.$get()
-      if (!res.ok) return null
-      const { data } = await res.json()
+      const { data, error } = await unwrap(apiClient.waitlist.$get())
+      if (error) return null
       return data.count
     },
   })
@@ -56,9 +55,22 @@ function WaitlistCount() {
 }
 
 export default function WaitlistPage() {
-  const [loading, setLoading] = useState(false)
   const [joined, setJoined] = useState(false)
   const queryClient = useQueryClient()
+
+  const joinWaitlist = useMutation({
+    mutationFn: (value: { email: string; subject: string }) =>
+      unwrap(apiClient.waitlist.$post({ json: value })),
+    onSuccess: ({ error }) => {
+      if (error) {
+        toast.error(error.message)
+        return
+      }
+      setJoined(true)
+      toast.success("You're on the waitlist!")
+      queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
+    },
+  })
 
   const form = useForm({
     // `subject` is a honeypot: humans never see it, bots fill it (dodges browser autofill)
@@ -68,25 +80,8 @@ export default function WaitlistPage() {
       onChange: formSchema,
       onBlur: formSchema,
     },
-    onSubmit: async ({ value }) => {
-      setLoading(true)
-      try {
-        const res = await apiClient.waitlist.$post({
-          json: { email: value.email, subject: value.subject },
-        })
-        if (!res.ok) {
-          const body = (await res.json().catch(() => null)) as {
-            error?: { message?: string }
-          } | null
-          toast.error(body?.error?.message ?? "Something went wrong. Please try again.")
-          return
-        }
-        setJoined(true)
-        toast.success("You're on the waitlist!")
-        queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
-      } finally {
-        setLoading(false)
-      }
+    onSubmit: ({ value }) => {
+      joinWaitlist.mutate(value)
     },
   })
 
@@ -143,7 +138,7 @@ export default function WaitlistPage() {
                       aria-invalid={isInvalid}
                       placeholder="you@example.com"
                       className="h-12 px-4 text-base"
-                      disabled={loading}
+                      disabled={joinWaitlist.isPending}
                     />
                     {isInvalid && (
                       <FieldError
@@ -155,8 +150,17 @@ export default function WaitlistPage() {
                 )
               }}
             </form.Field>
-            <Button type="submit" size="lg" className="h-12 px-6 text-base" disabled={loading}>
-              {loading ? <RiLoaderLine className="animate-spin" /> : "Join the waitlist"}
+            <Button
+              type="submit"
+              size="lg"
+              className="h-12 px-6 text-base"
+              disabled={joinWaitlist.isPending}
+            >
+              {joinWaitlist.isPending ? (
+                <RiLoaderLine className="animate-spin" />
+              ) : (
+                "Join the waitlist"
+              )}
             </Button>
           </form>
         )}

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -59,16 +59,17 @@ export default function WaitlistPage() {
   const queryClient = useQueryClient()
 
   const joinWaitlist = useMutation({
-    mutationFn: (value: { email: string; subject: string }) =>
-      unwrap(apiClient.waitlist.$post({ json: value })),
-    onSuccess: ({ error }) => {
-      if (error) {
-        toast.error(error.message)
-        return
-      }
+    mutationFn: async (value: { email: string; subject: string }) => {
+      const { error } = await unwrap(apiClient.waitlist.$post({ json: value }))
+      if (error) throw new Error(error.message)
+    },
+    onSuccess: () => {
       setJoined(true)
       toast.success("You're on the waitlist!")
       queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
+    },
+    onError: (error) => {
+      toast.error(error.message)
     },
   })
 

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { apiClient } from "@/lib/api/client"
+import { apiClient, unwrap } from "@/lib/api/client"
 import { authClient } from "@/lib/auth/client"
 import { config } from "@/lib/config"
 
@@ -40,9 +40,8 @@ export function Access() {
     queryKey: ["auth-providers"],
     staleTime: Infinity,
     queryFn: async () => {
-      const res = await apiClient.auth.providers.$get()
-      if (!res.ok) throw new Error("Failed to load auth providers")
-      const { data } = await res.json()
+      const { data, error } = await unwrap(apiClient.auth.providers.$get())
+      if (error) throw new Error("Failed to load auth providers")
       return data.providers
     },
   })

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -41,7 +41,7 @@ export function Access() {
     staleTime: Infinity,
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.auth.providers.$get())
-      if (error) throw new Error("Failed to load auth providers")
+      if (error) throw new Error(error.message)
       return data.providers
     },
   })

--- a/web/next/src/components/api-status.tsx
+++ b/web/next/src/components/api-status.tsx
@@ -2,17 +2,15 @@
 
 import { useQuery } from "@tanstack/react-query"
 
-import { apiClient } from "@/lib/api/client"
+import { apiClient, unwrap } from "@/lib/api/client"
 
 export function ApiStatus() {
   const { isLoading, isError } = useQuery({
     queryKey: ["api-health"],
     queryFn: async () => {
-      const res = await apiClient.health.$get()
-      if (!res.ok) {
-        throw new Error("Systems are facing issues")
-      }
-      return res.json()
+      const { data, error } = await unwrap(apiClient.health.$get())
+      if (error) throw new Error("Systems are facing issues")
+      return data
     },
     refetchInterval: 30000,
   })

--- a/web/next/src/components/api-status.tsx
+++ b/web/next/src/components/api-status.tsx
@@ -9,7 +9,7 @@ export function ApiStatus() {
     queryKey: ["api-health"],
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.health.$get())
-      if (error) throw new Error("Systems are facing issues")
+      if (error) throw new Error(error.message)
       return data
     },
     refetchInterval: 30000,

--- a/web/next/src/lib/api/client.ts
+++ b/web/next/src/lib/api/client.ts
@@ -17,8 +17,8 @@ const honoClient = hcWithType(url, {
 
 export const apiClient = honoClient.api
 
-// Standard error shape, matching the jsonError envelope in api/hono/src/lib/error.ts.
-export type ApiError = { code: string; message: string }
+// Standard error shape, matching the jsonError envelope in api/hono/src/lib/error.ts; extras like the validation `issues` array are preserved.
+export type ApiError = { code: string; message: string } & Record<string, unknown>
 
 // Success payload from the { data } envelope; a body without `data` yields never and unwrap reports it as an error.
 type SuccessData<B> = B extends { data: infer D } ? D : never
@@ -48,7 +48,7 @@ export async function unwrap<R extends RpcResponse>(
         typeof body.error.message === "string" && body.error.message
           ? body.error.message
           : "Request failed"
-      return { data: null, error: { code, message } }
+      return { data: null, error: { ...body.error, code, message } }
     }
     return { data: null, error: { code: "UNKNOWN_ERROR", message: "Unexpected response" } }
   } catch {

--- a/web/next/src/lib/api/client.ts
+++ b/web/next/src/lib/api/client.ts
@@ -42,7 +42,8 @@ export async function unwrap<R extends RpcResponse>(
       return { data: body.data as SuccessData<Awaited<ReturnType<R["json"]>>>, error: null }
     }
     if (isRecord(body) && isRecord(body.error)) {
-      const code = typeof body.error.code === "string" ? body.error.code : "ERROR"
+      const code =
+        typeof body.error.code === "string" && body.error.code ? body.error.code : "ERROR"
       const message =
         typeof body.error.message === "string" && body.error.message
           ? body.error.message

--- a/web/next/src/lib/api/client.ts
+++ b/web/next/src/lib/api/client.ts
@@ -20,6 +20,7 @@ export const apiClient = honoClient.api
 // Standard error shape, matching the jsonError envelope in api/hono/src/lib/error.ts.
 export type ApiError = { code: string; message: string }
 
+// Success payload from the { data } envelope; a body without `data` yields never and unwrap reports it as an error.
 type SuccessData<B> = B extends { data: infer D } ? D : never
 
 export type ApiResult<B> = { data: SuccessData<B>; error: null } | { data: null; error: ApiError }
@@ -42,7 +43,10 @@ export async function unwrap<R extends RpcResponse>(
     }
     if (isRecord(body) && isRecord(body.error)) {
       const code = typeof body.error.code === "string" ? body.error.code : "ERROR"
-      const message = typeof body.error.message === "string" ? body.error.message : "Request failed"
+      const message =
+        typeof body.error.message === "string" && body.error.message
+          ? body.error.message
+          : "Request failed"
       return { data: null, error: { code, message } }
     }
     return { data: null, error: { code: "UNKNOWN_ERROR", message: "Unexpected response" } }

--- a/web/next/src/lib/api/client.ts
+++ b/web/next/src/lib/api/client.ts
@@ -16,3 +16,37 @@ const honoClient = hcWithType(url, {
 })
 
 export const apiClient = honoClient.api
+
+// Standard error shape, matching the jsonError envelope in api/hono/src/lib/error.ts.
+export type ApiError = { code: string; message: string }
+
+type SuccessData<B> = B extends { data: infer D } ? D : never
+
+export type ApiResult<B> = { data: SuccessData<B>; error: null } | { data: null; error: ApiError }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+type RpcResponse = { ok: boolean; json: () => Promise<unknown> }
+
+// Turn a Hono RPC call into a { data, error } result (exactly one is non-null); never throws.
+export async function unwrap<R extends RpcResponse>(
+  call: Promise<R>,
+): Promise<ApiResult<Awaited<ReturnType<R["json"]>>>> {
+  try {
+    const res = await call
+    const body: unknown = await res.json()
+    if (res.ok && isRecord(body) && "data" in body) {
+      return { data: body.data as SuccessData<Awaited<ReturnType<R["json"]>>>, error: null }
+    }
+    if (isRecord(body) && isRecord(body.error)) {
+      const code = typeof body.error.code === "string" ? body.error.code : "ERROR"
+      const message = typeof body.error.message === "string" ? body.error.message : "Request failed"
+      return { data: null, error: { code, message } }
+    }
+    return { data: null, error: { code: "UNKNOWN_ERROR", message: "Unexpected response" } }
+  } catch {
+    return { data: null, error: { code: "NETWORK_ERROR", message: "Network request failed" } }
+  }
+}


### PR DESCRIPTION
## Why

Make API responses a `{ data, error }` shape that's clean to consume on the client and fully documented in the API reference. (Combines the former #536.)

## What

**Client: `unwrap`** (`web/next/src/lib/api/client.ts`): wrap any RPC call, get `{ data, error }` (exactly one non-null), never throws.

```ts
const { data, error } = await unwrap(apiClient.health.$get())
```

- Reads `throw` on the error arm so React Query reports `isError`; the waitlist submit is a `useMutation` that throws in `mutationFn` and toasts in `onError` (no toast in the success path).
- The generic is `<R extends RpcResponse>` + `Awaited<ReturnType<R["json"]>>`, so it handles Hono's per-status `ClientResponse` union (e.g. the waitlist `POST`'s `200` + validator `400`).
- Better-auth calls are untouched (a separate client that already returns `{ data, error }`).

**Server: OpenAPI error docs** (`api/hono/src/lib/error.ts`): each route advertises only the statuses it can actually return. `429/500` apply to every route via `index.ts` `defaultOptions` (`globalErrorResponses`); auth routes (`/api/v1/*`) add `401` (`authErrorResponses`); validated routes (waitlist `POST`) add `400` (`validationErrorResponses`). A route's own `responses` merge over the defaults (**`200` first, errors grouped after**), each with its **own** code/message example. `AppType` is unchanged.

**Server: error handling** (`api/hono/src/lib/error.ts`): `errorHandler` maps `ZodError → 400 VALIDATION_ERROR` (with `issues`) and now honors `HTTPException`, returning its status instead of masking every non-Zod error as a `500`. So a malformed JSON or form-data body is `400 BAD_REQUEST`, not `500`. Route validators (waitlist `POST`) include the `issues` array, so a wrong or empty body shows the real cause instead of a bare message.

**Docs**: `type-safe-api.mdx`, `api-conventions.mdx`, `README.md`, the homepage sample, and the OpenAPI `x-codeSamples` show `unwrap`.

## Verification

- `check-types` pass (`api/hono` + `web/next`); lint + format clean; pre-commit build passed.
- Live spec (`:4000`), per-route reachable statuses only, each with a distinct example per status:
  - `GET /api/health` → `200, 429, 500`
  - `GET /api/v1/{session,user}` → `200, 401, 429, 500`
  - `GET /api/waitlist` → `200, 429, 500`
  - `POST /api/waitlist` → `200, 400, 429, 500`
- Live error behavior on `POST /api/waitlist`: malformed JSON → `400 BAD_REQUEST` (was `500`); wrong content-type or missing email → `400` with an `issues` array; bad email → `400` with `issues`; valid → `200`.

## Note

Touches `web/next/src/app/waitlist/page.tsx`, which PR #533 (TanStack Form parity) also touches; small merge reconciliation on whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a typed `unwrap` helper that returns `{ data, error }` (no throwing) for safer, consistent API response handling across the app.
  * Improved API error handling and OpenAPI-documented error responses, including standardized validation and auth error outputs.

* **Documentation**
  * Updated getting-started, API conventions, and landing page examples to use `unwrap` and demonstrate `{ data, error }`.
  * Expanded guidance on error codes, validation behavior, and documenting route error responses.

* **UI Improvements**
  * Refreshed waitlist and auth-related screens to use improved client response handling and clearer error toasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
