### PR TITLE
fix(cli): create main locally so a fork's release flow works from the get-go

### DIFF
--- a/.github/workflows/auto-canary-into-main.yml
+++ b/.github/workflows/auto-canary-into-main.yml
@@ -28,14 +28,12 @@ jobs:
           BRANCH_ERR="$(mktemp)"
           if ! gh api repos/${{ github.repository }}/branches/main >/dev/null 2>"$BRANCH_ERR"; then
             if grep -q "HTTP 404" "$BRANCH_ERR"; then
-              echo "No main branch yet (fresh fork starts on canary); seeding main from canary's root commit so the first release PR can open."
-              ROOT=$(git rev-list --max-parents=0 HEAD | tail -1)
-              gh api -X POST repos/${{ github.repository }}/git/refs -f ref="refs/heads/main" -f sha="$ROOT"
-            else
-              echo "Failed to check for the main branch:" >&2
-              cat "$BRANCH_ERR" >&2
-              exit 1
+              echo "No main branch yet. A fork's main is created by the CLI and pushed (git push origin canary main); nothing to release until it exists. Skipping."
+              exit 0
             fi
+            echo "Failed to check for the main branch:" >&2
+            cat "$BRANCH_ERR" >&2
+            exit 1
           fi
           AHEAD=$(gh api repos/${{ github.repository }}/compare/main...canary --jq '.ahead_by')
           if [ "$AHEAD" -eq 0 ]; then

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -4,7 +4,7 @@ import { parseArgs } from "node:util"
 
 import { convertRepo } from "@/convert"
 import { dockerRunning, hasPostgresUrl, provisionDatabase, seedEnv } from "@/db"
-import { bunInstall, fetchZerostarter, gitCommitAll, gitInit } from "@/git"
+import { bunInstall, fetchZerostarter, gitBranch, gitCommitAll, gitInit } from "@/git"
 import { exists } from "@/io"
 
 import { green, isInteractive, orange, promptConfirm, promptText, yellow } from "./_prompt"
@@ -96,6 +96,8 @@ export const init = async (argv: string[]) => {
   if (!exists(join(target, ".git"))) {
     gitInit(target)
     gitCommitAll(target, "chore: scaffold from zerostarter")
+    // Seed `main` at the scaffold commit so canary leads it by the re-baseline; the first push then opens a canary->main release PR (a fork's Actions token cannot create main itself).
+    gitBranch(target, "main")
   }
 
   console.log("Removing starter content and rebranding ...")
@@ -151,6 +153,8 @@ export const init = async (argv: string[]) => {
     console.log(`  ${orange("bun run db:migrate")}`)
   }
   console.log(`  ${orange("bun dev")}`)
+  console.log("\nWhen you push to GitHub, push both branches so the release flow works:")
+  console.log(`  ${orange("git push origin canary main")}`)
   console.log("\nMake it yours:")
   for (const [path, desc] of tips) console.log(`  ${path.padEnd(29)} ${desc}`)
 }

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -153,7 +153,9 @@ export const init = async (argv: string[]) => {
     console.log(`  ${orange("bun run db:migrate")}`)
   }
   console.log(`  ${orange("bun dev")}`)
-  console.log("\nWhen you push to GitHub, push both branches so the release flow works:")
+  console.log(
+    "\nWhen you push to GitHub, push both branches together (main must exist when canary is pushed):",
+  )
   console.log(`  ${orange("git push origin canary main")}`)
   console.log("\nMake it yours:")
   for (const [path, desc] of tips) console.log(`  ${path.padEnd(29)} ${desc}`)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -13,9 +13,14 @@ export const bunInstall = (dir: string): void => {
   run("bun", ["install"], dir)
 }
 
