### PR TITLE
feat(web): restyle waitlist success message, stack form on mobile

### DIFF
--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -30,7 +30,7 @@ Bun v1.3.10 or later (matching the repo's `packageManager` pin). Docker is requi
 
    <Callout type="info">
 
-   You only need `git push origin canary`. A pre-push hook pushes `main` the first time (the `canary` to `main` release flow needs `main` on the remote) and prints the link to enable read-write Actions permissions.
+   You only need `git push origin canary`. Pushing `canary` first makes it your default branch; on your next push a pre-push hook seeds `main` (the `canary` to `main` release flow needs `main` on the remote) and prints a link to enable read-write Actions permissions. See [Release Management](/docs/manage/release) for the full flow.
 
    </Callout>
 

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { site } from "@packages/config/site"
-import { RiCheckLine, RiLoaderLine } from "@remixicon/react"
+import { RiLoaderLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
@@ -93,14 +93,13 @@ export default function WaitlistPage() {
         <p className="text-muted-foreground mb-8 max-w-md text-lg">{site.tagline}</p>
 
         {joined ? (
-          // same height/width as the form row, so submitting never shifts the layout
-          <div className="text-muted-foreground flex h-12 w-full items-center justify-center gap-2 text-base">
-            <RiCheckLine className="size-5 text-green-500" />
+          // matches the single-row form height so submitting never shifts the layout (sm+); on mobile the form stacks
+          <div className="flex min-h-12 w-full items-center justify-center text-lg text-green-500">
             {"You're on the list. We'll be in touch soon."}
           </div>
         ) : (
           <form
-            className="flex w-full items-center gap-2"
+            className="flex w-full flex-col gap-2 sm:flex-row sm:items-center"
             onSubmit={(e) => {
               e.preventDefault()
               form.handleSubmit()
@@ -125,7 +124,7 @@ export default function WaitlistPage() {
                 const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
                 return (
                   // relative so the error can be absolutely positioned and never grow the row
-                  <Field data-invalid={isInvalid} className="relative flex-1">
+                  <Field data-invalid={isInvalid} className="relative w-full sm:flex-1">
                     <FieldLabel htmlFor={field.name} className="sr-only">
                       Email
                     </FieldLabel>
@@ -138,7 +137,7 @@ export default function WaitlistPage() {
                       onChange={(e) => field.handleChange(e.target.value)}
                       aria-invalid={isInvalid}
                       placeholder="you@example.com"
-                      className="h-12 px-4 text-base"
+                      className="h-12 px-4 text-center text-base sm:text-left"
                       disabled={joinWaitlist.isPending}
                     />
                     {isInvalid && (
@@ -154,7 +153,7 @@ export default function WaitlistPage() {
             <Button
               type="submit"
               size="lg"
-              className="h-12 px-6 text-base"
+              className="h-12 w-full px-6 text-base sm:w-auto"
               disabled={joinWaitlist.isPending}
             >
               {joinWaitlist.isPending ? (

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -65,7 +65,6 @@ export default function WaitlistPage() {
     },
     onSuccess: () => {
       setJoined(true)
-      toast.success("You're on the list.")
       queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
     },
     onError: (error) => {

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -123,7 +123,7 @@ export default function WaitlistPage() {
               {(field) => {
                 const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid
                 return (
-                  // relative so the error can be absolutely positioned and never grow the row
+                  // relative anchors the absolute (sm+) error; on mobile it stays in-flow so it never overlaps the stacked button
                   <Field data-invalid={isInvalid} className="relative w-full sm:flex-1">
                     <FieldLabel htmlFor={field.name} className="sr-only">
                       Email
@@ -142,7 +142,7 @@ export default function WaitlistPage() {
                     />
                     {isInvalid && (
                       <FieldError
-                        className="absolute top-full left-0 mt-1 text-left"
+                        className="mt-1 text-center sm:absolute sm:top-full sm:left-0 sm:text-left"
                         errors={field.state.meta.errors}
                       />
                     )}

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -65,7 +65,7 @@ export default function WaitlistPage() {
     },
     onSuccess: () => {
       setJoined(true)
-      toast.success("You're on the waitlist!")
+      toast.success("You're on the list.")
       queryClient.invalidateQueries({ queryKey: ["waitlist-count"] })
     },
     onError: (error) => {


### PR DESCRIPTION
## What

Polish the waitlist page and fold in a related docs fix (kept to one PR).

**Waitlist UI** (`web/next/src/app/waitlist/page.tsx`):
- Success message: drop the check icon, match the tagline size (`text-lg`), color it **green** (`text-green-500`); `min-h-12` so it can wrap.
- Form (mobile): stacks to two lines — full-width input over full-width button (`flex-col` → `sm:flex-row`).
- Input (mobile): text/placeholder centered (`text-center` → `sm:text-left`).
- Validation error: in-flow on mobile (pushes the button down, no overlap), absolute on `sm+` (desktop row never grows).
- Toast copy now matches the on-screen confirmation ("You're on the list.").
- Desktop layout unchanged (single row, left-aligned input).

**Docs** (`web/next/content/docs/getting-started/setup.mdx`):
- Correct the fresh-fork publish callout to the **canary-first** flow shipped in v0.0.55: pushing `canary` first makes it the default branch; the hook seeds `main` on the *next* push (it no longer "pushes main the first time"). Aligns with `manage/release.mdx` and `manage/code-quality.mdx`.

## Verification

agent-browser at 390px and 1280px:
- Mobile: two-line form, centered input, green wrapping confirmation, and the invalid-email error sits below the input (no button overlap).
- Desktop: single row, left-aligned input, error absolute below the field (no row growth).

The `min-h-12` keeps the no-layout-shift behavior between form and success states on `sm+` (mobile shift is intentional, since the stacked form is taller).

## Commits
- `feat(web)` restyle success message + stack form on mobile
- `fix(web)` keep mobile validation error from overlapping the button
- `fix(web)` match the toast to the on-screen confirmation copy
- `docs(setup)` correct fork-publish flow to canary-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)