### PR TITLE
fix(web): clean up UI consistency from the audit

### DIFF
--- a/web/next/src/app/(protected)/layout.tsx
+++ b/web/next/src/app/(protected)/layout.tsx
@@ -20,11 +20,13 @@ export default async function Layout({ children }: { children: React.ReactNode }
     if (lastOrgId) {
       const url = `${config.api.internalUrl || config.api.url}/api/auth/organization/set-active`
       const reqHeaders = Object.fromEntries((await headers()).entries())
-      await fetch(url, {
-        method: "POST",
-        headers: { ...reqHeaders, "content-type": "application/json" },
-        body: JSON.stringify({ organizationId: lastOrgId }),
-      }).catch(() => {})
+      try {
+        await fetch(url, {
+          method: "POST",
+          headers: { ...reqHeaders, "content-type": "application/json" },
+          body: JSON.stringify({ organizationId: lastOrgId }),
+        })
+      } catch {}
     }
   }
 

--- a/web/next/src/app/hire/page.tsx
+++ b/web/next/src/app/hire/page.tsx
@@ -148,7 +148,7 @@ const linkClass = "border-border hover:border-ring border-b transition-colors"
 
 export default function Page() {
   return (
-    <div className="bg-background text-foreground min-h-screen space-y-16 py-36 text-lg">
+    <main className="bg-background text-foreground min-h-screen space-y-16 py-36 text-lg">
       {/* hook */}
       <div className="container mx-auto max-w-3xl space-y-8 px-5">
         <h1 className={`${caveat.className} text-3xl font-semibold tracking-wide`}>nrjdalal</h1>
@@ -245,7 +245,7 @@ export default function Page() {
       <div className="container mx-auto grid max-w-3xl gap-8 px-5 sm:grid-cols-2">
         {sections.map((section) => (
           <div key={section.title} className="space-y-8">
-            <h1 className={headingClass}>{section.title}</h1>
+            <h2 className={headingClass}>{section.title}</h2>
             {section.projects.map((project) => (
               <div key={project.title} className="space-y-2">
                 {project.external === false ? (
@@ -274,7 +274,7 @@ export default function Page() {
 
       {/* writing */}
       <div className="container mx-auto max-w-3xl space-y-8 px-5">
-        <h1 className={headingClass}>writing</h1>
+        <h2 className={headingClass}>writing</h2>
         <div className="space-y-2">
           <Link href="/blog/a-biography-written-in-code" className={linkClass}>
             A Biography Written in Code
@@ -289,7 +289,7 @@ export default function Page() {
 
       {/* hire me */}
       <div className="container mx-auto max-w-3xl space-y-8 px-5">
-        <h1 className={headingClass}>hire me</h1>
+        <h2 className={headingClass}>hire me</h2>
         <div className="space-y-4">
           <p>
             I'm best suited for teams building ambitious products with a small, high-agency
@@ -312,7 +312,7 @@ export default function Page() {
 
       {/* hobbies */}
       <div className="container mx-auto max-w-3xl space-y-8 px-5">
-        <h1 className={headingClass}>hobbies</h1>
+        <h2 className={headingClass}>hobbies</h2>
         <div className="space-y-4">
           <p>
             When I'm not coding, you'll find me consuming content and playing games.{" "}
@@ -329,7 +329,7 @@ export default function Page() {
 
       {/* connect */}
       <div className="container mx-auto max-w-3xl space-y-8 px-5">
-        <h1 className={headingClass}>connect</h1>
+        <h2 className={headingClass}>connect</h2>
         <p>
           Want to chat? Leave a message on{" "}
           <a
@@ -339,7 +339,7 @@ export default function Page() {
             aria-label="X (Twitter)"
             className={linkClass}
           >
-            <RiTwitterXFill className="-mt-1 inline size-4.5" />
+            <RiTwitterXFill className="-mt-1 inline size-5" />
           </a>{" "}
           or send an email to{" "}
           <a href="mailto:nrjdalal.dev@gmail.com" className={linkClass}>
@@ -348,6 +348,6 @@ export default function Page() {
           .
         </p>
       </div>
-    </div>
+    </main>
   )
 }

--- a/web/next/src/app/page.tsx
+++ b/web/next/src/app/page.tsx
@@ -219,7 +219,7 @@ bun dev`
   })
 
   return (
-    <div className="flex flex-col select-none">
+    <main className="flex flex-col select-none">
       {/* Hero Section */}
       <section
         aria-label="Hero"
@@ -796,6 +796,6 @@ bun dev`
           </div>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/web/next/src/app/resume/page.tsx
+++ b/web/next/src/app/resume/page.tsx
@@ -167,7 +167,7 @@ const linkClass = "border-border hover:border-ring border-b transition-colors"
 
 export default function Page() {
   return (
-    <div className="bg-background text-foreground min-h-screen space-y-16 py-36 text-base">
+    <main className="bg-background text-foreground min-h-screen space-y-16 py-36 text-base">
       {/* header */}
       <div className="container mx-auto max-w-3xl space-y-8 px-5">
         <h1 className={`${caveat.className} text-3xl font-semibold tracking-wide`}>résumé</h1>
@@ -316,6 +316,6 @@ export default function Page() {
           .
         </p>
       </div>
-    </div>
+    </main>
   )
 }

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { site } from "@packages/config/site"
-import { RiLoaderLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
@@ -12,6 +11,7 @@ import { Avatar, AvatarFallback, AvatarGroup } from "@/components/ui/avatar"
 import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { Spinner } from "@/components/ui/spinner"
 import { apiClient, unwrap } from "@/lib/api/client"
 
 const formSchema = z.object({
@@ -26,6 +26,7 @@ function WaitlistCount() {
     queryKey: ["waitlist-count"],
     queryFn: async () => {
       const { data, error } = await unwrap(apiClient.waitlist.$get())
+      // swallowing the error is deliberate: the count is non-critical chrome, so a failure just hides it
       if (error) return null
       return data
     },
@@ -157,11 +158,7 @@ export default function WaitlistPage() {
               className="h-12 w-full px-6 text-base sm:w-auto"
               disabled={joinWaitlist.isPending}
             >
-              {joinWaitlist.isPending ? (
-                <RiLoaderLine className="animate-spin" />
-              ) : (
-                "Join the waitlist"
-              )}
+              {joinWaitlist.isPending ? <Spinner /> : "Join the waitlist"}
             </Button>
           </form>
         )}

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { site } from "@packages/config/site"
-import { RiGithubFill, RiGoogleFill, RiLayoutGridFill, RiLoaderLine } from "@remixicon/react"
+import { RiGithubFill, RiGoogleFill, RiLayoutGridFill } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { useQuery } from "@tanstack/react-query"
 import { usePathname } from "next/navigation"
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { Spinner } from "@/components/ui/spinner"
 import { apiClient, unwrap } from "@/lib/api/client"
 import { authClient } from "@/lib/auth/client"
 import { config } from "@/lib/config"
@@ -36,7 +37,7 @@ export function Access() {
   const isDev = process.env.NODE_ENV === "development"
 
   // Render only the sign-in providers the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
-  const { data } = useQuery({
+  const { data, isError } = useQuery({
     queryKey: ["auth-providers"],
     staleTime: Infinity,
     queryFn: async () => {
@@ -87,7 +88,7 @@ export function Access() {
       <DialogTrigger render={<Button className="w-24 cursor-pointer" variant="outline" />}>
         Login
       </DialogTrigger>
-      <DialogContent className="max-w-md sm:max-w-md" initialFocus={false}>
+      <DialogContent className="max-w-md" initialFocus={false}>
         <DialogHeader className="sr-only">
           <DialogTitle className="text-center">Sign in/up</DialogTitle>
         </DialogHeader>
@@ -104,7 +105,7 @@ export function Access() {
           {magicLinkEnabled && (
             <form
               id="email"
-              className="space-y-4"
+              className="flex flex-col gap-4"
               onSubmit={(e) => {
                 e.preventDefault()
                 form.handleSubmit()
@@ -142,7 +143,7 @@ export function Access() {
                 className="w-full cursor-pointer"
                 disabled={loader === "email"}
               >
-                {loader === "email" ? <RiLoaderLine className="size-5 animate-spin" /> : null}
+                {loader === "email" ? <Spinner /> : null}
                 Sign in/up
               </Button>
             </form>
@@ -181,11 +182,7 @@ export function Access() {
                   }}
                   disabled={loader === "github"}
                 >
-                  {loader === "github" ? (
-                    <RiLoaderLine className="size-5 animate-spin" />
-                  ) : (
-                    <RiGithubFill className="size-5" />
-                  )}
+                  {loader === "github" ? <Spinner /> : <RiGithubFill className="size-5" />}
                   Continue with Github
                 </Button>
               )}
@@ -207,24 +204,25 @@ export function Access() {
                   }}
                   disabled={loader === "google"}
                 >
-                  {loader === "google" ? (
-                    <RiLoaderLine className="size-5 animate-spin" />
-                  ) : (
-                    <RiGoogleFill className="size-5" />
-                  )}
+                  {loader === "google" ? <Spinner /> : <RiGoogleFill className="size-5" />}
                   Continue with Google
                 </Button>
               )}
-              <div className="text-muted-foreground *:[a]:hover:text-primary text-center text-xs text-balance *:[a]:underline *:[a]:underline-offset-4">
-                By clicking continue, you agree to our <a href="#">Terms of Service</a> and{" "}
-                <a href="#">Privacy Policy</a>.
+              <div className="text-muted-foreground text-center text-xs text-balance">
+                By clicking continue, you agree to our Terms of Service and Privacy Policy.
               </div>
             </div>
           )}
-          {hasNoProviders && (
+          {isError ? (
             <p className="text-muted-foreground text-center text-sm">
-              No sign-in options are configured yet.
+              Could not load sign-in options. Refresh to try again.
             </p>
+          ) : (
+            hasNoProviders && (
+              <p className="text-muted-foreground text-center text-sm">
+                No sign-in options are configured yet.
+              </p>
+            )
           )}
         </div>
       </DialogContent>

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -213,17 +213,16 @@ export function Access() {
               </div>
             </div>
           )}
-          {isError ? (
-            <p className="text-muted-foreground text-center text-sm">
-              Could not load sign-in options. Refresh to try again.
-            </p>
-          ) : (
-            hasNoProviders && (
+          {hasNoProviders &&
+            (isError ? (
+              <p className="text-muted-foreground text-center text-sm">
+                Could not load sign-in options. Refresh to try again.
+              </p>
+            ) : (
               <p className="text-muted-foreground text-center text-sm">
                 No sign-in options are configured yet.
               </p>
-            )
-          )}
+            ))}
         </div>
       </DialogContent>
     </Dialog>

--- a/web/next/src/components/api-status.tsx
+++ b/web/next/src/components/api-status.tsx
@@ -23,7 +23,7 @@ export function ApiStatus() {
         className="invisible flex h-8 items-center justify-center gap-2 rounded-full border px-4 py-1.5 text-sm"
       >
         <div className="size-2 shrink-0 rounded-full" />
-        <span className="w-45 text-center">All systems are operational</span>
+        <span className="min-w-48 text-center whitespace-nowrap">All systems are operational</span>
       </div>
     )
   }
@@ -36,7 +36,7 @@ export function ApiStatus() {
         className="bg-destructive/10 text-destructive border-destructive/20 animate-in fade-in flex h-8 items-center justify-center gap-2 rounded-full border px-4 py-1.5 text-sm duration-2000"
       >
         <div className="bg-destructive size-2 shrink-0 rounded-full" />
-        <span className="w-45 text-center">Systems are facing issues</span>
+        <span className="min-w-48 text-center whitespace-nowrap">Systems are facing issues</span>
       </div>
     )
   }
@@ -48,7 +48,7 @@ export function ApiStatus() {
       className="animate-in fade-in flex h-8 items-center justify-center gap-2 rounded-full border border-green-500/20 bg-green-500/10 px-4 py-1.5 text-sm text-green-600 duration-2000 dark:text-green-400"
     >
       <div className="size-2 shrink-0 rounded-full bg-green-500" />
-      <span className="w-45 text-center">All systems are operational</span>
+      <span className="min-w-48 text-center whitespace-nowrap">All systems are operational</span>
     </div>
   )
 }

--- a/web/next/src/components/devtools.tsx
+++ b/web/next/src/components/devtools.tsx
@@ -45,10 +45,13 @@ export function DevTools() {
         </>
       )}
 
-      <RiCodeLine
-        className="size-7.5 cursor-pointer p-1.5"
+      <button
+        type="button"
+        aria-label="Toggle devtools"
         onClick={() => setExpandDevtools(!expandDevtools)}
-      />
+      >
+        <RiCodeLine className="size-8 p-1.5" />
+      </button>
     </div>
   )
 }

--- a/web/next/src/components/navbar/home.tsx
+++ b/web/next/src/components/navbar/home.tsx
@@ -5,7 +5,6 @@ import {
   RiArrowRightUpLine,
   RiDiscordFill,
   RiGithubFill,
-  RiLoaderLine,
   RiMenuLine,
   RiTwitterXFill,
 } from "@remixicon/react"
@@ -17,9 +16,10 @@ import { Access } from "@/components/access"
 import { ModeToggle } from "@/components/mode-toggle"
 import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
+import { Spinner } from "@/components/ui/spinner"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { authClient } from "@/lib/auth/client"
-import { cn } from "@/lib/utils"
+import { cn, isActive } from "@/lib/utils"
 
 const socialLinks = [
   {
@@ -95,9 +95,9 @@ export function Navbar() {
         </Link>
         <div className="flex items-center gap-2.5">
           {/* Desktop Navigation */}
-          <nav aria-label="Main navigation" className="mx-5 hidden items-center gap-7.5 lg:flex">
+          <nav aria-label="Main navigation" className="mx-5 hidden items-center gap-8 lg:flex">
             {navLinks.map((link) => {
-              const isActive = !link.external && pathname?.startsWith(link.href)
+              const active = !link.external && isActive(pathname, link.href, { exact: false })
               if (link.external) {
                 return (
                   <a
@@ -118,7 +118,7 @@ export function Navbar() {
                   href={link.href}
                   className={cn(
                     "font-medium transition-colors",
-                    isActive ? "text-foreground" : "hover:text-foreground/80 text-foreground/60",
+                    active ? "text-foreground" : "hover:text-foreground/80 text-foreground/60",
                   )}
                 >
                   {link.label}
@@ -140,7 +140,7 @@ export function Navbar() {
               onClick={() => setToDashboard(true)}
               render={<Link href="/dashboard" />}
             >
-              {toDashboard ? <RiLoaderLine className="animate-spin" /> : "Dashboard"}
+              {toDashboard ? <Spinner /> : "Dashboard"}
             </Button>
           ) : (
             <Access />
@@ -180,7 +180,7 @@ export function Navbar() {
               </SheetHeader>
               <nav className="ml-4 flex flex-col gap-5">
                 {navLinks.map((link) => {
-                  const isActive = !link.external && pathname?.startsWith(link.href)
+                  const active = !link.external && isActive(pathname, link.href, { exact: false })
                   if (link.external) {
                     return (
                       <a
@@ -202,9 +202,7 @@ export function Navbar() {
                       href={link.href}
                       className={cn(
                         "font-medium transition-colors",
-                        isActive
-                          ? "text-foreground"
-                          : "hover:text-foreground/80 text-foreground/60",
+                        active ? "text-foreground" : "hover:text-foreground/80 text-foreground/60",
                       )}
                       onClick={() => setIsOpen(false)}
                     >

--- a/web/next/src/components/sidebar/console.tsx
+++ b/web/next/src/components/sidebar/console.tsx
@@ -14,6 +14,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 import type { NavGroup } from "@/lib/docs/types"
+import { isActive } from "@/lib/utils"
 
 const mainItems = [
   { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false },
@@ -34,7 +35,7 @@ export function SidebarConsoleHeader() {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton
-              isActive={pathname === "/console" || pathname === "/console/"}
+              isActive={isActive(pathname, "/console")}
               tooltip="Dashboard"
               className="data-active:font-normal"
               render={<Link href="/console" onClick={close} />}
@@ -71,14 +72,12 @@ export function SidebarConsoleContent({ docsGroups }: { docsGroups: NavGroup[] }
       <SidebarGroupLabel className="pl-2.5">Getting Started</SidebarGroupLabel>
       <SidebarMenu className="space-y-0.5">
         {mainItems.map((item) => {
-          const isActive = item.exact
-            ? pathname === item.url || pathname === item.url + "/"
-            : pathname === item.url || pathname?.startsWith(item.url + "/")
+          const active = isActive(pathname, item.url, { exact: item.exact })
 
           return (
             <SidebarMenuItem key={item.url}>
               <SidebarMenuButton
-                isActive={isActive}
+                isActive={active}
                 tooltip={item.title}
                 className="data-active:font-normal"
                 render={<Link href={item.url} onClick={close} />}

--- a/web/next/src/components/sidebar/dashboard/org-switcher.tsx
+++ b/web/next/src/components/sidebar/dashboard/org-switcher.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { RiAddLine, RiBuildingLine, RiLoaderLine } from "@remixicon/react"
+import { RiAddLine, RiBuildingLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { useState } from "react"
 import { toast } from "sonner"
@@ -18,6 +18,7 @@ import {
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { Spinner } from "@/components/ui/spinner"
 import { authClient } from "@/lib/auth/client"
 import { slugify } from "@/lib/utils"
 
@@ -138,13 +139,18 @@ export function SidebarDashboardOrgSwitcher() {
             <DropdownMenuItem
               key={org.id}
               className="cursor-pointer"
+              disabled={isOrgTransitioning}
               onClick={() => handleSetActive(org.id)}
             >
               <RiBuildingLine />
               {org.name}
             </DropdownMenuItem>
           ))}
-        <DropdownMenuItem className="cursor-pointer" onClick={() => setCreateDialogOpen(true)}>
+        <DropdownMenuItem
+          className="cursor-pointer"
+          disabled={isOrgTransitioning}
+          onClick={() => setCreateDialogOpen(true)}
+        >
           <RiAddLine />
           Create organization
         </DropdownMenuItem>
@@ -202,7 +208,7 @@ export function SidebarDashboardOrgSwitcher() {
               className="w-full cursor-pointer"
               disabled={form.state.isSubmitting}
             >
-              {form.state.isSubmitting ? <RiLoaderLine className="size-5 animate-spin" /> : null}
+              {form.state.isSubmitting ? <Spinner /> : null}
               Create organization
             </Button>
           </form>

--- a/web/next/src/components/sidebar/dashboard/user-actions.tsx
+++ b/web/next/src/components/sidebar/dashboard/user-actions.tsx
@@ -21,7 +21,7 @@ export function SidebarDashboardUserActions({
         <SidebarMenuButton render={<Link href="/docs" />}>
           <RiBookLine />
           <span>Documentation</span>
-          <span className="text-muted-foreground ml-auto text-[0.6rem]">v{config.app.version}</span>
+          <span className="text-muted-foreground ml-auto text-xs">v{config.app.version}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
       <SidebarUserMenu user={user} area={canAccessConsole ? "dashboard" : undefined} />

--- a/web/next/src/components/sidebar/docs/content.tsx
+++ b/web/next/src/components/sidebar/docs/content.tsx
@@ -18,6 +18,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar"
 import type { NavGroup, NavItem, NavNode } from "@/lib/docs/types"
+import { isActive as isActivePath } from "@/lib/utils"
 
 const isPage = (node: NavNode): node is NavItem => "url" in node
 
@@ -29,7 +30,7 @@ export function SidebarDocsContent({ groups }: { groups: NavGroup[] }) {
   const pathname = usePathname()
   const { isMobile, setOpenMobile } = useSidebar()
 
-  const isActive = (url: string): boolean => pathname === url || pathname === url + "/"
+  const isActive = (url: string): boolean => isActivePath(pathname, url)
   const close = () => {
     if (isMobile) setOpenMobile(false)
   }

--- a/web/next/src/components/sidebar/docs/footer.tsx
+++ b/web/next/src/components/sidebar/docs/footer.tsx
@@ -17,9 +17,7 @@ export function SidebarDocsFooter() {
             }
           >
             <span>Feedback</span>
-            <span className="text-muted-foreground ml-auto text-[0.6rem]">
-              v{config.app.version}
-            </span>
+            <span className="text-muted-foreground ml-auto text-xs">v{config.app.version}</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/web/next/src/components/sidebar/floating-trigger.tsx
+++ b/web/next/src/components/sidebar/floating-trigger.tsx
@@ -15,7 +15,7 @@ export function SidebarFloatingTrigger() {
       variant="secondary"
       size="default"
       className={cn(
-        "bg-sidebar fixed right-0 bottom-0 z-20 mr-6 mb-18 h-8 cursor-pointer border",
+        "bg-sidebar fixed right-0 bottom-0 z-20 mr-6 mb-16 h-8 cursor-pointer border",
         isDocs ? "md:right-auto md:mb-48 md:size-7 md:rounded-l-none md:border-l-0" : "md:hidden",
       )}
     >

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -11,6 +11,8 @@ import {
 import { type User } from "better-auth/types"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
+import { useState } from "react"
+import { toast } from "sonner"
 
 import { SidebarDropdownMenu } from "@/components/sidebar/dropdown-menu"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -27,6 +29,7 @@ function getInitials(name: string) {
 // Shared sidebar user dropdown (avatar, identity, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
 export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard" | "console" }) {
   const router = useRouter()
+  const [signingOut, setSigningOut] = useState(false)
 
   // The user menu is shared, so the cross-link points at the other workspace: dashboard -> console, console -> dashboard.
   const crossLink =
@@ -74,9 +77,17 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
         )}
         <DropdownMenuItem
           className="cursor-pointer"
+          disabled={signingOut}
           onClick={async () => {
-            await authClient.signOut()
-            router.push("/")
+            if (signingOut) return
+            setSigningOut(true)
+            try {
+              await authClient.signOut()
+              router.push("/")
+            } catch {
+              toast.error("Failed to sign out. Please try again.")
+              setSigningOut(false)
+            }
           }}
         >
           <RiLogoutBoxLine />

--- a/web/next/src/lib/utils.ts
+++ b/web/next/src/lib/utils.ts
@@ -20,10 +20,10 @@ export function slugify(value: string, id = 0) {
   return suffix ? base + "-" + suffix : base
 }
 
-// Shared nav active-state matcher. Default is exact-or-trailing-slash; pass { exact: false } for prefix matching.
+// Shared nav active-state matcher. Default = exact path (or its trailing-slash form); { exact: false } also matches child paths, but only at a segment boundary, never a bare prefix.
 export function isActive(pathname: string | null, href: string, opts?: { exact?: boolean }) {
   if (!pathname) return false
   const exact = opts && opts.exact === false ? false : true
   if (exact) return pathname === href || pathname === href + "/"
-  return pathname.startsWith(href)
+  return pathname === href || pathname.startsWith(href + "/")
 }

--- a/web/next/src/lib/utils.ts
+++ b/web/next/src/lib/utils.ts
@@ -19,3 +19,11 @@ export function slugify(value: string, id = 0) {
   const suffix = generateId(id)
   return suffix ? base + "-" + suffix : base
 }
+
+// Shared nav active-state matcher. Default is exact-or-trailing-slash; pass { exact: false } for prefix matching.
+export function isActive(pathname: string | null, href: string, opts?: { exact?: boolean }) {
+  if (!pathname) return false
+  const exact = opts && opts.exact === false ? false : true
+  if (exact) return pathname === href || pathname === href + "/"
+  return pathname.startsWith(href)
+}

--- a/web/next/src/lib/utils.ts
+++ b/web/next/src/lib/utils.ts
@@ -23,7 +23,7 @@ export function slugify(value: string, id = 0) {
 // Shared nav active-state matcher. Default = exact path (or its trailing-slash form); { exact: false } also matches child paths, but only at a segment boundary, never a bare prefix.
 export function isActive(pathname: string | null, href: string, opts?: { exact?: boolean }) {
   if (!pathname) return false
-  const exact = opts && opts.exact === false ? false : true
+  const exact = !opts || opts.exact !== false
   if (exact) return pathname === href || pathname === href + "/"
   return pathname === href || pathname.startsWith(href + "/")
 }


### PR DESCRIPTION
## UI consistency cleanup (from the audit)

Clear fixes surfaced by the audit (`.github/audit/2026-06-28-css-audit.md`). The audit confirmed the app is already consistent; these are the real defects plus mechanical snaps. Design-language decisions and the `cursor-pointer` pass are tracked separately.

### Real defects
- **Login no longer fails silently** - `access.tsx` distinguishes an `auth-providers` API failure ("Could not load sign-in options. Refresh to try again.") from a genuinely empty config, instead of both showing "No sign-in options are configured yet."
- **`hire` heading hierarchy** - section headings demoted from `<h1>` to `<h2>` (one `<h1>` per page).
- **`<main>` landmarks** - added to home/hire/resume (they had none). Per-page, not the root layout, since the route groups render their own `<main>`.
- **Dead links** - the auth dialog's `<a href="#">` Terms/Privacy are now plain text.
- **Pending guards** - sign-out and org-switch can no longer be double-invoked; sign-out now handles errors.

### Mechanical
- Adopt the existing `Spinner` primitive at its default size (no per-instance size overrides), replacing hand-rolled `RiLoaderLine` loaders.
- Snap off-ladder one-offs: `gap-7.5`->`gap-8`, `size-7.5`->`size-8`, `size-4.5`->`size-5`, `w-45`->`min-w-48`, `text-[0.6rem]`->`text-xs`, `mb-18`->`mb-16`.
- `access.tsx` `max-w-md sm:max-w-md` -> `max-w-md`; the form uses a single `flex flex-col gap-4` rhythm.
- `.catch(() => {})` -> `try/catch` in the protected layout.
- Extract a shared `isActive(pathname, href, { exact })` helper; navbar/console/docs navs use it instead of three divergent matchers.
- Give the devtools toggle real `<button aria-label>` semantics.

### Not in this PR (tracked)
- The **`cursor-pointer` pass**: apply only to navigation (links/anchors/router pushes), strip from action buttons. Needs per-button classification.
- **Design-language decisions**: the two marketing scales, viewport idiom (`min-h-*`), a `--success` token, adopting `Empty`/`Item`/`Badge` for hand-rolled equivalents, a container-gutter token.
- The **audit doc** itself (separate PR, per the audit-doc convention).

Verified: check-types 12/12, build gate + commitlint pass. No `components/ui/*` files modified (Spinner is only imported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more consistent active-state experience across navigation, including dashboard, docs, and mobile links.
  * Updated loading indicators in several places to a shared spinner style.
* **Bug Fixes**
  * Improved sign-in, sign-out, and organization-switching flows with clearer error handling and disabled actions during loading.
  * Non-critical requests now fail silently without interrupting the page.
* **Style**
  * Improved page semantics and accessibility by using main content regions and clearer button/label structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->