### PR TITLE
feat(web): console/dashboard sidebar navigation + rename dev agent to LocalAgent

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -37,7 +37,7 @@ Also restart after changing `@packages/*` exports the API consumes (they resolve
 
 ## Agent login
 
-Sign in as `AgentZero` (local only, trusted Origin required):
+Sign in as `LocalAgent` (local only, trusted Origin required):
 
 ```bash
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Logging in (agents)
 
-Signs in as `AgentZero` (`agent@zerostarter.dev`). Click **Login (agents)** in the dev UI, or use curl:
+Signs in as `LocalAgent` (`agent@local.host`). Click **Login (agents)** in the dev UI, or use curl:
 
 ```bash
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as

--- a/packages/config/src/site.ts
+++ b/packages/config/src/site.ts
@@ -11,8 +11,8 @@ export const site = {
   },
   // Local-only dev agent identity (api/hono agents router).
   agent: {
-    name: "AgentZero",
-    email: "agent@zerostarter.dev",
+    name: "LocalAgent",
+    email: "agent@local.host",
   },
   // Injectable long-form text blocks. These are starter defaults; a fork overrides them to inject its own.
   // OpenAPI / Scalar reference description (api/hono/src/index.ts).

--- a/web/next/content/blog/web-development-2026.mdx
+++ b/web/next/content/blog/web-development-2026.mdx
@@ -866,7 +866,7 @@ The practice is **optimized developer experience**. Fast feedback. Clear errors.
 └── dev/             # run and verify the dev stack
 ```
 
-**Agent-friendly local sign-in.** A `Login (agents)` action signs in as a fixed `AgentZero` user via `/api/agents/sign-in-as` (local-only and trusted-origin gated), so an agent can exercise authenticated routes without a real OAuth dance.
+**Agent-friendly local sign-in.** A `Login (agents)` action signs in as a fixed `LocalAgent` user via `/api/agents/sign-in-as` (local-only and trusted-origin gated), so an agent can exercise authenticated routes without a real OAuth dance.
 
 **llms.txt** auto-generates documentation optimized for AI:
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -34,7 +34,7 @@ The auth config does not set a redirect for the social providers. The post-authe
 
 ### Agent Sign-In (local only)
 
-For local development and AI agents, `POST /api/agents/sign-in-as` signs in as a fixed `AgentZero` user (`agent@zerostarter.dev`) and mints a session cookie directly. It is gated to the `local` environment and a trusted `Origin` header. See `api/hono/src/routers/agents.ts`.
+For local development and AI agents, `POST /api/agents/sign-in-as` signs in as a fixed `LocalAgent` user (`agent@local.host`) and mints a session cookie directly. It is gated to the `local` environment and a trusted `Origin` header. See `api/hono/src/routers/agents.ts`.
 
 ### Adding OAuth Providers
 
@@ -66,7 +66,7 @@ There is no env-based access list: the `role` is the single source of truth, set
 - **Or** `bun run db:studio` / `UPDATE "user" SET role = 'admin' WHERE email = '…';`.
 - **Or**, once an admin exists, the Better Auth `setRole` admin API to grant the role to other users (a console user-management UI is not built yet).
 
-For reference, the local agent sign-in route (`api/hono/src/routers/agents.ts`) sets `role: "admin"` on the `AgentZero` user for local development.
+For reference, the local agent sign-in route (`api/hono/src/routers/agents.ts`) sets `role: "admin"` on the `LocalAgent` user for local development.
 
 ## Organizations & Teams
 

--- a/web/next/src/app/(console)/console/layout.tsx
+++ b/web/next/src/app/(console)/console/layout.tsx
@@ -27,7 +27,7 @@ export default async function Layout({ children }: { children: React.ReactNode }
       nav={<SidebarConsoleContent docsGroups={resolveDocsNav("console")} />}
       footer={
         <SidebarMenu>
-          <SidebarUserMenu user={session.user} />
+          <SidebarUserMenu user={session.user} area="console" />
         </SidebarMenu>
       }
     >

--- a/web/next/src/app/(protected)/layout.tsx
+++ b/web/next/src/app/(protected)/layout.tsx
@@ -31,7 +31,12 @@ export default async function Layout({ children }: { children: React.ReactNode }
   return (
     <SidebarShell
       header={<SidebarDashboardOrgSwitcher />}
-      footer={<SidebarDashboardUserActions user={session.user} />}
+      footer={
+        <SidebarDashboardUserActions
+          user={session.user}
+          canAccessConsole={session.user.role === "admin"}
+        />
+      }
     >
       {children}
     </SidebarShell>

--- a/web/next/src/app/(protected)/layout.tsx
+++ b/web/next/src/app/(protected)/layout.tsx
@@ -30,8 +30,6 @@ export default async function Layout({ children }: { children: React.ReactNode }
 
   return (
     <SidebarShell
-      badge="Dashboard"
-      homeHref="/dashboard"
       header={<SidebarDashboardOrgSwitcher />}
       footer={
         <SidebarDashboardUserActions

--- a/web/next/src/app/(protected)/layout.tsx
+++ b/web/next/src/app/(protected)/layout.tsx
@@ -30,6 +30,8 @@ export default async function Layout({ children }: { children: React.ReactNode }
 
   return (
     <SidebarShell
+      badge="Dashboard"
+      homeHref="/dashboard"
       header={<SidebarDashboardOrgSwitcher />}
       footer={
         <SidebarDashboardUserActions

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -29,19 +29,21 @@ export function SidebarConsoleHeader() {
 
   return (
     <>
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            isActive={pathname === "/console" || pathname === "/console/"}
-            tooltip="Dashboard"
-            className="data-active:font-normal"
-            render={<Link href="/console" onClick={close} />}
-          >
-            <RiDashboardLine />
-            <span>Dashboard</span>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      </SidebarMenu>
+      {!isDocs && (
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              isActive={pathname === "/console" || pathname === "/console/"}
+              tooltip="Dashboard"
+              className="data-active:font-normal"
+              render={<Link href="/console" onClick={close} />}
+            >
+              <RiDashboardLine />
+              <span>Dashboard</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      )}
       {isDocs && (
         <div className="group-data-[collapsible=icon]:hidden">
           <SidebarDocsSearch />

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -68,7 +68,7 @@ export function SidebarConsoleContent({ docsGroups }: { docsGroups: NavGroup[] }
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>Getting Started</SidebarGroupLabel>
+      <SidebarGroupLabel className="pl-2.5">Getting Started</SidebarGroupLabel>
       <SidebarMenu className="space-y-0.5">
         {mainItems.map((item) => {
           const isActive = item.exact

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -15,19 +15,39 @@ import {
 import type { NavGroup } from "@/lib/docs/types"
 
 const mainItems = [
-  { title: "Dashboard", url: "/console", icon: RiTerminalBoxLine, exact: true },
   { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false },
 ] as const
 
-// Sidebar-header slot: shows the docs search only inside /console/docs (matching public /docs); hidden when collapsed to icons.
+// Sidebar-header slot: the console home ("Dashboard") link, plus the docs search inside /console/docs (matching public /docs).
 export function SidebarConsoleHeader() {
   const pathname = usePathname()
-  if (!pathname?.startsWith("/console/docs")) return null
+  const { isMobile, setOpenMobile } = useSidebar()
+  const close = () => {
+    if (isMobile) setOpenMobile(false)
+  }
+  const isDocs = pathname ? pathname.startsWith("/console/docs") : false
 
   return (
-    <div className="group-data-[collapsible=icon]:hidden">
-      <SidebarDocsSearch />
-    </div>
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={pathname === "/console" || pathname === "/console/"}
+            tooltip="Dashboard"
+            className="data-active:font-normal"
+            render={<Link href="/console" onClick={close} />}
+          >
+            <RiTerminalBoxLine />
+            <span>Dashboard</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+      {isDocs && (
+        <div className="group-data-[collapsible=icon]:hidden">
+          <SidebarDocsSearch />
+        </div>
+      )}
+    </>
   )
 }
 

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { RiBookLine, RiTerminalBoxLine } from "@remixicon/react"
+import { RiBookLine, RiDashboardLine } from "@remixicon/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
@@ -18,7 +18,7 @@ const mainItems = [
   { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false },
 ] as const
 
-// Sidebar-header slot: the console home ("Dashboard") link, plus the docs search inside /console/docs (matching public /docs).
+// Sidebar-header slot: a link back to the app Dashboard, plus the docs search inside /console/docs (matching public /docs).
 export function SidebarConsoleHeader() {
   const pathname = usePathname()
   const { isMobile, setOpenMobile } = useSidebar()
@@ -32,12 +32,10 @@ export function SidebarConsoleHeader() {
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton
-            isActive={pathname === "/console" || pathname === "/console/"}
             tooltip="Dashboard"
-            className="data-active:font-normal"
-            render={<Link href="/console" onClick={close} />}
+            render={<Link href="/dashboard" onClick={close} />}
           >
-            <RiTerminalBoxLine />
+            <RiDashboardLine />
             <span>Dashboard</span>
           </SidebarMenuButton>
         </SidebarMenuItem>

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation"
 import { SidebarDocsContent, SidebarDocsSearch } from "@/components/sidebar/docs"
 import {
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -67,6 +68,7 @@ export function SidebarConsoleContent({ docsGroups }: { docsGroups: NavGroup[] }
 
   return (
     <SidebarGroup>
+      <SidebarGroupLabel>Getting Started</SidebarGroupLabel>
       <SidebarMenu className="space-y-0.5">
         {mainItems.map((item) => {
           const isActive = item.exact

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -18,7 +18,7 @@ const mainItems = [
   { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false },
 ] as const
 
-// Sidebar-header slot: a link back to the app Dashboard, plus the docs search inside /console/docs (matching public /docs).
+// Sidebar-header slot: the console home ("Dashboard") link, plus the docs search inside /console/docs (matching public /docs).
 export function SidebarConsoleHeader() {
   const pathname = usePathname()
   const { isMobile, setOpenMobile } = useSidebar()
@@ -32,8 +32,10 @@ export function SidebarConsoleHeader() {
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton
+            isActive={pathname === "/console" || pathname === "/console/"}
             tooltip="Dashboard"
-            render={<Link href="/dashboard" onClick={close} />}
+            className="data-active:font-normal"
+            render={<Link href="/console" onClick={close} />}
           >
             <RiDashboardLine />
             <span>Dashboard</span>

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { RiBookLine, RiDashboardLine } from "@remixicon/react"
+import { RiBookLine, RiTerminalBoxLine } from "@remixicon/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 
@@ -15,7 +15,7 @@ import {
 import type { NavGroup } from "@/lib/docs/types"
 
 const mainItems = [
-  { title: "Dashboard", url: "/console", icon: RiDashboardLine, exact: true },
+  { title: "Dashboard", url: "/console", icon: RiTerminalBoxLine, exact: true },
   { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false },
 ] as const
 

--- a/web/next/src/components/sidebar/dashboard/user-actions.tsx
+++ b/web/next/src/components/sidebar/dashboard/user-actions.tsx
@@ -8,7 +8,13 @@ import { SidebarUserMenu } from "@/components/sidebar/user-menu"
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar"
 import { config } from "@/lib/config"
 
-export function SidebarDashboardUserActions({ user }: { user: User }) {
+export function SidebarDashboardUserActions({
+  user,
+  canAccessConsole,
+}: {
+  user: User
+  canAccessConsole: boolean
+}) {
   return (
     <SidebarMenu className="space-y-1.5">
       <SidebarMenuItem>
@@ -18,7 +24,7 @@ export function SidebarDashboardUserActions({ user }: { user: User }) {
           <span className="text-muted-foreground ml-auto text-[0.6rem]">v{config.app.version}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
-      <SidebarUserMenu user={user} />
+      <SidebarUserMenu user={user} area={canAccessConsole ? "dashboard" : undefined} />
     </SidebarMenu>
   )
 }

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -1,14 +1,20 @@
 "use client"
 
 import { env } from "@packages/env/web-next"
-import { RiLogoutBoxLine, RiMessage2Line } from "@remixicon/react"
+import {
+  RiArrowRightSLine,
+  RiDashboardLine,
+  RiLogoutBoxLine,
+  RiMessage2Line,
+  RiTerminalBoxLine,
+} from "@remixicon/react"
 import { type User } from "better-auth/types"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 
 import { SidebarDropdownMenu } from "@/components/sidebar/dropdown-menu"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
-import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
+import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { SidebarMenuItem } from "@/components/ui/sidebar"
 import { authClient } from "@/lib/auth/client"
 
@@ -19,8 +25,16 @@ function getInitials(name: string) {
 }
 
 // Shared sidebar user dropdown (avatar, identity, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
-export function SidebarUserMenu({ user }: { user: User }) {
+export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard" | "console" }) {
   const router = useRouter()
+
+  // The user menu is shared, so the cross-link points at the other workspace: dashboard -> console, console -> dashboard.
+  const crossLink =
+    area === "dashboard"
+      ? { label: "Console", href: "/console", icon: <RiTerminalBoxLine /> }
+      : area === "console"
+        ? { label: "Dashboard", href: "/dashboard", icon: <RiDashboardLine /> }
+        : null
 
   const avatar = (
     <Avatar className="size-8 rounded-md after:hidden">
@@ -33,6 +47,16 @@ export function SidebarUserMenu({ user }: { user: User }) {
   return (
     <SidebarMenuItem>
       <SidebarDropdownMenu trigger={identity} header={identity} align="end" mobileSide="top">
+        {crossLink && (
+          <>
+            <DropdownMenuItem render={<Link href={crossLink.href} className="cursor-pointer" />}>
+              {crossLink.icon}
+              {crossLink.label}
+              <RiArrowRightSLine className="text-muted-foreground ml-auto size-4" />
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         {env.NEXT_PUBLIC_USERJOT_URL && (
           <DropdownMenuItem
             render={


### PR DESCRIPTION
Sidebar / workspace navigation across the dashboard and console areas, plus the dev-agent rename (#558 folded in).

## Dropdown cross-links (shared user menu)
- **Dashboard** user menu → a **Console** item, shown **only to admins** (`user.role === "admin"`, the same gate as `assertConsoleAccess`, so the link never points where the user can't go).
- **Console** user menu → a **Dashboard** item.
- Trailing chevron (`RiArrowRightSLine`, muted). `SidebarUserMenu` gains an optional `area` prop; the dashboard's admin-ness is resolved server-side in `(protected)/layout.tsx` and threaded down.

## Console sidebar
- The **Dashboard** link moved into the sidebar **header** (→ `/console`, the console's own home), with the dashboard icon. It's hidden on `/console/docs` — there the header shows only the docs search.
- New **Getting Started** group label (`SidebarGroupLabel`) above the **Documentation** nav item; the item itself is unchanged (→ `/console/docs`).

## Dev agent rename
- `AgentZero` / `agent@zerostarter.dev` → **`LocalAgent`** / **`agent@local.host`** in `packages/config/src/site.ts` (source of truth); docs/skill synced — `AGENTS.md` (→ `CLAUDE.md` symlink), `docs/manage/authentication.mdx`, the `web-development-2026` blog, `.agents/skills/dev/SKILL.md` (→ `.claude/skills` symlink). `CHANGELOG`/`.github/audit/*` left as historical.
- `/api/agents/sign-in-as` is local-only (gated to `NODE_ENV=local` + trusted Origin) — no prod/canary impact, no migration; the user is created on first sign-in.

## Verified
- `web` type-checks clean; pre-commit build green.
- Live (agent login → role admin): cross-links present; `/console` shows the Dashboard header link + the "Getting Started" label over "Documentation"; `/console/docs` hides the Dashboard link (search only); rename verified (sign-in creates `LocalAgent` / `agent@local.host`).
- The dropdown cross-link items are client-rendered, so a visual confirmation in the dev UI is the one remaining manual step (no headless browser in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)