### PR TITLE
fix(web): sidebar chevron + dropdown open-state styling (Base UI attrs)

### DIFF
--- a/web/next/src/components/sidebar/docs/content.tsx
+++ b/web/next/src/components/sidebar/docs/content.tsx
@@ -129,8 +129,8 @@ function NavTreeGroup({
       render={<Item />}
     >
       <CollapsibleTrigger render={<Trigger {...(sub ? {} : { tooltip: group.label })} />}>
-        <RiArrowRightSLine className="transition-transform duration-200 group-data-[state=open]:rotate-90" />
         <span>{group.label}</span>
+        <RiArrowRightSLine className="ml-auto transition-transform duration-200 group-data-[open]:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent>
         <SidebarMenuSub className="mr-0 gap-y-0.5 pr-0 pl-2">

--- a/web/next/src/components/sidebar/dropdown-menu.tsx
+++ b/web/next/src/components/sidebar/dropdown-menu.tsx
@@ -52,7 +52,7 @@ export function SidebarDropdownMenu({
         render={
           <SidebarMenuButton
             size="lg"
-            className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground cursor-pointer border"
+            className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground cursor-pointer border"
           />
         }
       >


### PR DESCRIPTION
Three sidebar fixes:
1. Docs sidebar collapsible chevrons now sit on the **right** edge.
2. Chevrons **rotate down on expand** (was Radix `data-state` vs Base UI `data-open`).
3. Sidebar dropdown trigger (org switcher + user menu) **highlights while open** (Radix `data-state` vs Base UI `data-popup-open`).

2 and 3 were latent bugs from the Radix to Base UI migration; 1 is a layout tweak. Verified in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar menu behavior so open states display consistently.
  * Fixed the documentation navigation header layout so the arrow icon stays aligned to the right and the label appears first.
  * Updated open-state styling in dropdown and collapsible sidebar elements for more reliable visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->