### PR TITLE
refactor(web): cursor-pointer only on navigation, not action buttons

### DIFF
--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -85,9 +85,7 @@ export function Access() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<Button className="w-24 cursor-pointer" variant="outline" />}>
-        Login
-      </DialogTrigger>
+      <DialogTrigger render={<Button className="w-24" variant="outline" />}>Login</DialogTrigger>
       <DialogContent className="max-w-md" initialFocus={false}>
         <DialogHeader className="sr-only">
           <DialogTitle className="text-center">Sign in/up</DialogTitle>
@@ -140,7 +138,7 @@ export function Access() {
                 form="email"
                 type="submit"
                 variant="secondary"
-                className="w-full cursor-pointer"
+                className="w-full"
                 disabled={loader === "email"}
               >
                 {loader === "email" ? <Spinner /> : null}
@@ -159,7 +157,7 @@ export function Access() {
             <div className="grid gap-4">
               {isDev && (
                 <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
-                  <Button type="submit" variant="outline" className="w-full cursor-pointer">
+                  <Button type="submit" variant="outline" className="w-full">
                     Login (agents)
                   </Button>
                 </form>
@@ -168,7 +166,7 @@ export function Access() {
                 <Button
                   variant="outline"
                   type="button"
-                  className="w-full cursor-pointer"
+                  className="w-full"
                   onClick={async () => {
                     setLoader("github")
                     const res = await authClient.signIn.social({
@@ -190,7 +188,7 @@ export function Access() {
                 <Button
                   variant="outline"
                   type="button"
-                  className="w-full cursor-pointer"
+                  className="w-full"
                   onClick={async () => {
                     setLoader("google")
                     const res = await authClient.signIn.social({

--- a/web/next/src/components/mode-toggle.tsx
+++ b/web/next/src/components/mode-toggle.tsx
@@ -25,7 +25,7 @@ export function ModeToggle() {
 
   return (
     <Button
-      className="size-8 cursor-pointer [&_svg]:size-4!"
+      className="size-8 [&_svg]:size-4!"
       onClick={smartToggle}
       aria-label="Switch between system/light/dark version"
       size="sm"

--- a/web/next/src/components/navbar/home.tsx
+++ b/web/next/src/components/navbar/home.tsx
@@ -135,7 +135,7 @@ export function Navbar() {
           {session?.user ? (
             <Button
               role="link"
-              className="w-24 cursor-pointer"
+              className="w-24"
               variant="outline"
               onClick={() => setToDashboard(true)}
               render={<Link href="/dashboard" />}
@@ -155,7 +155,7 @@ export function Navbar() {
             <SheetTrigger
               render={
                 <Button
-                  className="-mr-2.5 size-8 cursor-pointer lg:hidden [&_svg]:size-4!"
+                  className="-mr-2.5 size-8 lg:hidden [&_svg]:size-4!"
                   aria-label="Open menu"
                   size="sm"
                   variant="outline"

--- a/web/next/src/components/sidebar/dashboard/org-switcher.tsx
+++ b/web/next/src/components/sidebar/dashboard/org-switcher.tsx
@@ -138,7 +138,6 @@ export function SidebarDashboardOrgSwitcher() {
           .map((org) => (
             <DropdownMenuItem
               key={org.id}
-              className="cursor-pointer"
               disabled={isOrgTransitioning}
               onClick={() => handleSetActive(org.id)}
             >
@@ -146,11 +145,7 @@ export function SidebarDashboardOrgSwitcher() {
               {org.name}
             </DropdownMenuItem>
           ))}
-        <DropdownMenuItem
-          className="cursor-pointer"
-          disabled={isOrgTransitioning}
-          onClick={() => setCreateDialogOpen(true)}
-        >
+        <DropdownMenuItem disabled={isOrgTransitioning} onClick={() => setCreateDialogOpen(true)}>
           <RiAddLine />
           Create organization
         </DropdownMenuItem>
@@ -205,7 +200,7 @@ export function SidebarDashboardOrgSwitcher() {
             <Button
               type="submit"
               variant="secondary"
-              className="w-full cursor-pointer"
+              className="w-full"
               disabled={form.state.isSubmitting}
             >
               {form.state.isSubmitting ? <Spinner /> : null}

--- a/web/next/src/components/sidebar/docs/search.tsx
+++ b/web/next/src/components/sidebar/docs/search.tsx
@@ -81,7 +81,7 @@ export function SidebarDocsSearch() {
         placeholder="Search"
         onClick={handleClick}
         readOnly
-        className={`cursor-pointer pl-8 ${isMobile ? "pr-3" : "pr-20"}`}
+        className={`cursor-default pl-8 ${isMobile ? "pr-3" : "pr-20"}`}
       />
       {!isMobile && (
         <div className="pointer-events-none absolute top-1/2 right-2 flex -translate-y-1/2 items-center gap-1">

--- a/web/next/src/components/sidebar/dropdown-menu.tsx
+++ b/web/next/src/components/sidebar/dropdown-menu.tsx
@@ -52,7 +52,7 @@ export function SidebarDropdownMenu({
         render={
           <SidebarMenuButton
             size="lg"
-            className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground cursor-pointer border"
+            className="data-[popup-open]:bg-sidebar-accent data-[popup-open]:text-sidebar-accent-foreground border"
           />
         }
       >

--- a/web/next/src/components/sidebar/floating-trigger.tsx
+++ b/web/next/src/components/sidebar/floating-trigger.tsx
@@ -15,7 +15,7 @@ export function SidebarFloatingTrigger() {
       variant="secondary"
       size="default"
       className={cn(
-        "bg-sidebar fixed right-0 bottom-0 z-20 mr-6 mb-16 h-8 cursor-pointer border",
+        "bg-sidebar fixed right-0 bottom-0 z-20 mr-6 mb-16 h-8 border",
         isDocs ? "md:right-auto md:mb-48 md:size-7 md:rounded-l-none md:border-l-0" : "md:hidden",
       )}
     >

--- a/web/next/src/components/sidebar/shell.tsx
+++ b/web/next/src/components/sidebar/shell.tsx
@@ -50,7 +50,7 @@ export async function SidebarShell({
                 </Badge>
               )}
             </Link>{" "}
-            <SidebarTrigger variant="secondary" className="bg-sidebar cursor-pointer border" />
+            <SidebarTrigger variant="secondary" className="bg-sidebar border" />
           </div>
           {header}
         </SidebarHeader>

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -52,7 +52,7 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
       <SidebarDropdownMenu trigger={identity} header={identity} align="end" mobileSide="top">
         {crossLink && (
           <>
-            <DropdownMenuItem render={<Link href={crossLink.href} className="cursor-pointer" />}>
+            <DropdownMenuItem render={<Link href={crossLink.href} />}>
               {crossLink.icon}
               {crossLink.label}
               <RiArrowRightSLine className="text-muted-foreground ml-auto size-4" />
@@ -63,12 +63,7 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
         {env.NEXT_PUBLIC_USERJOT_URL && (
           <DropdownMenuItem
             render={
-              <Link
-                href={env.NEXT_PUBLIC_USERJOT_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="cursor-pointer"
-              />
+              <Link href={env.NEXT_PUBLIC_USERJOT_URL} target="_blank" rel="noopener noreferrer" />
             }
           >
             <RiMessage2Line />
@@ -76,7 +71,6 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
           </DropdownMenuItem>
         )}
         <DropdownMenuItem
-          className="cursor-pointer"
           disabled={signingOut}
           onClick={async () => {
             if (signingOut) return


### PR DESCRIPTION
## cursor-pointer only on navigation

Applies the rule: `cursor-pointer` belongs only on path-changing navigation (links/anchors), never on action buttons. This matches the CSS spec / accessibility guidance (the pointer signals a link) and the Tailwind v4 + shadcn default (buttons use the arrow).

### Key finding
`buttonVariants` sets no cursor, and the browser already does the right thing: `<a href>` (including a Button rendered as `<Link>`) shows the pointer natively, `<button>` shows the arrow natively. So `cursor-pointer` was only ever *forcing* a pointer onto action buttons (against the rule) or sitting redundant on nav anchors. The pass removes every `cursor-pointer` class.

### Changes
- Removed `cursor-pointer` from all action controls: theme toggle, dialog/menu triggers, sidebar trigger, floating trigger, mobile-menu trigger, sign-in (magic-link / social / agents), sign-out, org-switch, create-org.
- Removed the now-redundant class from nav anchors (Dashboard-as-`Link`, the user-menu cross-link, the UserJot link) - they keep the pointer the `<a>` gives them for free.
- The docs search trigger (a readOnly `<input>`) uses `cursor-default` - a button-like control, so no pointer, but not a text field, so no I-beam.
- No `components/ui/*` files touched.

### Verified
- `rg cursor-pointer web/next/src` → zero matches.
- check-types 12/12, format clean.
- Browser (computed `cursor`): action buttons `default`, links `pointer`, search input `default`.

Standards: [CSS `cursor: pointer` is link-only](https://github.com/w3c/csswg-drafts/issues/7772), [Tailwind v4 dropped it from buttons](https://github.com/tailwindlabs/tailwindcss/pull/8962).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
