### PR TITLE
feat(web): wire the console landing with DashboardShell + DashboardHeader

### DIFF
--- a/web/next/src/app/(console)/console/page.tsx
+++ b/web/next/src/app/(console)/console/page.tsx
@@ -1,3 +1,10 @@
+import { DashboardHeader } from "@/components/dashboard/header"
+import { DashboardShell } from "@/components/dashboard/shell"
+
 export default function Page() {
-  return null
+  return (
+    <DashboardShell>
+      <DashboardHeader title="Console" description="Welcome back." />
+    </DashboardShell>
+  )
 }


### PR DESCRIPTION
## Console landing content

Wires `/console` (was `return null`) to mirror the dashboard home from #589: a `DashboardShell` (md) + `DashboardHeader` showing `Console` / "Welcome back."

Kept deliberately minimal and consistent with the dashboard - no org card, quick links, or invented admin tables (the console sidebar already carries its nav: Console + Documentation). This closes the last `return null` stub from the FE-refinements audit (H1).

### Verified (e2e, 1280px viewport)
`/console` renders the header at the `md` default (`shellW: 896`, matching the dashboard). check-types 12/12.

| Before (blank pane) | After |
|---|---|
| ![console blank content pane](https://litter.catbox.moe/hqh7h9.png) | ![console with Console / Welcome back header](https://litter.catbox.moe/6iic13.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible Console page layout with a dashboard shell and header.
  * The page now shows a “Console” title and a “Welcome back.” message instead of appearing empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->