### PR TITLE
fix(api): jsonError code/message win over extra; sync error model docs

### DIFF
--- a/api/hono/src/lib/error.ts
+++ b/api/hono/src/lib/error.ts
@@ -28,7 +28,7 @@ export function jsonError<S extends ContentfulStatusCode>(
   message: string,
   extra?: Record<string, unknown>,
 ) {
-  return c.json({ error: { code, message, ...extra } }, status)
+  return c.json({ error: { ...extra, code, message } }, status)
 }
 
 // Throw this anywhere and onError shapes the { error } envelope. Extends HTTPException so Hono treats it as a known error; carries our envelope's domain code and any extras (e.g. validation issues).

--- a/web/next/content/blog/web-development-2026.mdx
+++ b/web/next/content/blog/web-development-2026.mdx
@@ -167,11 +167,15 @@ The practice is **type safety across the network boundary**. Whether you infer t
 { "error": { "code": "NOT_FOUND", "message": "Not Found" } }
 ```
 
-**Global error handler** standardizes error responses:
+**Routes `throw`** — an `ApiError` for domain codes, or a Hono `HTTPException` for standard ones — and a single global handler turns every thrown error into the envelope:
 
 ```ts
 // api/hono/src/lib/error.ts (wired into app.onError)
 export const errorHandler = (err: Error, c: Context) => {
+  // Domain errors carry their own code/extra; check before HTTPException since ApiError extends it.
+  if (err instanceof ApiError) {
+    return jsonError(c, err.status, err.code, err.message, err.extra)
+  }
   if (err instanceof z.ZodError) {
     return jsonError(c, 400, "VALIDATION_ERROR", "Invalid request payload", { issues: err.issues })
   }

--- a/web/next/content/docs/getting-started/project-structure.mdx
+++ b/web/next/content/docs/getting-started/project-structure.mdx
@@ -42,7 +42,7 @@ The backend API server built with [Hono](https://hono.dev).
 - **`src/middlewares/`**: Custom middlewares
   - `auth.ts`: Authentication middleware for protected routes
   - `rate-limiter.ts`: Rate limiting middleware
-- **`src/lib/error.ts`**: Centralized `errorHandler` (formats Zod validation and internal errors) plus a `jsonError()` helper for consistent `{ error: { code, message } }` envelopes
+- **`src/lib/error.ts`**: Centralized `errorHandler` (the `app.onError` switchboard) that shapes every thrown `ApiError` / `HTTPException` / `ZodError` into a consistent `{ error: { code, message } }` envelope; routes `throw new ApiError(...)` for domain codes from the shared `ErrorCode` union
 
 ### `web/next/`
 


### PR DESCRIPTION
Follow-up to #553 (merged), addressing review findings.

## Doc-sync (the surviving finding)
- **`web/next/content/blog/web-development-2026.mdx`** — the path-attributed `errorHandler` reproduction was stale: it omitted the new `if (err instanceof ApiError)` branch (the centerpiece of #553), so a reader copying it would route every thrown `ApiError` into the `HTTPException`/500 path and lose domain codes. Added the `ApiError` branch and updated the lead-in to the throw model. #553 synced `manage/api-conventions.mdx` but missed this second reproduction.
- **`docs/getting-started/project-structure.mdx`** — reframed `error.ts` from "errorHandler + jsonError helper" to the `app.onError` switchboard that shapes `ApiError`/`HTTPException`/`ZodError`, with routes throwing `ApiError` from the shared `ErrorCode` union.

## Hardening (latent footgun)
- **`api/hono/src/lib/error.ts`** — `jsonError` now builds `{ error: { ...extra, code, message } }` (was `{ code, message, ...extra }`), so the explicit `code`/`message` always win over a stray `extra.code`/`extra.message` and the closed-union guarantee can't be silently broken. Behavior-neutral today (the only `extra` is `{ issues }`) — verified live: validation 400 still returns `VALIDATION_ERROR` + the `issues` array.

## Not changed (by design)
- The `as ApiError["code"]` cast in `client.ts` stays. `ERROR_CODES` exists now, but it isn't safely importable as a runtime value into the web bundle (its module pulls server-only deps), so client-side validation isn't free — the boundary cast is the deliberate trade.

`api` + `web` type-check clean; pre-commit build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses now consistently preserve the main error code and message, even when extra details are included.

* **Documentation**
  * Clarified API error-handling examples in the blog and getting-started docs.
  * Added guidance for handling standardized API errors alongside standard HTTP errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->