### PR TITLE
feat(web): flush navbar + sidebars with background, fix docs active-link

### DIFF
--- a/web/next/src/app/globals.css
+++ b/web/next/src/app/globals.css
@@ -73,7 +73,7 @@
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.985 0 0);
+  --sidebar: var(--background);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
   --sidebar-primary-foreground: oklch(0.985 0 0);
@@ -110,7 +110,7 @@
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: var(--background);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
   --sidebar-primary-foreground: oklch(0.985 0 0);

--- a/web/next/src/components/navbar/home.tsx
+++ b/web/next/src/components/navbar/home.tsx
@@ -88,7 +88,7 @@ export function Navbar() {
   ]
 
   return (
-    <header className="bg-sidebar fixed top-0 left-0 z-50 w-full border-b">
+    <header className="bg-background fixed top-0 left-0 z-50 w-full border-b">
       <div className="flex min-h-14 items-center justify-between pr-5 pl-3.5">
         <Link href="/" className="flex items-center gap-2 font-bold">
           {site.name}

--- a/web/next/src/components/sidebar/docs/content.tsx
+++ b/web/next/src/components/sidebar/docs/content.tsx
@@ -29,8 +29,7 @@ export function SidebarDocsContent({ groups }: { groups: NavGroup[] }) {
   const pathname = usePathname()
   const { isMobile, setOpenMobile } = useSidebar()
 
-  const isActive = (url: string): boolean =>
-    pathname === url || pathname === url + "/" || (pathname?.startsWith(url + "/") ?? false)
+  const isActive = (url: string): boolean => pathname === url || pathname === url + "/"
   const close = () => {
     if (isMobile) setOpenMobile(false)
   }


### PR DESCRIPTION
## Changes
- **fix** — docs sidebar highlights only the *exact* active page. Dropped a `startsWith(url + "/")` over-match that lit `/docs` (Introduction) on every `/docs/*` page. Also covers `/console/docs`, which reuses the same `SidebarDocsContent`.
- **style** — `--sidebar` token → `var(--background)` so all sidebars sit flush with the page, and the navbar header → `bg-background`. Unifies navbar + docs/console/dashboard sidebars with the background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sidebar and header styling to better match the current page background in both light and dark themes.
  * Improved section highlighting in the docs sidebar so only the exact page and its trailing-slash variant are marked active, reducing incorrect matches on nested routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->