### PR TITLE
fix(web): log the swallowed active-org restore error (a11y L3; L4 verified)

### DIFF
--- a/web/next/src/app/(protected)/layout.tsx
+++ b/web/next/src/app/(protected)/layout.tsx
@@ -21,11 +21,16 @@ export default async function Layout({ children }: { children: React.ReactNode }
       const url = `${config.api.internalUrl || config.api.url}/api/auth/organization/set-active`
       const reqHeaders = Object.fromEntries((await headers()).entries())
       try {
-        await fetch(url, {
+        const response = await fetch(url, {
           method: "POST",
           headers: { ...reqHeaders, "content-type": "application/json" },
           body: JSON.stringify({ organizationId: lastOrgId }),
         })
+        if (!response.ok) {
+          console.error(
+            `failed to restore active organization: ${response.status} ${response.statusText}`,
+          )
+        }
       } catch (error) {
         console.error("failed to restore active organization", error)
       }

--- a/web/next/src/app/(protected)/layout.tsx
+++ b/web/next/src/app/(protected)/layout.tsx
@@ -26,7 +26,9 @@ export default async function Layout({ children }: { children: React.ReactNode }
           headers: { ...reqHeaders, "content-type": "application/json" },
           body: JSON.stringify({ organizationId: lastOrgId }),
         })
-      } catch {}
+      } catch (error) {
+        console.error("failed to restore active organization", error)
+      }
     }
   }
 


### PR DESCRIPTION
## a11y/polish: L3 + L4 from the FE-refinements audit

### L3 - surface the swallowed org-restore error (`(protected)/layout.tsx`)
The best-effort "restore last active org" fetch had an empty `catch {}`, so a persistent failure (bad internal URL, network, auth drift) was invisible. Now it logs:

```ts
} catch (error) {
  console.error("failed to restore active organization", error)
}
```

Behavior unchanged (still best-effort) - just adds a server-side signal for debugging.

### L4 - navbar focus-visible: verified, no change
Keyboard-tested with `agent-browser` (Tab onto a nav link): the links already show a focus indicator - a `1px` outline in the ring color, from the global `* { outline-ring/50 }`, which is the design skill's documented bare-link convention. So L4 is **not missing**; closing it as verified rather than adding a redundant per-link ring.

Evidence (the "Documentation" link keyboard-focused, outline visible):

![nav link Documentation keyboard-focused, showing the outline-ring focus indicator](https://litter.catbox.moe/hggwsw.png)

A more prominent focus ring would be a global `globals.css` decision (it'd affect every link/control), not navbar-specific - out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error logging when restoring the last active organization fails, making it easier to notice and diagnose sign-in or session restore issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->