### PR TITLE
chore: bump Bun to 1.3.14

### DIFF
--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --ignore-scripts

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Configure Git
         run: |

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Release Package
         run: |

--- a/api/hono/Dockerfile
+++ b/api/hono/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM oven/bun:1.3.10-alpine AS base
+FROM oven/bun:1.3.14-alpine AS base
 WORKDIR /app
 
 FROM base AS prepare

--- a/api/hono/vercel.json
+++ b/api/hono/vercel.json
@@ -4,5 +4,5 @@
   "installCommand": "cd ../.. && bun install --ignore-scripts",
   "buildCommand": "cd ../.. && bun .github/scripts/migrate-on-deploy.ts && turbo build:vercel --filter=@api/hono",
   "outputDirectory": "vercel-bundle",
-  "bunVersion": "1.3.10"
+  "bunVersion": "1.3.14"
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "@commitlint/config-conventional"
     ]
   },
-  "packageManager": "bun@1.3.10",
+  "packageManager": "bun@1.3.14",
   "catalog": {
     "@arcjet/ip": "^1.5.0",
     "@base-ui/react": "^1.6.0",

--- a/web/next/Dockerfile
+++ b/web/next/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM oven/bun:1.3.10-alpine AS base
+FROM oven/bun:1.3.14-alpine AS base
 WORKDIR /app
 
 FROM base AS prepare

--- a/web/next/content/docs/deployment/docker.mdx
+++ b/web/next/content/docs/deployment/docker.mdx
@@ -91,7 +91,7 @@ docker run -p 3000:3000 --env-file .env zerostarter-web
 
 Both Dockerfiles share the same shape:
 
-- Base image `oven/bun:1.3.10-alpine`.
+- Base image `oven/bun:1.3.14-alpine`.
 - Four stages: `base` -> `prepare` -> `builder` -> `runner`. The `prepare` stage runs `turbo prune <workspace> --docker` to produce a pruned, workspace-only build context, so each image installs and builds just the dependencies it needs.
 - The final `runner` stage runs as the non-root `USER bun`.
 

--- a/web/next/content/docs/deployment/vercel.mdx
+++ b/web/next/content/docs/deployment/vercel.mdx
@@ -27,7 +27,7 @@ Each workspace includes a `vercel.json` with the correct install, build, and fra
 | Framework       | Next.js                                      |
 | Install Command | `cd ../.. && bun install --ignore-scripts`   |
 | Build Command   | `cd ../.. && turbo build --filter=@web/next` |
-| Bun Version     | 1.3.10                                       |
+| Bun Version     | 1.3.14                                       |
 
 ### Environment Variables
 
@@ -59,7 +59,7 @@ NEXT_PUBLIC_USERJOT_URL=your_userjot_url
 | Install Command  | `cd ../.. && bun install --ignore-scripts`                                                      |
 | Build Command    | `cd ../.. && bun .github/scripts/migrate-on-deploy.ts && turbo build:vercel --filter=@api/hono` |
 | Output Directory | `vercel-bundle`                                                                                 |
-| Bun Version      | 1.3.10                                                                                          |
+| Bun Version      | 1.3.14                                                                                          |
 
 ### Migrations on deploy
 

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -14,7 +14,7 @@ This guide will walk you through installing and setting up ZeroStarter on your l
 
 <Callout type="warn">
 
-Bun v1.3.10 or later (matching the repo's `packageManager` pin). Docker is required for the `--db` database provisioning. A reachable PostgreSQL instance is required to run the app.
+Bun v1.3.14 or later (matching the repo's `packageManager` pin). Docker is required for the `--db` database provisioning. A reachable PostgreSQL instance is required to run the app.
 
 </Callout>
 

--- a/web/next/vercel.json
+++ b/web/next/vercel.json
@@ -3,5 +3,5 @@
   "framework": "nextjs",
   "installCommand": "cd ../.. && bun install --ignore-scripts",
   "buildCommand": "cd ../.. && turbo build --filter=@web/next",
-  "bunVersion": "1.3.10"
+  "bunVersion": "1.3.14"
 }


### PR DESCRIPTION
Bumps the pinned Bun version from `1.3.10` to `1.3.14` across the repo.

## Changes
- `oven/bun` Docker base images — `api/hono/Dockerfile`, `web/next/Dockerfile`
- `packageManager` pin in root `package.json`
- `bunVersion` in `api/hono/vercel.json` + `web/next/vercel.json`
- CI `setup-bun` `bun-version` pinned `latest` → `1.3.14` (5 steps across 4 workflows)
- Docs: `getting-started/setup.mdx`, `deployment/docker.mdx`, `deployment/vercel.mdx`

## Notes
- Dated `.github/audit/*` reports left unchanged (historical record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)