### PR TITLE
refactor(web): return unwrapped data from useQuery, not a pre-extracted field

### DIFF
--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -22,19 +22,19 @@ const formSchema = z.object({
 
 function WaitlistCount() {
   // the API returns a display-ready count (floored and rounded server-side)
-  const { data: count } = useQuery({
+  const { data } = useQuery({
     queryKey: ["waitlist-count"],
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.waitlist.$get())
       if (error) return null
-      return data.count
+      return data
     },
   })
 
   // fixed-height slot so the count appearing never shifts the layout
   return (
     <div className="mt-10 flex h-7 items-center justify-center">
-      {typeof count === "number" && count > 0 && (
+      {data && data.count > 0 && (
         <div className="animate-in fade-in flex items-center gap-3 duration-500">
           <AvatarGroup>
             <Avatar className="size-7">
@@ -47,7 +47,9 @@ function WaitlistCount() {
               <AvatarFallback className="bg-chart-4 text-xs text-white">C</AvatarFallback>
             </Avatar>
           </AvatarGroup>
-          <span className="text-muted-foreground text-sm">{count}+ people on the waitlist</span>
+          <span className="text-muted-foreground text-sm">
+            {data.count}+ people on the waitlist
+          </span>
         </div>
       )}
     </div>

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -36,18 +36,18 @@ export function Access() {
   const isDev = process.env.NODE_ENV === "development"
 
   // Render only the sign-in providers the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
-  const { data: providers } = useQuery({
+  const { data } = useQuery({
     queryKey: ["auth-providers"],
     staleTime: Infinity,
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.auth.providers.$get())
       if (error) throw new Error(error.message)
-      return data.providers
+      return data
     },
   })
-  const githubEnabled = providers?.includes("github") ?? false
-  const googleEnabled = providers?.includes("google") ?? false
-  const magicLinkEnabled = providers?.includes("magic-link") ?? false
+  const githubEnabled = data?.providers.includes("github") ?? false
+  const googleEnabled = data?.providers.includes("google") ?? false
+  const magicLinkEnabled = data?.providers.includes("magic-link") ?? false
   const hasAlternatives = isDev || githubEnabled || googleEnabled
   const hasNoProviders = !magicLinkEnabled && !hasAlternatives
 


### PR DESCRIPTION
## What

Make the `useQuery` + `unwrap` sites return the **unwrapped `data` object** and read the field in render, instead of pre-extracting a single field in the `queryFn`.

- `WaitlistCount` (`app/waitlist/page.tsx`): `queryFn` returns `data` (was `data.count`); render uses `data && data.count > 0` → `{data.count}+ …`.
- `Access` (`components/access.tsx`): `queryFn` returns `data` (was `data.providers`); consumers use `data?.providers.includes(…)`.
- `ApiStatus` already returned `data` — left as-is (now consistent across all sites).

## Why

The query holds the raw API payload and the component selects what it needs in render — no narrowing/massaging in the `queryFn`, type flows straight from `unwrap`.

## Notes
- No behavior change (same rendering conditions). `web` type-checks clean; pre-commit build green.
- Independent of #553 (touches only these two web components), so branched off `canary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)