### PR TITLE
docs(setup): correct fork-publish flow to canary-first

### DIFF
--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -30,7 +30,7 @@ Bun v1.3.10 or later (matching the repo's `packageManager` pin). Docker is requi
 
    <Callout type="info">
 
-   You only need `git push origin canary`. A pre-push hook pushes `main` the first time (the `canary` to `main` release flow needs `main` on the remote) and prints the link to enable read-write Actions permissions.
+   You only need `git push origin canary`. Pushing `canary` first makes it your default branch; on your next push a pre-push hook seeds `main` (the `canary` to `main` release flow needs `main` on the remote) and prints a link to enable read-write Actions permissions. See [Release Management](/docs/manage/release) for the full flow.
 
    </Callout>
 


### PR DESCRIPTION
## What

Fix stale wording in `getting-started/setup.mdx`. The fresh-fork publish callout said:

> A pre-push hook pushes `main` the first time

That predates the **canary-first** flow shipped in v0.0.55 (CLI `0.0.12`). It now reads:

> Pushing `canary` first makes it your default branch; on your next push a pre-push hook seeds `main` … and prints a link to enable read-write Actions permissions.

Also links out to **Release Management** for the full flow.

## Why

`manage/release.mdx` and `manage/code-quality.mdx` were already updated for canary-first; `getting-started/setup.mdx` was missed and described the old "push main on the first push" behavior, which the hook no longer does (it seeds `main` on the *second* push, after `canary` exists and GitHub has made it the default branch).

Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)