### PR TITLE
refactor(web): marketing polish (responsive hero + body copy, unified heading weight)

### DIFF
--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -31,6 +31,7 @@ The canonical, prescriptive record of this app's UI conventions: what to do. The
 
 - Exactly one `<h1>` per page (the page title). Sections use `<h2>` and below; never skip levels.
 - Use the existing type scale and tokens; do not introduce font sizes outside the scale.
+- Marketing-page headings (home, hire, resume) are `font-bold`, unified across all three. Sub-headings within a section stay lighter (e.g. a `font-semibold` `h3`) to preserve hierarchy; non-heading display text (a stat value) is not a heading and follows its own weight.
 
 ## Color and theming
 

--- a/web/next/src/app/hire/page.tsx
+++ b/web/next/src/app/hire/page.tsx
@@ -144,7 +144,7 @@ const sections: {
 
 const buttonClass =
   "bg-secondary hover:bg-secondary/80 flex items-center gap-2 rounded-md px-4 py-2 text-sm transition-colors"
-const headingClass = `${caveat.className} text-muted-foreground text-3xl font-semibold tracking-wide`
+const headingClass = `${caveat.className} text-muted-foreground text-3xl font-bold tracking-wide`
 const linkClass = "border-border hover:border-ring border-b transition-colors"
 
 export default function Page() {
@@ -152,7 +152,7 @@ export default function Page() {
     <main className="bg-background text-foreground min-h-svh space-y-16 py-24 text-lg">
       {/* hook */}
       <div className="container mx-auto max-w-3xl space-y-8 px-4 md:px-6">
-        <h1 className={cn(caveat.className, "text-3xl font-semibold tracking-wide")}>nrjdalal</h1>
+        <h1 className={cn(caveat.className, "text-3xl font-bold tracking-wide")}>nrjdalal</h1>
 
         <div className="space-y-4">
           <p>

--- a/web/next/src/app/page.tsx
+++ b/web/next/src/app/page.tsx
@@ -335,7 +335,7 @@ bun dev`
                 Zero speed
               </span>
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl sm:text-lg">
               Everything you need to launch your SaaS in no time. Get all the core functionalities
               and integrations out of the box, so you can focus on the business.
             </p>
@@ -530,7 +530,7 @@ bun dev`
         <div className="container mx-auto max-w-6xl px-4 md:px-6">
           <div className="mb-16 text-center">
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">Why ZeroStarter?</h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl sm:text-lg">
               Architecture & Best Practices as a Service, ZeroStarter isn't just a starter template,
               it's a complete blueprint for building production-ready SaaS applications.
             </p>
@@ -623,7 +623,7 @@ bun dev`
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
               Type-Safe API Calls
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl sm:text-lg">
               Full type inference from backend to frontend. No more manual type definitions. See the
               magic happen.
             </p>
@@ -649,7 +649,7 @@ bun dev`
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
               Get Started in Minutes
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl sm:text-lg">
               Clone, install, and start building. It's that simple.
             </p>
           </div>
@@ -685,7 +685,7 @@ bun dev`
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
               Frequently Asked Questions
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl sm:text-lg">
               Have another question? Check out our documentation or reach out.
             </p>
           </div>
@@ -754,7 +754,7 @@ bun dev`
           <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
             Ready to Build Your SaaS?
           </h2>
-          <p className="text-muted-foreground mb-8 text-base sm:text-lg">
+          <p className="text-muted-foreground mb-8 sm:text-lg">
             Start building your next project with {site.name} today. Skip the complex setups and
             start building features on day one.
           </p>

--- a/web/next/src/app/page.tsx
+++ b/web/next/src/app/page.tsx
@@ -228,7 +228,7 @@ bun dev`
       >
         <div className="absolute inset-0 bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] mask-[radial-gradient(ellipse_80%_50%_at_50%_0%,white_70%,transparent_110%)] bg-size-[20px_20px]" />
         <div className="relative z-10 container mx-auto flex min-h-0 max-w-6xl flex-1 items-center justify-center px-4 py-12 sm:py-16 md:px-6">
-          <div className="mx-auto flex max-w-3xl flex-col justify-center text-center">
+          <div className="mx-auto flex min-h-160 max-w-3xl flex-col justify-center text-center">
             <Badge variant="secondary" className="mx-auto mb-6">
               The{" "}
               <span className="from-primary to-primary/60 bg-linear-to-r bg-clip-text font-semibold text-transparent">

--- a/web/next/src/app/page.tsx
+++ b/web/next/src/app/page.tsx
@@ -228,7 +228,7 @@ bun dev`
       >
         <div className="absolute inset-0 bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] mask-[radial-gradient(ellipse_80%_50%_at_50%_0%,white_70%,transparent_110%)] bg-size-[20px_20px]" />
         <div className="relative z-10 container mx-auto flex min-h-0 max-w-6xl flex-1 items-center justify-center px-4 py-12 sm:py-16 md:px-6">
-          <div className="mx-auto flex min-h-[700px] max-w-3xl flex-col justify-center text-center">
+          <div className="mx-auto flex max-w-3xl flex-col justify-center text-center">
             <Badge variant="secondary" className="mx-auto mb-6">
               The{" "}
               <span className="from-primary to-primary/60 bg-linear-to-r bg-clip-text font-semibold text-transparent">
@@ -335,7 +335,7 @@ bun dev`
                 Zero speed
               </span>
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
               Everything you need to launch your SaaS in no time. Get all the core functionalities
               and integrations out of the box, so you can focus on the business.
             </p>
@@ -530,7 +530,7 @@ bun dev`
         <div className="container mx-auto max-w-6xl px-4 md:px-6">
           <div className="mb-16 text-center">
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">Why ZeroStarter?</h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
               Architecture & Best Practices as a Service, ZeroStarter isn't just a starter template,
               it's a complete blueprint for building production-ready SaaS applications.
             </p>
@@ -623,7 +623,7 @@ bun dev`
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
               Type-Safe API Calls
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
               Full type inference from backend to frontend. No more manual type definitions. See the
               magic happen.
             </p>
@@ -649,7 +649,7 @@ bun dev`
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
               Get Started in Minutes
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
               Clone, install, and start building. It's that simple.
             </p>
           </div>
@@ -685,7 +685,7 @@ bun dev`
             <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
               Frequently Asked Questions
             </h2>
-            <p className="text-muted-foreground mx-auto max-w-2xl text-lg">
+            <p className="text-muted-foreground mx-auto max-w-2xl text-base sm:text-lg">
               Have another question? Check out our documentation or reach out.
             </p>
           </div>
@@ -754,7 +754,7 @@ bun dev`
           <h2 className="mb-4 text-3xl font-bold tracking-tight sm:text-4xl">
             Ready to Build Your SaaS?
           </h2>
-          <p className="text-muted-foreground mb-8 text-lg">
+          <p className="text-muted-foreground mb-8 text-base sm:text-lg">
             Start building your next project with {site.name} today. Skip the complex setups and
             start building features on day one.
           </p>

--- a/web/next/src/app/resume/page.tsx
+++ b/web/next/src/app/resume/page.tsx
@@ -163,7 +163,7 @@ const skills: { group: string; items: string }[] = [
   },
 ]
 
-const sectionHeading = `${caveat.className} text-muted-foreground text-3xl font-semibold tracking-wide`
+const sectionHeading = `${caveat.className} text-muted-foreground text-3xl font-bold tracking-wide`
 const linkClass = "border-border hover:border-ring border-b transition-colors"
 
 export default function Page() {
@@ -171,7 +171,7 @@ export default function Page() {
     <main className="bg-background text-foreground min-h-svh space-y-16 py-24 text-base">
       {/* header */}
       <div className="container mx-auto max-w-3xl space-y-8 px-4 md:px-6">
-        <h1 className={cn(caveat.className, "text-3xl font-semibold tracking-wide")}>résumé</h1>
+        <h1 className={cn(caveat.className, "text-3xl font-bold tracking-wide")}>résumé</h1>
         <p className="text-lg">
           AI-native Product Engineer with 5+ years shipping production SaaS, developer tools,
           full-stack TypeScript systems, and AI agent infrastructure. Currently building AI-powered


### PR DESCRIPTION
## Marketing FE polish (M1, L1, L2)

Last of the FE-refinements plan (audit: `.github/audit/2026-06-29-fe-refinements.md`). One cohesive marketing pass, no behavior or feature changes.

- **M1 - hero floor** (`page.tsx`): replace the arbitrary `min-h-[700px]` with `min-h-160` (640px / 40rem) - on the rem-based spacing scale, and 60px shorter. Keeps a substantial hero minimum without an off-scale px literal; `min-h-160` is the Tailwind number utility (confirmed computed `min-height: 640px`).
- **L1 - responsive section body copy** (`page.tsx`): the 6 flat `text-lg` section/CTA descriptions → `sm:text-lg`, so they step down on mobile (the base step is the inherited `text-base` default - no need to restate it) like the hero already does. The hero's own responsive `p` (245) and the `h3` sub-headings stay untouched.
- **L2 - unified marketing heading weight** (`hire`, `resume`): section headings `font-semibold` → `font-bold` to match home (audit open decision #2, resolved: unify). The stat-value `text-2xl` is left alone. Recorded in the design skill.

**Dropped M2** (the proposed `--color-grid` token): keeping the hero grid value page-local. A starter shouldn't add a global CSS variable for a single-use value.

check-types 12/12.

### Before / after (M1 hero, 577px viewport)

The floor goes from `min-h-[700px]` to `min-h-160` (640px); the after is ~60px more compact so the buttons sit higher in frame. Both still exceed a 577px viewport (the floor is taller than it), so this is a value + on-scale-expression refinement, not an overflow fix.

| Before (`min-h-[700px]`) | After (`min-h-160` / 640px) |
|---|---|
| ![hero before, 700px floor](https://litter.catbox.moe/m5u305.png) | ![hero after, 640px floor, content more compact](https://litter.catbox.moe/xar21k.png) |

_L1 is a mobile-width text step (`sm:text-lg`) - identical at desktop widths, so a desktop before/after shows nothing. L2 bumps the hire/resume heading weight from semibold to bold (confirmed `font-weight: 700`), but it's visually subtle in the Caveat handwriting font, so no before/after shot._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography on the hire and résumé pages to use bolder headings for stronger visual emphasis.
  * Adjusted the landing page hero spacing and section intro text sizing for improved layout balance across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->