-// Start a fresh git repo in `dir` on the `canary` working branch (no commit yet); `main` is the release target, created on the first canary->main release.
+// Start a fresh git repo in `dir` on the `canary` working branch (no commit yet).
 export const gitInit = (dir: string): void => {
   run("git", ["init", "-q", "-b", "canary"], dir)
+}
+
+// Create a branch at the current HEAD without checking it out (used to seed `main` from the scaffold commit).
+export const gitBranch = (dir: string, name: string): void => {
+  run("git", ["branch", name], dir)
 }
 
 // Stage everything and commit, bypassing the fork's hooks (bun install may have installed

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -22,7 +22,7 @@ This guide will walk you through installing and setting up ZeroStarter on your l
    npx zerostarter@latest init
    ```
 
-   This fetches the latest ZeroStarter, removes the sample content, rebrands it to your project, installs dependencies, and creates `.env` from `.env.example` with a generated `BETTER_AUTH_SECRET`. When Docker is running it also offers to provision a local Postgres (via [pglaunch](https://github.com/nrjdalal/pglaunch)) and run migrations; pass `--db` to do that without prompting. A fresh fork starts on `canary` with `main` seeded from the initial commit (canary is one commit ahead). When you publish to GitHub, push both branches (`git push origin canary main`) so the `canary` to `main` release flow works.
+   This fetches the latest ZeroStarter, removes the sample content, rebrands it to your project, installs dependencies, and creates `.env` from `.env.example` with a generated `BETTER_AUTH_SECRET`. When Docker is running it also offers to provision a local Postgres (via [pglaunch](https://github.com/nrjdalal/pglaunch)) and run migrations; pass `--db` to do that without prompting. A fresh fork starts on `canary` with `main` seeded from the initial commit (canary is one commit ahead). When you publish to GitHub, push both branches together (`git push origin canary main`) so the `canary` to `main` release flow works. `main` must exist when `canary` is pushed; if you push `canary` alone first, the release PR opens only on the next `canary` push or a manual `auto-canary-into-main` run.
 
 2. Set up environment variables:
 

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -22,7 +22,7 @@ This guide will walk you through installing and setting up ZeroStarter on your l
    npx zerostarter@latest init
    ```
 
-   This fetches the latest ZeroStarter, removes the sample content, rebrands it to your project, installs dependencies, and creates `.env` from `.env.example` with a generated `BETTER_AUTH_SECRET`. When Docker is running it also offers to provision a local Postgres (via [pglaunch](https://github.com/nrjdalal/pglaunch)) and run migrations; pass `--db` to do that without prompting. A fresh fork starts on a `canary` branch (`main` is created on your first release).
+   This fetches the latest ZeroStarter, removes the sample content, rebrands it to your project, installs dependencies, and creates `.env` from `.env.example` with a generated `BETTER_AUTH_SECRET`. When Docker is running it also offers to provision a local Postgres (via [pglaunch](https://github.com/nrjdalal/pglaunch)) and run migrations; pass `--db` to do that without prompting. A fresh fork starts on `canary` with `main` seeded from the initial commit (canary is one commit ahead). When you publish to GitHub, push both branches (`git push origin canary main`) so the `canary` to `main` release flow works.
 
 2. Set up environment variables:
 


### PR DESCRIPTION
## Summary

Follow-up to #539. A fork's Actions `GITHUB_TOKEN` **cannot create a branch** — `POST .../git/refs` returns `403 Resource not accessible by integration` even with `contents: write` and no rulesets (confirmed on a live fork). So #539's attempt to seed `main` from the workflow can detect a missing `main` but never create it; the run just 403s.

This moves `main` creation to where it actually has permission: **the CLI, locally**.

## Changes

- **CLI creates `main`** (`git.ts` `gitBranch`, `init.ts`): after the scaffold commit, seed `main` there, so `canary` leads `main` by the re-baseline commit. When the user pushes both branches, `main` exists on GitHub (created by their push, not the Actions token), and the first push opens a `canary → main` release PR.
- **Push guidance**: init's "next steps" and `setup.mdx` tell users to `git push origin canary main`.
- **Workflow simplified**: `auto-canary-into-main` no longer tries to create `main` (it can't on a fork). A genuine 404 skips gracefully; non-404 errors still fail loudly (keeps CodeRabbit's distinction from #539).
- Bump CLI to `0.0.10`.

## Verification

Built, type-checked, 8/8 tests. Ran the built CLI into a fresh dir: it creates both `canary` and `main`, with `canary` one commit ahead (`main` = scaffold commit, `canary` = re-baseline). On the live demo, once `main` existed the workflow went green and opened the release PR, confirming branch creation was the token's only blocked operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository initialization now explicitly creates both `canary` and `main` branches with proper setup for the release workflow.

* **Chores**
  * Version bumped to 0.0.10.
  * Documentation updated to reflect new initialization behavior and branch push requirements for release flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->