### PR TITLE
feat(api): centralize Hono route plumbing in defineRoute/ok/validate helpers

### DIFF
--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -9,11 +9,13 @@ import { logger } from "hono/logger"
 import { z } from "zod"
 
 import { errorHandler, globalErrorResponses, jsonError } from "@/lib/error"
-import { defineRoute, ok } from "@/lib/route"
+import { routeGroup } from "@/lib/route"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
+
+const route = routeGroup({ tags: ["System"] })
 
 const app = new Hono()
 
@@ -35,18 +37,17 @@ app.onError(errorHandler)
 app.notFound((c) => jsonError(c, 404, "NOT_FOUND", "Not Found"))
 
 const routes = app
-  .get("/", (c) => ok(c, { version: BUILD_VERSION, environment: env.NODE_ENV }))
+  .get("/", (c) => c.json({ data: { version: BUILD_VERSION, environment: env.NODE_ENV } }))
   .get("/headers", (c) => {
     if (env.NODE_ENV !== "local" && env.NODE_ENV !== "development") {
       return jsonError(c, 403, "FORBIDDEN", "Forbidden")
     }
-    return ok(c, c.req.header())
+    return c.json({ data: c.req.header() })
   })
   .basePath("/api")
   .get(
     "/health",
-    defineRoute({
-      tags: ["System"],
+    route({
       description: "Get the system health",
       output: z.object({
         environment: z
@@ -56,7 +57,7 @@ const routes = app
         version: z.string().meta({ example: BUILD_VERSION }),
       }),
     }),
-    (c) => ok(c, { message: "ok", version: BUILD_VERSION, environment: env.NODE_ENV }),
+    (c) => c.json({ data: { message: "ok", version: BUILD_VERSION, environment: env.NODE_ENV } }),
   )
   .route("/agents", agentsRouter)
   .route("/auth", authRouter)

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -3,12 +3,13 @@ import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
-import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
+import { openAPIRouteHandler } from "hono-openapi"
 import { cors } from "hono/cors"
 import { logger } from "hono/logger"
 import { z } from "zod"
 
 import { errorHandler, globalErrorResponses, jsonError } from "@/lib/error"
+import { defineRoute, ok } from "@/lib/route"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
@@ -34,59 +35,28 @@ app.onError(errorHandler)
 app.notFound((c) => jsonError(c, 404, "NOT_FOUND", "Not Found"))
 
 const routes = app
-  .get("/", (c) => {
-    const data = { version: BUILD_VERSION, environment: env.NODE_ENV }
-    return c.json({ data })
-  })
+  .get("/", (c) => ok(c, { version: BUILD_VERSION, environment: env.NODE_ENV }))
   .get("/headers", (c) => {
     if (env.NODE_ENV !== "local" && env.NODE_ENV !== "development") {
       return jsonError(c, 403, "FORBIDDEN", "Forbidden")
     }
-    const data = c.req.header()
-    return c.json({ data })
+    return ok(c, c.req.header())
   })
   .basePath("/api")
   .get(
     "/health",
-    describeRoute({
+    defineRoute({
       tags: ["System"],
       description: "Get the system health",
-      ...({
-        "x-codeSamples": [
-          {
-            lang: "typescript",
-            label: "hono/client",
-            source: `import { apiClient, unwrap } from "@/lib/api/client"
-
-const { data, error } = await unwrap(apiClient.health.$get())`,
-          },
-        ],
-      } as object),
-      responses: {
-        200: {
-          description: "OK",
-          content: {
-            "application/json": {
-              schema: resolver(
-                z.object({
-                  data: z.object({
-                    environment: z
-                      .enum(["local", "development", "test", "staging", "production"])
-                      .meta({ example: env.NODE_ENV }),
-                    message: z.string().meta({ example: "ok" }),
-                    version: z.string().meta({ example: BUILD_VERSION }),
-                  }),
-                }),
-              ),
-            },
-          },
-        },
-      },
+      output: z.object({
+        environment: z
+          .enum(["local", "development", "test", "staging", "production"])
+          .meta({ example: env.NODE_ENV }),
+        message: z.string().meta({ example: "ok" }),
+        version: z.string().meta({ example: BUILD_VERSION }),
+      }),
     }),
-    (c) => {
-      const data = { message: "ok", version: BUILD_VERSION, environment: env.NODE_ENV }
-      return c.json({ data })
-    },
+    (c) => ok(c, { message: "ok", version: BUILD_VERSION, environment: env.NODE_ENV }),
   )
   .route("/agents", agentsRouter)
   .route("/auth", authRouter)

--- a/api/hono/src/lib/route.ts
+++ b/api/hono/src/lib/route.ts
@@ -8,7 +8,7 @@ import { authErrorResponses, validationErrorResponses } from "@/lib/error"
 // Typed success envelope. The handler still calls c.json (via ok), so Hono's RPC type inference stays anchored on the route and the client keeps seeing { data: T }.
 export const ok = <T>(c: Context, data: T) => c.json({ data }, 200)
 
-type RouteSpec = {
+type RouteDoc = {
   tags: string[]
   description: string
   output: ZodType
@@ -16,8 +16,8 @@ type RouteSpec = {
   auth?: boolean
 }
 
-// One place that builds a route's OpenAPI doc: wraps output in the { data } envelope and documents only the route-specific errors. 429/500 are applied globally by openAPIRouteHandler's defaultOptions; 400 is added when the route validates input, 401 when it is behind auth.
-export function defineRoute({ tags, description, output, input, auth }: RouteSpec) {
+// One place that builds a route's OpenAPI doc: wraps output in the { data } envelope and adds only the route-specific errors (400 when it validates input, 401 when behind auth). 429/500 are applied globally by openAPIRouteHandler's defaultOptions.
+export function defineRoute({ tags, description, output, input, auth }: RouteDoc) {
   return describeRoute({
     tags,
     description,
@@ -31,6 +31,11 @@ export function defineRoute({ tags, description, output, input, auth }: RouteSpe
     },
   })
 }
+
+// Pre-bind a router's shared tags (and auth) so each route declares only what varies.
+export const scopeRoute =
+  (scope: { tags: string[]; auth?: boolean }) => (spec: Omit<RouteDoc, "tags">) =>
+    defineRoute({ ...spec, tags: scope.tags, auth: spec.auth ?? scope.auth })
 
 // Body validator whose failures throw, so onError shapes every validation 400 in one place. Placed directly in the route chain (not spread) so c.req.valid("json") stays typed.
 export const validate = <T extends ZodType>(schema: T) =>

--- a/api/hono/src/lib/route.ts
+++ b/api/hono/src/lib/route.ts
@@ -1,0 +1,39 @@
+import { sValidator } from "@hono/standard-validator"
+import type { Context } from "hono"
+import { describeRoute, resolver } from "hono-openapi"
+import { z, type ZodType } from "zod"
+
+import { authErrorResponses, validationErrorResponses } from "@/lib/error"
+
+// Typed success envelope. The handler still calls c.json (via ok), so Hono's RPC type inference stays anchored on the route and the client keeps seeing { data: T }.
+export const ok = <T>(c: Context, data: T) => c.json({ data }, 200)
+
+type RouteSpec = {
+  tags: string[]
+  description: string
+  output: ZodType
+  input?: ZodType
+  auth?: boolean
+}
+
+// One place that builds a route's OpenAPI doc: wraps output in the { data } envelope and documents only the route-specific errors. 429/500 are applied globally by openAPIRouteHandler's defaultOptions; 400 is added when the route validates input, 401 when it is behind auth.
+export function defineRoute({ tags, description, output, input, auth }: RouteSpec) {
+  return describeRoute({
+    tags,
+    description,
+    responses: {
+      200: {
+        description: "OK",
+        content: { "application/json": { schema: resolver(z.object({ data: output })) } },
+      },
+      ...(input ? validationErrorResponses : {}),
+      ...(auth ? authErrorResponses : {}),
+    },
+  })
+}
+
+// Body validator whose failures throw, so onError shapes every validation 400 in one place. Placed directly in the route chain (not spread) so c.req.valid("json") stays typed.
+export const validate = <T extends ZodType>(schema: T) =>
+  sValidator("json", schema, (result) => {
+    if (!result.success) throw result.error
+  })

--- a/api/hono/src/lib/route.ts
+++ b/api/hono/src/lib/route.ts
@@ -1,41 +1,32 @@
 import { sValidator } from "@hono/standard-validator"
-import type { Context } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z, type ZodType } from "zod"
 
 import { authErrorResponses, validationErrorResponses } from "@/lib/error"
 
-// Typed success envelope. The handler still calls c.json (via ok), so Hono's RPC type inference stays anchored on the route and the client keeps seeing { data: T }.
-export const ok = <T>(c: Context, data: T) => c.json({ data }, 200)
-
-type RouteDoc = {
-  tags: string[]
+type RouteSpec = {
   description: string
   output: ZodType
   input?: ZodType
   auth?: boolean
 }
 
-// One place that builds a route's OpenAPI doc: wraps output in the { data } envelope and adds only the route-specific errors (400 when it validates input, 401 when behind auth). 429/500 are applied globally by openAPIRouteHandler's defaultOptions.
-export function defineRoute({ tags, description, output, input, auth }: RouteDoc) {
-  return describeRoute({
-    tags,
-    description,
-    responses: {
-      200: {
-        description: "OK",
-        content: { "application/json": { schema: resolver(z.object({ data: output })) } },
+// A router's routes share a tag (and often auth). routeGroup binds those once and returns a per-route definer that builds the OpenAPI doc: output wrapped in the { data } envelope, plus only the route-specific errors (400 when it validates input, 401 when behind auth). 429/500 are applied globally by openAPIRouteHandler's defaultOptions.
+export const routeGroup =
+  (group: { tags: string[]; auth?: boolean }) =>
+  ({ description, output, input, auth }: RouteSpec) =>
+    describeRoute({
+      tags: group.tags,
+      description,
+      responses: {
+        200: {
+          description: "OK",
+          content: { "application/json": { schema: resolver(z.object({ data: output })) } },
+        },
+        ...(input ? validationErrorResponses : {}),
+        ...((auth ?? group.auth) ? authErrorResponses : {}),
       },
-      ...(input ? validationErrorResponses : {}),
-      ...(auth ? authErrorResponses : {}),
-    },
-  })
-}
-
-// Pre-bind a router's shared tags (and auth) so each route declares only what varies.
-export const scopeRoute =
-  (scope: { tags: string[]; auth?: boolean }) => (spec: Omit<RouteDoc, "tags">) =>
-    defineRoute({ ...spec, tags: scope.tags, auth: spec.auth ?? scope.auth })
+    })
 
 // Body validator whose failures throw, so onError shapes every validation 400 in one place. Placed directly in the route chain (not spread) so c.req.valid("json") stays typed.
 export const validate = <T extends ZodType>(schema: T) =>

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,9 +1,7 @@
 import { auth, enabledProviders } from "@packages/auth"
 import { Hono } from "hono"
 
-import { ok } from "@/lib/route"
-
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
-  .get("/providers", (c) => ok(c, { providers: enabledProviders }))
+  .get("/providers", (c) => c.json({ data: { providers: enabledProviders } }))
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,7 +1,9 @@
 import { auth, enabledProviders } from "@packages/auth"
 import { Hono } from "hono"
 
+import { ok } from "@/lib/route"
+
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
-  .get("/providers", (c) => c.json({ data: { providers: enabledProviders } }))
+  .get("/providers", (c) => ok(c, { providers: enabledProviders }))
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -2,7 +2,7 @@ import type { Session } from "@packages/auth"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import { ok, scopeRoute } from "@/lib/route"
+import { routeGroup } from "@/lib/route"
 import { authMiddleware } from "@/middlewares"
 
 const sessionSchema = z.object({
@@ -26,15 +26,15 @@ const userSchema = z.object({
   updatedAt: z.string().meta({ format: "date-time", example: "2025-12-17T14:33:40.317Z" }),
 })
 
-const route = scopeRoute({ tags: ["v1"], auth: true })
+const route = routeGroup({ tags: ["v1"], auth: true })
 
 export const v1Router = new Hono<{
   Variables: Session
 }>()
   .use("/*", authMiddleware)
   .get("/session", route({ description: "Get current session only", output: sessionSchema }), (c) =>
-    ok(c, c.get("session")),
+    c.json({ data: c.get("session") }),
   )
   .get("/user", route({ description: "Get current user only", output: userSchema }), (c) =>
-    ok(c, c.get("user")),
+    c.json({ data: c.get("user") }),
   )

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -2,7 +2,7 @@ import type { Session } from "@packages/auth"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import { defineRoute, ok } from "@/lib/route"
+import { ok, scopeRoute } from "@/lib/route"
 import { authMiddleware } from "@/middlewares"
 
 const sessionSchema = z.object({
@@ -26,27 +26,15 @@ const userSchema = z.object({
   updatedAt: z.string().meta({ format: "date-time", example: "2025-12-17T14:33:40.317Z" }),
 })
 
+const route = scopeRoute({ tags: ["v1"], auth: true })
+
 export const v1Router = new Hono<{
   Variables: Session
 }>()
   .use("/*", authMiddleware)
-  .get(
-    "/session",
-    defineRoute({
-      tags: ["v1"],
-      description: "Get current session only",
-      output: sessionSchema,
-      auth: true,
-    }),
-    (c) => ok(c, c.get("session")),
+  .get("/session", route({ description: "Get current session only", output: sessionSchema }), (c) =>
+    ok(c, c.get("session")),
   )
-  .get(
-    "/user",
-    defineRoute({
-      tags: ["v1"],
-      description: "Get current user only",
-      output: userSchema,
-      auth: true,
-    }),
-    (c) => ok(c, c.get("user")),
+  .get("/user", route({ description: "Get current user only", output: userSchema }), (c) =>
+    ok(c, c.get("user")),
   )

--- a/api/hono/src/routers/v1.ts
+++ b/api/hono/src/routers/v1.ts
@@ -1,9 +1,8 @@
 import type { Session } from "@packages/auth"
 import { Hono } from "hono"
-import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
-import { authErrorResponses } from "@/lib/error"
+import { defineRoute, ok } from "@/lib/route"
 import { authMiddleware } from "@/middlewares"
 
 const sessionSchema = z.object({
@@ -33,67 +32,21 @@ export const v1Router = new Hono<{
   .use("/*", authMiddleware)
   .get(
     "/session",
-    describeRoute({
+    defineRoute({
       tags: ["v1"],
       description: "Get current session only",
-      ...({
-        "x-codeSamples": [
-          {
-            lang: "typescript",
-            label: "hono/client",
-            source: `import { apiClient, unwrap } from "@/lib/api/client"
-
-const { data, error } = await unwrap(apiClient.v1.session.$get())`,
-          },
-        ],
-      } as object),
-      responses: {
-        200: {
-          description: "OK",
-          content: {
-            "application/json": {
-              schema: resolver(z.object({ data: sessionSchema })),
-            },
-          },
-        },
-        ...authErrorResponses,
-      },
+      output: sessionSchema,
+      auth: true,
     }),
-    (c) => {
-      const data = c.get("session")
-      return c.json({ data })
-    },
+    (c) => ok(c, c.get("session")),
   )
   .get(
     "/user",
-    describeRoute({
+    defineRoute({
       tags: ["v1"],
       description: "Get current user only",
-      ...({
-        "x-codeSamples": [
-          {
-            lang: "typescript",
-            label: "hono/client",
-            source: `import { apiClient, unwrap } from "@/lib/api/client"
-
-const { data, error } = await unwrap(apiClient.v1.user.$get())`,
-          },
-        ],
-      } as object),
-      responses: {
-        200: {
-          description: "OK",
-          content: {
-            "application/json": {
-              schema: resolver(z.object({ data: userSchema })),
-            },
-          },
-        },
-        ...authErrorResponses,
-      },
+      output: userSchema,
+      auth: true,
     }),
-    (c) => {
-      const data = c.get("user")
-      return c.json({ data })
-    },
+    (c) => ok(c, c.get("user")),
   )

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -1,10 +1,8 @@
-import { sValidator } from "@hono/standard-validator"
 import { db, waitlist } from "@packages/db"
 import { Hono } from "hono"
-import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
-import { jsonError, validationErrorResponses } from "@/lib/error"
+import { defineRoute, ok, validate } from "@/lib/route"
 
 const joinSchema = z.object({
   email: z.string().trim().pipe(z.email().max(254)).meta({ example: "you@example.com" }),
@@ -19,77 +17,27 @@ const COUNT_STEP = 5
 export const waitlistRouter = new Hono()
   .get(
     "/",
-    describeRoute({
+    defineRoute({
       tags: ["Waitlist"],
       description:
         "Approximate waitlist count once it passes a display threshold (0 below it), rounded down in steps of 5",
-      ...({
-        "x-codeSamples": [
-          {
-            lang: "typescript",
-            label: "hono/client",
-            source: `import { apiClient, unwrap } from "@/lib/api/client"
-
-const { data, error } = await unwrap(apiClient.waitlist.$get())`,
-          },
-        ],
-      } as object),
-      responses: {
-        200: {
-          description: "OK",
-          content: {
-            "application/json": {
-              schema: resolver(
-                z.object({ data: z.object({ count: z.number().meta({ example: 40 }) }) }),
-              ),
-            },
-          },
-        },
-      },
+      output: z.object({ count: z.number().meta({ example: 40 }) }),
     }),
     async (c) => {
       const exact = await db.$count(waitlist)
       const count = exact >= COUNT_MIN ? Math.floor(exact / COUNT_STEP) * COUNT_STEP : 0
-      return c.json({ data: { count } })
+      return ok(c, { count })
     },
   )
   .post(
     "/",
-    describeRoute({
+    defineRoute({
       tags: ["Waitlist"],
       description: "Join the waitlist",
-      ...({
-        "x-codeSamples": [
-          {
-            lang: "typescript",
-            label: "hono/client",
-            source: `import { apiClient, unwrap } from "@/lib/api/client"
-
-const { data, error } = await unwrap(apiClient.waitlist.$post({ json: { email: "you@example.com" } }))`,
-          },
-        ],
-      } as object),
-      responses: {
-        200: {
-          description: "OK",
-          content: {
-            "application/json": {
-              schema: resolver(
-                z.object({ data: z.object({ message: z.string().meta({ example: "ok" }) }) }),
-              ),
-            },
-          },
-        },
-        ...validationErrorResponses,
-      },
+      input: joinSchema,
+      output: z.object({ message: z.string().meta({ example: "ok" }) }),
     }),
-    sValidator("json", joinSchema, (result, c) => {
-      if (!result.success) {
-        return jsonError(c, 400, "VALIDATION_ERROR", "Invalid email address", {
-          issues: result.error,
-        })
-      }
-    }),
+    validate(joinSchema),
     async (c) => {
       const { email, subject } = c.req.valid("json")
       // honeypot filled => silently accept without storing (bot)
@@ -99,6 +47,6 @@ const { data, error } = await unwrap(apiClient.waitlist.$post({ json: { email: "
           .values({ email: email.toLowerCase() })
           .onConflictDoNothing({ target: waitlist.email })
       }
-      return c.json({ data: { message: "ok" } })
+      return ok(c, { message: "ok" })
     },
   )

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -2,7 +2,7 @@ import { db, waitlist } from "@packages/db"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import { defineRoute, ok, validate } from "@/lib/route"
+import { ok, scopeRoute, validate } from "@/lib/route"
 
 const joinSchema = z.object({
   email: z.string().trim().pipe(z.email().max(254)).meta({ example: "you@example.com" }),
@@ -14,11 +14,12 @@ const joinSchema = z.object({
 const COUNT_MIN = 10
 const COUNT_STEP = 5
 
+const route = scopeRoute({ tags: ["Waitlist"] })
+
 export const waitlistRouter = new Hono()
   .get(
     "/",
-    defineRoute({
-      tags: ["Waitlist"],
+    route({
       description:
         "Approximate waitlist count once it passes a display threshold (0 below it), rounded down in steps of 5",
       output: z.object({ count: z.number().meta({ example: 40 }) }),
@@ -31,8 +32,7 @@ export const waitlistRouter = new Hono()
   )
   .post(
     "/",
-    defineRoute({
-      tags: ["Waitlist"],
+    route({
       description: "Join the waitlist",
       input: joinSchema,
       output: z.object({ message: z.string().meta({ example: "ok" }) }),

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -2,7 +2,7 @@ import { db, waitlist } from "@packages/db"
 import { Hono } from "hono"
 import { z } from "zod"
 
-import { ok, scopeRoute, validate } from "@/lib/route"
+import { routeGroup, validate } from "@/lib/route"
 
 const joinSchema = z.object({
   email: z.string().trim().pipe(z.email().max(254)).meta({ example: "you@example.com" }),
@@ -14,7 +14,7 @@ const joinSchema = z.object({
 const COUNT_MIN = 10
 const COUNT_STEP = 5
 
-const route = scopeRoute({ tags: ["Waitlist"] })
+const route = routeGroup({ tags: ["Waitlist"] })
 
 export const waitlistRouter = new Hono()
   .get(
@@ -27,7 +27,7 @@ export const waitlistRouter = new Hono()
     async (c) => {
       const exact = await db.$count(waitlist)
       const count = exact >= COUNT_MIN ? Math.floor(exact / COUNT_STEP) * COUNT_STEP : 0
-      return ok(c, { count })
+      return c.json({ data: { count } })
     },
   )
   .post(
@@ -47,6 +47,6 @@ export const waitlistRouter = new Hono()
           .values({ email: email.toLowerCase() })
           .onConflictDoNothing({ target: waitlist.email })
       }
-      return ok(c, { message: "ok" })
+      return c.json({ data: { message: "ok" } })
     },
   )


### PR DESCRIPTION
## What

A minimal way to write Hono routes here: OpenAPI docs + RPC types preserved, per-route footprint cut to intent, concerns separated. New module `api/hono/src/lib/route.ts` (39 lines):

- **`defineRoute({ tags, description, output, input?, auth? })`** — builds the route's OpenAPI doc. Wraps `output` in the `{ data }` envelope for the `200`, adds `400` when `input` is given and `401` when `auth: true`. `429`/`500` stay global (already applied by `openAPIRouteHandler`'s `defaultOptions`).
- **`ok(c, data)`** — typed success envelope. The handler still calls `c.json` (via `ok`), so Hono's **RPC type inference stays anchored** and the client keeps inferring `{ data: T }`.
- **`validate(schema)`** — body validator placed *directly* in the chain (not spread), so `c.req.valid("json")` stays typed; its failures **throw**, so `onError` shapes every validation `400` in one place.

Converted `waitlist`, `v1` (auth), `/health`, `/`, `/headers`.

## Design decisions (grilled)

- **Helper stops short of owning `c.json`.** A full handler-wrapping factory erodes Hono's RPC inference — verified: spreading a middleware tuple collapsed `c.req.valid("json")` to `never`. So `ok()` keeps `c.json` at the route; `validate()` is a direct arg.
- **Validation funnels through `onError`** (one envelope, one test surface); drops the per-route custom message and fixes the `issues: result.error` shape bug.
- **`429/500` stay global**, routes only declare their own `400`/`401`.

## Verified

- `api/hono` + `web/next` type-check clean → RPC inference and `c.req.valid` typing both intact.
- Generated the live OpenAPI spec from the app:
  - `POST /api/waitlist` → `200, 400, 429, 500`; `200` schema = `{ data: { message } }`
  - `GET /api/v1/user` → `200, 401, 429, 500`
  - `GET /api/waitlist` / `GET /api/health` → `200, 429, 500`

## Footprint

Routers shed **163 lines** of plumbing for **29 lines** of declarations behind a **39-line** module (+70/−160 net).

## Trade-off / follow-ups

- The hand-written `x-codeSamples` (the `hono/client` snippet) are dropped — they were ~12 lines of per-route boilerplate and can return as an optional one-line `client` hint if we want them in Scalar.
- `agentsRouter` / `authRouter` not converted (auth is Better Auth's handler; agents is local-only) — the helper is ready for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized API responses across multiple endpoints using a consistent `{ data: ... }` JSON envelope.
  * Updated OpenAPI/route documentation wiring for v1 session/user, health, and waitlist endpoints.
* **Bug Fixes**
  * Made request validation and error handling more consistent for form submissions and protected routes.
* **Documentation**
  * Improved route metadata definitions to better match actual response shapes (including waitlist and auth-related endpoints).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->