### PR TITLE
feat(api): advertise the standard error responses in the OpenAPI docs

### DIFF
--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -8,7 +8,7 @@ import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 import { z } from "zod"
 
-import { errorHandler, jsonError } from "@/lib/error"
+import { errorEnvelope, errorHandler, jsonError } from "@/lib/error"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
@@ -32,6 +32,31 @@ app.use(
 
 app.onError(errorHandler)
 app.notFound((c) => jsonError(c, 404, "NOT_FOUND", "Not Found"))
+
+// Standard error envelope shown on every documented route, each with its own status code/message example.
+const errorResponses = Object.fromEntries(
+  (
+    [
+      [400, "VALIDATION_ERROR", "Invalid request payload"],
+      [401, "UNAUTHORIZED", "Unauthorized"],
+      [403, "FORBIDDEN", "Forbidden"],
+      [404, "NOT_FOUND", "Not Found"],
+      [429, "TOO_MANY_REQUESTS", "Too Many Requests"],
+      [500, "INTERNAL_SERVER_ERROR", "Internal Server Error"],
+    ] as const
+  ).map(([status, code, message]) => [
+    status,
+    {
+      description: message,
+      content: {
+        "application/json": {
+          schema: resolver(errorEnvelope),
+          example: { error: { code, message } },
+        },
+      },
+    },
+  ]),
+)
 
 const routes = app
   .get("/", (c) => {
@@ -102,6 +127,10 @@ const { data } = await response.json()`,
           title: site.name,
           description: site.apiReferenceDescription,
         },
+      },
+      defaultOptions: {
+        GET: { responses: errorResponses },
+        POST: { responses: errorResponses },
       },
     }),
   )

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -4,6 +4,11 @@ import type { Context } from "hono"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { z } from "zod"
 
+// Single source of the API error shape, reused by the OpenAPI error responses in index.ts.
+export const errorEnvelope = z.object({
+  error: z.object({ code: z.string(), message: z.string() }),
+})
+
 export function jsonError<S extends ContentfulStatusCode>(
   c: Context,
   status: S,


### PR DESCRIPTION
## Why

The OpenAPI / Scalar docs at `/api/docs` only listed each route's declared `200` — the standard `jsonError` error envelope (`{ error: { code, message } }`) was invisible. This advertises it on every route, with a correct per-status example.

Follow-up to #535 (the client `{ data, error }` / `unwrap` work).

## What

- `lib/error.ts`: add the `errorEnvelope` zod schema as the single source of the error shape (`jsonError` / `errorHandler` unchanged).
- `index.ts`: `openAPIRouteHandler` `defaultOptions: { GET/POST: { responses } }` adds `400/401/403/404/429/500` to every documented route, **each with its own code/message example** (e.g. `401 → UNAUTHORIZED / "Unauthorized"`, `400 → VALIDATION_ERROR / "Invalid request payload"`) — not one shared `INTERNAL_SERVER_ERROR` body.

`AppType` is unchanged — docs-only; the client (`unwrap`) returns a fixed `ApiError` and needs no typed error arm.

## Ordering

OpenAPI `responses` are integer-keyed, so they serialize in ascending status order — **`200` first, then the error codes grouped after** (`400, 401, 403, 404, 429, 500`).

## Verification

- `check-types` clean (`api/hono`); lint + format clean; pre-commit build passed.
- Generated spec confirms the order `200, 400, 401, 403, 404, 429, 500` and a distinct example per status.

## Note

Touches `api/hono/src/index.ts`, which #535 also edits (the health `x-codeSamples` string) — different regions, so it auto-merges; no real conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized API error responses with consistent OpenAPI documentation for GET and POST endpoints, ensuring uniform error format across the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->