### PR TITLE
chore: cleanup batch — Zod 4 error param, bun audit to pre-push, CI concurrency

### DIFF
--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -7,6 +7,10 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   auto-check-build:
     name: Audit, Lint, and Build

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,11 +1,6 @@
 pre-commit:
   piped: true
   commands:
-    audit:
-      run: bun audit --audit-level high
-      use_stdin: true
-      only:
-        - ref: canary
     lint-staged:
       run: bunx lint-staged --verbose
       stage_fixed: true
@@ -20,5 +15,9 @@ commit-msg:
 
 pre-push:
   commands:
+    audit:
+      run: bun audit --audit-level high
+      only:
+        - ref: canary
     ensure-main:
       run: bun .github/scripts/ensure-remote-main.ts {1}

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -15,7 +15,7 @@ import { Input } from "@/components/ui/input"
 import { apiClient, unwrap } from "@/lib/api/client"
 
 const formSchema = z.object({
-  email: z.email({ message: "Please enter a valid email address." }).max(254),
+  email: z.email({ error: "Please enter a valid email address." }).max(254),
   // honeypot: unconstrained so it never blocks submission; the server silently drops bots
   subject: z.string(),
 })

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -24,7 +24,7 @@ import { authClient } from "@/lib/auth/client"
 import { config } from "@/lib/config"
 
 const formSchema = z.object({
-  email: z.email({ message: "Please enter a valid email address." }),
+  email: z.email({ error: "Please enter a valid email address." }),
 })
 
 export function Access() {


### PR DESCRIPTION
Finalize cleanup — three small, self-contained fixes, one per issue.

- **#524** — Zod 4 `error` param: `z.email({ error: … })` at the waitlist and access sign-in forms (Zod 4 deprecated `message`). Behavior unchanged.
- **#461** — `lefthook.yml`: moved `bun audit --audit-level high` from **pre-commit** to **pre-push** (still `canary`-gated), so an offline commit no longer hits the registry. CI's `auto-check-build` already runs the audit too.
- **#422** — `auto-check-build.yml`: added a `concurrency` group (per-PR, `cancel-in-progress: true`) so the `pull_request` and `pull_request_review` triggers never run at the same time — both triggers kept (as requested); a newer run supersedes the in-progress one. (The original `pull_request_target` base-branch bug was already gone.)

Closes #524, closes #461, closes #422.

**Deferred — #485** (route home OG through `renderOgImage`): the home OG and `renderOgImage` are genuinely different layouts (hero vs content card), not the trivial de-dup the issue implies. Will do later.

## Verified
- `web` type-checks clean; `lefthook.yml` and the workflow YAML are valid.
- Note: the pre-commit build non-deterministically re-compresses `web/next/public/docs/release/workflow-permissions.png`; excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)