### PR TITLE
feat(web): add DashboardShell + DashboardHeader page wrappers

### DIFF
--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -43,7 +43,7 @@ The canonical, prescriptive record of this app's UI conventions: what to do. The
 
 - Each top-level page wraps its content in a single `<main>`. Route-group layouts (dashboard via `SidebarShell`, docs, blog) already render their own `<main>`, so do NOT add one to the root layout or you nest landmarks.
 - Collapsible app shells go through `SidebarShell`.
-- Top-level full-height surfaces (the body, marketing pages, the `SidebarShell` root) use `min-h-svh`, matching the shadcn sidebar; no `dvh`. Surfaces nested inside the shell's content pane (route `error`/`loading`, dashboard/console content) fill it with `flex-1` — the shell `<main>` is `flex min-h-svh flex-1 flex-col`, so don't re-assert `min-h-svh` inside an already-full-height parent.
+- Top-level full-height surfaces (the body, marketing pages, the `SidebarShell` root) use `min-h-svh`, matching the shadcn sidebar; no `dvh`. Surfaces nested inside the shell's content pane (route `error`/`loading`, dashboard/console content) fill it with `flex-1` — the shell `<main>` is `flex min-h-svh min-w-0 flex-1 flex-col`, so don't re-assert `min-h-svh` inside an already-full-height parent.
 
 ## Components
 

--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -24,7 +24,7 @@ The canonical, prescriptive record of this app's UI conventions: what to do. The
 
 - Stay on the Tailwind scale. No off-ladder one-offs (`gap-7.5`, `size-4.5`, `w-45`, `mb-18`, `text-[0.6rem]`); snap to the nearest step.
 - `gap-2` is the workhorse for tight clusters.
-- Dashboard and console pages use the collapsible `SidebarShell`. Their page content targets `max-w-4xl` with `p-4 sm:p-6` padding; the `DashboardShell` wrapper that encapsulates this is not in this codebase yet (it lands in a separate PR), so apply those values directly until it does.
+- Dashboard and console pages use the collapsible `SidebarShell` and wrap their content in `DashboardShell` (`components/dashboard/shell.tsx`): it owns `mx-auto` + width + `p-4 sm:p-6` via a `size` variant (`sm`/`md`/`lg`/`full`, default `md` = `max-w-4xl`). The title/description/actions row is `DashboardHeader`. Don't hand-roll `mx-auto`/`max-w-*`/`p-*` or the header layout.
 - Marketing pages share one vertical scale: `py-24` sections and a `px-4 md:px-6` container gutter (hire and resume are aligned to home).
 
 ## Typography and headings

--- a/web/next/content/docs/getting-started/project-structure.mdx
+++ b/web/next/content/docs/getting-started/project-structure.mdx
@@ -60,6 +60,7 @@ The frontend application built with [Next.js 16](https://nextjs.org).
 - **`src/components/`**: React components
   - `ui/`: Shadcn UI components
   - `sidebar/`: Navigation sidebar components
+  - `dashboard/`: Page-layout wrappers (`DashboardShell`, `DashboardHeader`) for protected pages
 - **`src/lib/`**: Shared utilities
   - `api/client.ts`: Type-safe API client using Hono RPC
   - `auth/`: Authentication client and utilities (including `console.ts`, the `/console` access gate)

--- a/web/next/src/app/(protected)/dashboard/page.tsx
+++ b/web/next/src/app/(protected)/dashboard/page.tsx
@@ -1,3 +1,10 @@
+import { DashboardHeader } from "@/components/dashboard/header"
+import { DashboardShell } from "@/components/dashboard/shell"
+
 export default function Page() {
-  return null
+  return (
+    <DashboardShell>
+      <DashboardHeader title="Dashboard" description="Welcome back." />
+    </DashboardShell>
+  )
 }

--- a/web/next/src/components/dashboard/header.tsx
+++ b/web/next/src/components/dashboard/header.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+// The title/description/actions row for a protected page: owns the heading typography and spacing so pages never hand-roll the header layout.
+function DashboardHeader({
+  title,
+  description,
+  actions,
+  className,
+}: {
+  title: React.ReactNode
+  description?: React.ReactNode
+  actions?: React.ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      data-slot="dashboard-header"
+      className={cn("mb-6 flex items-start justify-between gap-4", className)}
+    >
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        {description && <p className="text-muted-foreground text-sm">{description}</p>}
+      </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
+    </div>
+  )
+}
+
+export { DashboardHeader }

--- a/web/next/src/components/dashboard/shell.tsx
+++ b/web/next/src/components/dashboard/shell.tsx
@@ -1,0 +1,35 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const dashboardShellVariants = cva("mx-auto w-full p-4 sm:p-6", {
+  variants: {
+    size: {
+      sm: "max-w-2xl",
+      md: "max-w-4xl",
+      lg: "max-w-6xl",
+      full: "max-w-none",
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+})
+
+// The content container for a protected (dashboard/console) page: owns centering, width, and padding so pages never hand-roll mx-auto/max-w/p-* classes.
+function DashboardShell({
+  className,
+  size,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof dashboardShellVariants>) {
+  return (
+    <div
+      data-slot="dashboard-shell"
+      className={cn(dashboardShellVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+export { DashboardShell, dashboardShellVariants }

--- a/web/next/src/components/sidebar/shell.tsx
+++ b/web/next/src/components/sidebar/shell.tsx
@@ -58,7 +58,7 @@ export async function SidebarShell({
         <SidebarFooter>{footer}</SidebarFooter>
         <SidebarRail />
       </AdaptiveShellSidebar>
-      <main className="flex min-h-svh flex-1 flex-col">
+      <main className="flex min-h-svh min-w-0 flex-1 flex-col">
         <SidebarFloatingTrigger />
         {children}
       </main>


### PR DESCRIPTION
## Dashboard page-layout wrappers

Supersedes #575, which was 9 commits behind canary and conflicted with #583 on the shell `<main>`. Rebuilt clean on current canary with that conflict reconciled.

- **`DashboardShell`** (`components/dashboard/shell.tsx`): page-content container - `mx-auto w-full p-4 sm:p-6` + a `size` variant (`sm`/`md`/`lg`/`full`, **default `md` = `max-w-4xl`**, matching the design skill).
- **`DashboardHeader`** (`components/dashboard/header.tsx`): the title/description/actions row (one `<h1>`).
- **Shell `<main>` reconciled** to `flex min-h-svh min-w-0 flex-1 flex-col` - keeps #583's `min-h-svh` (route error/loading boundaries fill via it) **and** adds `min-w-0` (so `DashboardShell`'s `w-full` sizes and centers without the flex min-width overflow).
- **Wires the dashboard home** (was `return null`) as the first consumer.
- **Docs**: the design skill's DashboardShell note is flipped (it exists now, with the API); `dashboard/` added to project-structure.

### Verified (e2e, 1280px viewport)
Dashboard renders at the `md` default: `shellW: 896` (max-w-4xl) centered in `mainW: 1024`. check-types 12/12. (The original #575 body claimed an `lg`/1024 default; the code is `md`/896, which is what ships here.)

| Before (blank pane) | After |
|---|---|
| ![dashboard blank content pane](https://litter.catbox.moe/yg2ot5.png) | ![dashboard with DashboardShell + DashboardHeader](https://litter.catbox.moe/mnuyrx.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
