### PR TITLE
refactor(api): contained error handling + typed ErrorCode union end-to-end

### DIFF
--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -125,6 +125,7 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
   )
 
 export type AppType = typeof routes
+export type { ErrorCode } from "@/lib/error"
 
 export default {
   port: env.HONO_PORT,

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -5,6 +5,7 @@ import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { cors } from "hono/cors"
+import { HTTPException } from "hono/http-exception"
 import { logger } from "hono/logger"
 import { z } from "zod"
 
@@ -40,7 +41,7 @@ const routes = app
   })
   .get("/headers", (c) => {
     if (env.NODE_ENV !== "local" && env.NODE_ENV !== "development") {
-      return jsonError(c, 403, "FORBIDDEN", "Forbidden")
+      throw new HTTPException(403, { message: "Forbidden" })
     }
     const data = c.req.header()
     return c.json({ data })

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -8,7 +8,7 @@ import { z } from "zod"
 
 // Every code the API can put in the { error } envelope. Single source of truth: the TS union, the OpenAPI schema, and the web client all derive from this list. "ERROR" is the catch-all for an HTTPException whose status isn't mapped below.
 export const ERROR_CODES = [
-  "AGENTS_LOGIN_FAILED",
+  "AGENT_LOGIN_FAILED",
   "BAD_REQUEST",
   "ERROR",
   "FORBIDDEN",

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -6,10 +6,22 @@ import { HTTPException } from "hono/http-exception"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { z } from "zod"
 
+// Every code the API can put in the { error } envelope. Single source of truth, shared to the web client so error.code is a closed union. "ERROR" is the catch-all for an HTTPException whose status isn't mapped below.
+export type ErrorCode =
+  | "VALIDATION_ERROR"
+  | "BAD_REQUEST"
+  | "UNAUTHORIZED"
+  | "FORBIDDEN"
+  | "NOT_FOUND"
+  | "TOO_MANY_REQUESTS"
+  | "INTERNAL_SERVER_ERROR"
+  | "AGENTS_LOGIN_FAILED"
+  | "ERROR"
+
 export function jsonError<S extends ContentfulStatusCode>(
   c: Context,
   status: S,
-  code: string,
+  code: ErrorCode,
   message: string,
   extra?: Record<string, unknown>,
 ) {
@@ -18,11 +30,11 @@ export function jsonError<S extends ContentfulStatusCode>(
 
 // Throw this anywhere and onError shapes the { error } envelope. Extends HTTPException so Hono treats it as a known error; carries our envelope's domain code and any extras (e.g. validation issues).
 export class ApiError extends HTTPException {
-  readonly code: string
+  readonly code: ErrorCode
   readonly extra?: Record<string, unknown>
   constructor(
     status: ContentfulStatusCode,
-    code: string,
+    code: ErrorCode,
     message: string,
     extra?: Record<string, unknown>,
   ) {
@@ -33,7 +45,7 @@ export class ApiError extends HTTPException {
 }
 
 // Code for an HTTPException, by status; Hono throws these for client errors (e.g. 400 on malformed JSON).
-const httpExceptionCodes: Record<number, string> = {
+const httpExceptionCodes: Record<number, ErrorCode> = {
   400: "BAD_REQUEST",
   401: "UNAUTHORIZED",
   403: "FORBIDDEN",

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -8,15 +8,15 @@ import { z } from "zod"
 
 // Every code the API can put in the { error } envelope. Single source of truth, shared to the web client so error.code is a closed union. "ERROR" is the catch-all for an HTTPException whose status isn't mapped below.
 export type ErrorCode =
-  | "VALIDATION_ERROR"
+  | "AGENTS_LOGIN_FAILED"
   | "BAD_REQUEST"
-  | "UNAUTHORIZED"
+  | "ERROR"
   | "FORBIDDEN"
+  | "INTERNAL_SERVER_ERROR"
   | "NOT_FOUND"
   | "TOO_MANY_REQUESTS"
-  | "INTERNAL_SERVER_ERROR"
-  | "AGENTS_LOGIN_FAILED"
-  | "ERROR"
+  | "UNAUTHORIZED"
+  | "VALIDATION_ERROR"
 
 export function jsonError<S extends ContentfulStatusCode>(
   c: Context,

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -16,6 +16,22 @@ export function jsonError<S extends ContentfulStatusCode>(
   return c.json({ error: { code, message, ...extra } }, status)
 }
 
+// Throw this anywhere and onError shapes the { error } envelope. Extends HTTPException so Hono treats it as a known error; carries our envelope's domain code and any extras (e.g. validation issues).
+export class ApiError extends HTTPException {
+  readonly code: string
+  readonly extra?: Record<string, unknown>
+  constructor(
+    status: ContentfulStatusCode,
+    code: string,
+    message: string,
+    extra?: Record<string, unknown>,
+  ) {
+    super(status, { message })
+    this.code = code
+    this.extra = extra
+  }
+}
+
 // Code for an HTTPException, by status; Hono throws these for client errors (e.g. 400 on malformed JSON).
 const httpExceptionCodes: Record<number, string> = {
   400: "BAD_REQUEST",
@@ -26,6 +42,11 @@ const httpExceptionCodes: Record<number, string> = {
 }
 
 export const errorHandler = (err: Error, c: Context) => {
+  // Our domain errors carry their own code/extra; check before HTTPException since ApiError extends it.
+  if (err instanceof ApiError) {
+    return jsonError(c, err.status, err.code, err.message, err.extra)
+  }
+
   if (err instanceof z.ZodError) {
     return jsonError(c, 400, "VALIDATION_ERROR", "Invalid request payload", { issues: err.issues })
   }

--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -6,17 +6,20 @@ import { HTTPException } from "hono/http-exception"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 import { z } from "zod"
 
-// Every code the API can put in the { error } envelope. Single source of truth, shared to the web client so error.code is a closed union. "ERROR" is the catch-all for an HTTPException whose status isn't mapped below.
-export type ErrorCode =
-  | "AGENTS_LOGIN_FAILED"
-  | "BAD_REQUEST"
-  | "ERROR"
-  | "FORBIDDEN"
-  | "INTERNAL_SERVER_ERROR"
-  | "NOT_FOUND"
-  | "TOO_MANY_REQUESTS"
-  | "UNAUTHORIZED"
-  | "VALIDATION_ERROR"
+// Every code the API can put in the { error } envelope. Single source of truth: the TS union, the OpenAPI schema, and the web client all derive from this list. "ERROR" is the catch-all for an HTTPException whose status isn't mapped below.
+export const ERROR_CODES = [
+  "AGENTS_LOGIN_FAILED",
+  "BAD_REQUEST",
+  "ERROR",
+  "FORBIDDEN",
+  "INTERNAL_SERVER_ERROR",
+  "NOT_FOUND",
+  "TOO_MANY_REQUESTS",
+  "UNAUTHORIZED",
+  "VALIDATION_ERROR",
+] as const
+
+export type ErrorCode = (typeof ERROR_CODES)[number]
 
 export function jsonError<S extends ContentfulStatusCode>(
   c: Context,
@@ -75,13 +78,13 @@ export const errorHandler = (err: Error, c: Context) => {
 
 // Shape of the error envelope jsonError emits; reused by the OpenAPI error responses below.
 export const errorEnvelope = z.object({
-  error: z.object({ code: z.string(), message: z.string() }),
+  error: z.object({ code: z.enum(ERROR_CODES), message: z.string() }),
 })
 
 // Validation errors also carry the failing fields, so document that on the 400 response.
 const validationErrorEnvelope = z.object({
   error: z.object({
-    code: z.string(),
+    code: z.enum(ERROR_CODES),
     message: z.string(),
     issues: z
       .array(z.object({ path: z.array(z.union([z.string(), z.number()])), message: z.string() }))

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm"
 import { Hono } from "hono"
 import { setCookie } from "hono/cookie"
 
-import { jsonError } from "@/lib/error"
+import { ApiError } from "@/lib/error"
 
 const AGENT_EMAIL = site.agent.email
 const AGENT_NAME = site.agent.name
@@ -16,7 +16,9 @@ const AGENT_NAME = site.agent.name
 export const agentsRouter = new Hono()
   .use(async (c, next) => (isLocal(env.NODE_ENV) ? next() : c.notFound()))
   .post("/sign-in-as", async (c) => {
-    const fail = (message: string) => jsonError(c, 500, "AGENTS_LOGIN_FAILED", message)
+    const fail = (message: string): never => {
+      throw new ApiError(500, "AGENTS_LOGIN_FAILED", message)
+    }
 
     const origin = c.req.header("origin")
     if (!origin) return fail("missing Origin header")

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -17,7 +17,7 @@ export const agentsRouter = new Hono()
   .use(async (c, next) => (isLocal(env.NODE_ENV) ? next() : c.notFound()))
   .post("/sign-in-as", async (c) => {
     const fail = (message: string): never => {
-      throw new ApiError(500, "AGENTS_LOGIN_FAILED", message)
+      throw new ApiError(500, "AGENT_LOGIN_FAILED", message)
     }
 
     const origin = c.req.header("origin")

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
-import { jsonError, validationErrorResponses } from "@/lib/error"
+import { ApiError, validationErrorResponses } from "@/lib/error"
 
 const joinSchema = z.object({
   email: z.string().trim().pipe(z.email().max(254)).meta({ example: "you@example.com" }),
@@ -83,9 +83,10 @@ const { data, error } = await unwrap(apiClient.waitlist.$post({ json: { email: "
         ...validationErrorResponses,
       },
     }),
-    sValidator("json", joinSchema, (result, c) => {
+    // validation failures throw so onError shapes the 400 in one place
+    sValidator("json", joinSchema, (result) => {
       if (!result.success) {
-        return jsonError(c, 400, "VALIDATION_ERROR", "Invalid email address", {
+        throw new ApiError(400, "VALIDATION_ERROR", "Invalid email address", {
           issues: result.error,
         })
       }

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -31,7 +31,7 @@ All API responses use a standardized JSON envelope:
 }
 ```
 
-This envelope is produced by the `jsonError(c, status, code, message, extra?)` helper in `api/hono/src/lib/error.ts`, which is the standard way routers and middleware emit errors.
+Routes never build this envelope by hand. They `throw` — `new ApiError(status, code, message, extra?)` for a domain code, or a Hono `HTTPException(status, { message })` for a standard one — and the central `onError` handler in `api/hono/src/lib/error.ts` is the single place that turns any thrown error into the envelope (via the internal `jsonError` builder). `onError` dispatches in order: `ApiError` (its own code) → `ZodError` (400) → `HTTPException` (status-mapped code) → `500`. Middleware and `notFound` may still call `jsonError` directly.
 
 ### Consuming responses on the client
 
@@ -50,20 +50,23 @@ if (error) {
 
 With TanStack Query, `throw` on the error arm, in a `queryFn` (so the query reports `isError`), or in a `useMutation` `mutationFn` and toast it in `onError`.
 
+`error.code` is typed as the `ErrorCode` union (re-exported from `@api/hono`) plus the two transport codes `unwrap` itself produces (`NETWORK_ERROR`, `UNKNOWN_ERROR`), so it is a closed union on the client, with autocomplete and exhaustive `switch`.
+
 ### Error Codes
 
-| Code                    | Status | When                                                          |
-| ----------------------- | ------ | ------------------------------------------------------------- |
-| `NOT_FOUND`             | 404    | Route does not exist                                          |
-| `UNAUTHORIZED`          | 401    | Missing or invalid session                                    |
-| `FORBIDDEN`             | 403    | Insufficient permissions (e.g., `/headers` in production)     |
-| `TOO_MANY_REQUESTS`     | 429    | Rate limit exceeded                                           |
-| `VALIDATION_ERROR`      | 400    | Zod schema validation failed                                  |
-| `BAD_REQUEST`           | 400    | Malformed JSON/form-data body (Hono `HTTPException`)          |
-| `INTERNAL_SERVER_ERROR` | 500    | Unhandled server error                                        |
-| `AGENTS_LOGIN_FAILED`   | 500    | Local agent sign-in failed (`api/hono/src/routers/agents.ts`) |
+| Code                    | Status   | When                                                          |
+| ----------------------- | -------- | ------------------------------------------------------------- |
+| `AGENTS_LOGIN_FAILED`   | 500      | Local agent sign-in failed (`api/hono/src/routers/agents.ts`) |
+| `BAD_REQUEST`           | 400      | Malformed JSON/form-data body (Hono `HTTPException`)          |
+| `ERROR`                 | (varies) | `HTTPException` with a status not mapped to a specific code   |
+| `FORBIDDEN`             | 403      | Insufficient permissions (e.g., `/headers` in production)     |
+| `INTERNAL_SERVER_ERROR` | 500      | Unhandled server error                                        |
+| `NOT_FOUND`             | 404      | Route does not exist                                          |
+| `TOO_MANY_REQUESTS`     | 429      | Rate limit exceeded                                           |
+| `UNAUTHORIZED`          | 401      | Missing or invalid session                                    |
+| `VALIDATION_ERROR`      | 400      | Zod schema validation failed                                  |
 
-Beyond these shared codes, individual routers may define route-specific codes by calling `jsonError(c, status, code, message)` directly (as `agents.ts` does for `AGENTS_LOGIN_FAILED`).
+These codes are the `ErrorCode` union in `api/hono/src/lib/error.ts` — the single source of truth, re-exported to the web client. A router emits a domain code by throwing `new ApiError(status, code, message, extra?)` (e.g. `agents.ts` throws `ApiError(500, "AGENTS_LOGIN_FAILED", …)`). Adding a code means extending the `ErrorCode` union, so the throw site, the client type, and this table stay in sync.
 
 ### Validation Errors
 
@@ -79,7 +82,7 @@ When a Zod validation fails, the response includes the full issues array:
 }
 ```
 
-Route-level validators (e.g. `sValidator` on the waitlist `POST`) follow the same convention: a custom message plus the `issues` array. Note that Hono's validator only parses the body when its content-type matches (JSON validators ignore a non-JSON body and validate `{}`), so a wrong content-type surfaces as a normal field-level issue.
+Route-level validators (e.g. `sValidator` on the waitlist `POST`) `throw new ApiError(400, "VALIDATION_ERROR", message, { issues })` on failure, so `onError` shapes the 400 in one place. Note that Hono's validator only parses the body when its content-type matches (JSON validators ignore a non-JSON body and validate `{}`), so a wrong content-type surfaces as a normal field-level issue.
 
 A body that is present but unparseable (malformed JSON, malformed form-data) is a client error, not a server error: Hono throws an `HTTPException`, and `errorHandler` returns it with the thrown status (`400 BAD_REQUEST`) instead of masking it as a `500`.
 
@@ -208,6 +211,8 @@ export const v1Router = new Hono<{ Variables: Session }>().use("/*", authMiddlew
 ```
 
 The `new Hono<{ Variables: Session }>()` generic (with `import type { Session } from "@packages/auth"`) is what makes `c.get("user")` and `c.get("session")` typed, matching the real `v1Router`. The `authMiddleware` populates those context variables.
+
+To emit an error from a handler, `throw new ApiError(status, code, message)` (a domain code) or `throw new HTTPException(status, { message })` (a standard one); `onError` builds the envelope, so never construct it inline.
 
 2. Register in `api/hono/src/index.ts` if it's a new router. The app sets `.basePath("/api")`, so the route path is relative to `/api`:
 

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -56,7 +56,7 @@ With TanStack Query, `throw` on the error arm, in a `queryFn` (so the query repo
 
 | Code                    | Status   | When                                                          |
 | ----------------------- | -------- | ------------------------------------------------------------- |
-| `AGENTS_LOGIN_FAILED`   | 500      | Local agent sign-in failed (`api/hono/src/routers/agents.ts`) |
+| `AGENT_LOGIN_FAILED`    | 500      | Local agent sign-in failed (`api/hono/src/routers/agents.ts`) |
 | `BAD_REQUEST`           | 400      | Malformed JSON/form-data body (Hono `HTTPException`)          |
 | `ERROR`                 | (varies) | `HTTPException` with a status not mapped to a specific code   |
 | `FORBIDDEN`             | 403      | Insufficient permissions (e.g., `/headers` in production)     |
@@ -66,7 +66,7 @@ With TanStack Query, `throw` on the error arm, in a `queryFn` (so the query repo
 | `UNAUTHORIZED`          | 401      | Missing or invalid session                                    |
 | `VALIDATION_ERROR`      | 400      | Zod schema validation failed                                  |
 
-These codes are the `ErrorCode` union in `api/hono/src/lib/error.ts` — the single source of truth, re-exported to the web client. A router emits a domain code by throwing `new ApiError(status, code, message, extra?)` (e.g. `agents.ts` throws `ApiError(500, "AGENTS_LOGIN_FAILED", …)`). Adding a code means extending the `ErrorCode` union, so the throw site, the client type, and this table stay in sync.
+These codes are the `ErrorCode` union in `api/hono/src/lib/error.ts` — the single source of truth, re-exported to the web client. A router emits a domain code by throwing `new ApiError(status, code, message, extra?)` (e.g. `agents.ts` throws `ApiError(500, "AGENT_LOGIN_FAILED", …)`). Adding a code means extending the `ErrorCode` union, so the throw site, the client type, and this table stay in sync.
 
 ### Validation Errors
 

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -22,19 +22,19 @@ const formSchema = z.object({
 
 function WaitlistCount() {
   // the API returns a display-ready count (floored and rounded server-side)
-  const { data: count } = useQuery({
+  const { data } = useQuery({
     queryKey: ["waitlist-count"],
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.waitlist.$get())
       if (error) return null
-      return data.count
+      return data
     },
   })
 
   // fixed-height slot so the count appearing never shifts the layout
   return (
     <div className="mt-10 flex h-7 items-center justify-center">
-      {typeof count === "number" && count > 0 && (
+      {data && data.count > 0 && (
         <div className="animate-in fade-in flex items-center gap-3 duration-500">
           <AvatarGroup>
             <Avatar className="size-7">
@@ -47,7 +47,9 @@ function WaitlistCount() {
               <AvatarFallback className="bg-chart-4 text-xs text-white">C</AvatarFallback>
             </Avatar>
           </AvatarGroup>
-          <span className="text-muted-foreground text-sm">{count}+ people on the waitlist</span>
+          <span className="text-muted-foreground text-sm">
+            {data.count}+ people on the waitlist
+          </span>
         </div>
       )}
     </div>

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -36,18 +36,18 @@ export function Access() {
   const isDev = process.env.NODE_ENV === "development"
 
   // Render only the sign-in providers the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
-  const { data: providers } = useQuery({
+  const { data } = useQuery({
     queryKey: ["auth-providers"],
     staleTime: Infinity,
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.auth.providers.$get())
       if (error) throw new Error(error.message)
-      return data.providers
+      return data
     },
   })
-  const githubEnabled = providers?.includes("github") ?? false
-  const googleEnabled = providers?.includes("google") ?? false
-  const magicLinkEnabled = providers?.includes("magic-link") ?? false
+  const githubEnabled = data?.providers.includes("github") ?? false
+  const googleEnabled = data?.providers.includes("google") ?? false
+  const magicLinkEnabled = data?.providers.includes("magic-link") ?? false
   const hasAlternatives = isDev || githubEnabled || googleEnabled
   const hasNoProviders = !magicLinkEnabled && !hasAlternatives
 

--- a/web/next/src/lib/api/client.ts
+++ b/web/next/src/lib/api/client.ts
@@ -1,4 +1,4 @@
-import type { AppType } from "@api/hono"
+import type { AppType, ErrorCode } from "@api/hono"
 import { hc } from "hono/client"
 
 import { config } from "@/lib/config"
@@ -17,8 +17,11 @@ const honoClient = hcWithType(url, {
 
 export const apiClient = honoClient.api
 
-// Standard error shape, matching the jsonError envelope in api/hono/src/lib/error.ts; extras like the validation `issues` array are preserved.
-export type ApiError = { code: string; message: string } & Record<string, unknown>
+// Standard error shape, matching the jsonError envelope in api/hono/src/lib/error.ts; extras like the validation `issues` array are preserved. `code` is the API's ErrorCode union plus the transport codes unwrap itself produces.
+export type ApiError = {
+  code: ErrorCode | "NETWORK_ERROR" | "UNKNOWN_ERROR"
+  message: string
+} & Record<string, unknown>
 
 // Success payload from the { data } envelope; a body without `data` yields never and unwrap reports it as an error.
 type SuccessData<B> = B extends { data: infer D } ? D : never
@@ -42,8 +45,9 @@ export async function unwrap<R extends RpcResponse>(
       return { data: body.data as SuccessData<Awaited<ReturnType<R["json"]>>>, error: null }
     }
     if (isRecord(body) && isRecord(body.error)) {
-      const code =
+      const code = (
         typeof body.error.code === "string" && body.error.code ? body.error.code : "ERROR"
+      ) as ApiError["code"]
       const message =
         typeof body.error.message === "string" && body.error.message
           ? body.error.message


### PR DESCRIPTION
Single PR for the API error-handling rework and its end-to-end typing (#554 folded in as `80e6f69`). Contained strictly to error handling + how it's consumed — no route/RPC/OpenAPI abstraction (that was #552, closed).

### 1 — Contain error shaping (`ApiError` + `onError`)
- **`ApiError extends HTTPException`** (`lib/error.ts`) carries the envelope's domain `code` + optional `extra`; throw it anywhere.
- **`onError` is the one switchboard** that turns an error into `{ error: { code, message, … } }`: `ApiError` → `ZodError` → `HTTPException` (status-mapped) → `500`. Routes stop hand-building envelopes and **throw**: `/headers` (`HTTPException(403)`), `agents` `fail` (`ApiError(500, "AGENTS_LOGIN_FAILED")`), waitlist validator (`ApiError(400, "VALIDATION_ERROR", …, { issues })`).

### 2 — Type the `ErrorCode` union end-to-end
- A single, **alphabetized** `ErrorCode` union in `lib/error.ts` (used by `ApiError` / `jsonError` / `httpExceptionCodes`), re-exported from `@api/hono`.
- The web client's `error.code` (`lib/api/client.ts`) is now `ErrorCode | "NETWORK_ERROR" | "UNKNOWN_ERROR"` instead of `string` → autocomplete + exhaustive `switch`.

### 3 — Tidy frontend query consumption (folded from #554)
- `useQuery` + `unwrap` sites return the unwrapped `data` object rather than pre-extracting a field: `WaitlistCount` (`data` vs `data.count`) and `Access` (`data` vs `data.providers`); `ApiStatus` already did. No behavior change.

### Docs
- `web/next/content/docs/manage/api-conventions.mdx` synced to the throw/`onError` model (corrects the stale `jsonError`/`agents.ts` citation), documents `ApiError`, and alphabetizes the error-codes table to mirror the union (added the missing `ERROR` row).

## Grounding
- Hono's idiom is `throw` → central `onError` dispatching by `instanceof`; its custom-error example extends `HTTPException`. [HTTPException](https://hono.dev/docs/api/exception)
- The earlier "route validation through onError" crash is fixed correctly here by throwing our own `ApiError` (a real `Error`), not `@hono/standard-validator`'s non-`Error` `result.error`.

## Verified
- Live: agents → `AGENTS_LOGIN_FAILED` 500, validation → `VALIDATION_ERROR` 400 (issues intact), success → 200 — envelopes byte-identical to before. Type/query/doc steps change no runtime behavior.
- `api` + `web` type-check clean (combined); pre-commit build green.

## Out of scope (deliberate)
- No wrapping of Hono routing / RPC / OpenAPI (the #552 trap).
- Per-route error-code narrowing — its mechanisms undo the throw-containment or recreate #552; Hono may land it natively ([RFC #4270](https://github.com/honojs/hono/issues/4270)). Deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)