### PR TITLE
chore(config): rename dev agent identity to LocalAgent (agent@local.host)

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -37,7 +37,7 @@ Also restart after changing `@packages/*` exports the API consumes (they resolve
 
 ## Agent login
 
-Sign in as `AgentZero` (local only, trusted Origin required):
+Sign in as `LocalAgent` (local only, trusted Origin required):
 
 ```bash
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This file provides guidance to AI coding agents when working with code in this r
 
 ## Logging in (agents)
 
-Signs in as `AgentZero` (`agent@zerostarter.dev`). Click **Login (agents)** in the dev UI, or use curl:
+Signs in as `LocalAgent` (`agent@local.host`). Click **Login (agents)** in the dev UI, or use curl:
 
 ```bash
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as

--- a/packages/config/src/site.ts
+++ b/packages/config/src/site.ts
@@ -11,8 +11,8 @@ export const site = {
   },
   // Local-only dev agent identity (api/hono agents router).
   agent: {
-    name: "AgentZero",
-    email: "agent@zerostarter.dev",
+    name: "LocalAgent",
+    email: "agent@local.host",
   },
   // Injectable long-form text blocks. These are starter defaults; a fork overrides them to inject its own.
   // OpenAPI / Scalar reference description (api/hono/src/index.ts).

--- a/web/next/content/blog/web-development-2026.mdx
+++ b/web/next/content/blog/web-development-2026.mdx
@@ -866,7 +866,7 @@ The practice is **optimized developer experience**. Fast feedback. Clear errors.
 └── dev/             # run and verify the dev stack
 ```
 
-**Agent-friendly local sign-in.** A `Login (agents)` action signs in as a fixed `AgentZero` user via `/api/agents/sign-in-as` (local-only and trusted-origin gated), so an agent can exercise authenticated routes without a real OAuth dance.
+**Agent-friendly local sign-in.** A `Login (agents)` action signs in as a fixed `LocalAgent` user via `/api/agents/sign-in-as` (local-only and trusted-origin gated), so an agent can exercise authenticated routes without a real OAuth dance.
 
 **llms.txt** auto-generates documentation optimized for AI:
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -34,7 +34,7 @@ The auth config does not set a redirect for the social providers. The post-authe
 
 ### Agent Sign-In (local only)
 
-For local development and AI agents, `POST /api/agents/sign-in-as` signs in as a fixed `AgentZero` user (`agent@zerostarter.dev`) and mints a session cookie directly. It is gated to the `local` environment and a trusted `Origin` header. See `api/hono/src/routers/agents.ts`.
+For local development and AI agents, `POST /api/agents/sign-in-as` signs in as a fixed `LocalAgent` user (`agent@local.host`) and mints a session cookie directly. It is gated to the `local` environment and a trusted `Origin` header. See `api/hono/src/routers/agents.ts`.
 
 ### Adding OAuth Providers
 
@@ -66,7 +66,7 @@ There is no env-based access list: the `role` is the single source of truth, set
 - **Or** `bun run db:studio` / `UPDATE "user" SET role = 'admin' WHERE email = '…';`.
 - **Or**, once an admin exists, the Better Auth `setRole` admin API to grant the role to other users (a console user-management UI is not built yet).
 
-For reference, the local agent sign-in route (`api/hono/src/routers/agents.ts`) sets `role: "admin"` on the `AgentZero` user for local development.
+For reference, the local agent sign-in route (`api/hono/src/routers/agents.ts`) sets `role: "admin"` on the `LocalAgent` user for local development.
 
 ## Organizations & Teams
 


### PR DESCRIPTION
Renames the local-only dev agent identity: `AgentZero` / `agent@zerostarter.dev` → **`LocalAgent`** / **`agent@local.host`**.

## Changes
- `packages/config/src/site.ts` — `site.agent.name` / `site.agent.email` (the source of truth the `agents` router reads).
- Doc-sync: `AGENTS.md` (→ `CLAUDE.md` via symlink), `docs/manage/authentication.mdx` (×2), the `web-development-2026` blog, and `.agents/skills/dev/SKILL.md` (→ `.claude/skills` via symlink).
- `CHANGELOG.md` and `.github/audit/*` left as historical records.

## Notes
- The `/api/agents/sign-in-as` route is **local-only** (gated to `NODE_ENV=local` + trusted Origin), so this touches only local dev — prod/canary are unaffected, no migration. The route creates the user on first sign-in, so the new `LocalAgent` is provisioned automatically; the old `AgentZero` row just becomes an unused local-DB remnant.

## Verified
- Rebuilt `@packages/config`, restarted dev, signed in via `/api/agents/sign-in-as`: creates **LocalAgent / agent@local.host / role admin** (Better Auth accepts the email). Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)