### PR TITLE
docs: sync docs with current code (dashboard wrappers, structure, theming)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Every item below is wired and working out of the box, not just a dependency in `
 - **Database**: [PostgreSQL](https://www.postgresql.org) with [Drizzle ORM](https://orm.drizzle.team) and migrations
 - **Authentication**: [Better Auth](https://better-auth.com) with GitHub and Google OAuth, organizations, and teams
 - **Authorization**: a role-gated admin console at `/console`, backed by the Better Auth admin plugin
+- **Public Waitlist**: a waitlist landing + signup API (`/api/waitlist`) with an approximate count; the default home for a fresh fork
 - **Rate Limiting**: [hono-rate-limiter](https://www.npmjs.com/package/hono-rate-limiter) keyed per user, API key, or IP (with [Arcjet](https://arcjet.com) IP detection)
 - **Data & Forms**: [TanStack Query](https://tanstack.com/query) for server state and [TanStack Form](https://tanstack.com/form) for forms
 - **Validation**: [Zod](https://zod.dev), shared across the API, forms, and type-safe environment variables
@@ -42,7 +43,7 @@ Every item below is wired and working out of the box, not just a dependency in `
 ```
 .
 ├── api/
-│   └── hono/      # Backend API (Hono): /api/v1, /api/auth, /api/agents, /api/docs
+│   └── hono/      # Backend API (Hono): /api/agents, /api/auth, /api/docs, /api/v1, /api/waitlist
 ├── web/
 │   └── next/      # Frontend (Next.js App Router): dashboard, admin console, docs, blog
 └── packages/

--- a/web/next/content/docs/getting-started/project-structure.mdx
+++ b/web/next/content/docs/getting-started/project-structure.mdx
@@ -53,19 +53,25 @@ The frontend application built with [Next.js 16](https://nextjs.org).
   - `(protected)/`: Authenticated user pages (dashboard)
   - `(console)/`: Access-gated privileged admin console at `/console` (docs live under `/console/docs`)
   - `(llms.txt)/`: Auto-generated AI documentation endpoints
-  - `waitlist/`: Public waitlist landing. A freshly scaffolded fork's home (`page.tsx`) redirects here until you build your product; remove it by deleting `app/waitlist/`, `routers/waitlist.ts`, and `schema/waitlist.ts`
+  - `waitlist/`: Public waitlist landing. The upstream home (`page.tsx`) is a full marketing page; in a fresh fork the CLI replaces it with a redirect here until you build your product. Remove it by deleting `app/waitlist/`, `routers/waitlist.ts`, and `schema/waitlist.ts`
+  - `hire/`, `resume/`: Author/demo marketing pages — the CLI strips these at init, so a fork starts without them
   - `og/`: Dynamic Open Graph image routes
   - `robots.ts`: `robots.txt` generation
   - `sitemap.ts`: Sitemap generation
 - **`src/components/`**: React components
-  - `ui/`: Shadcn UI components
-  - `sidebar/`: Navigation sidebar components
+  - `blog/`: Blog post components
   - `dashboard/`: Page-layout wrappers (`DashboardShell`, `DashboardHeader`) for protected pages
+  - `navbar/`: Home/marketing navbar
+  - `route/`: Route-boundary components (`RouteError`, `RouteLoading`) used by `error.tsx`/`loading.tsx`
+  - `sidebar/`: Navigation sidebar components
+  - `ui/`: Shadcn UI components
 - **`src/lib/`**: Shared utilities
   - `api/client.ts`: Type-safe API client using Hono RPC
   - `auth/`: Authentication client and utilities (including `console.ts`, the `/console` access gate)
   - `config.ts`: Application configuration
   - Content and SEO helpers: `blog.ts`, `blog-policy.ts`, `llms.ts`, `og-image.tsx`, `fumadocs.tsx`, `source.ts`, `sort-by-meta.ts`, and the `docs/` helpers
+  - `fonts.ts`: Font loading; `utils.ts`: the `cn` class-name helper
+- **`src/hooks/`**: React hooks (`use-mobile.ts`)
 - **`content/`**: MDX content
   - `docs/`: Documentation pages
   - `blog/`: Blog posts

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -57,11 +57,11 @@ Bun v1.3.14 or later (matching the repo's `packageManager` pin). Docker is requi
    # Generate using `openssl rand -base64 32`
    BETTER_AUTH_SECRET=
 
-   # Generate at `https://github.com/settings/developers`
+   # Optional GitHub OAuth — generate at `https://github.com/settings/developers`; leave blank to hide the GitHub sign-in button
    GITHUB_CLIENT_ID=
    GITHUB_CLIENT_SECRET=
 
-   # Generate at `https://console.cloud.google.com/apis/credentials`
+   # Optional Google OAuth — generate at `https://console.cloud.google.com/apis/credentials`; leave blank to hide the Google sign-in button
    GOOGLE_CLIENT_ID=
    GOOGLE_CLIENT_SECRET=
 

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -31,7 +31,7 @@ All API responses use a standardized JSON envelope:
 }
 ```
 
-Routes never build this envelope by hand. They `throw`, `new ApiError(status, code, message, extra?)` for a domain code, or a Hono `HTTPException(status, { message })` for a standard one, and the central `onError` handler in `api/hono/src/lib/error.ts` is the single place that turns any thrown error into the envelope (via the internal `jsonError` builder). `onError` dispatches in order: `ApiError` (its own code) → `ZodError` (400) → `HTTPException` (status-mapped code) → `500`. Middleware and `notFound` may still call `jsonError` directly.
+Routes never build this envelope by hand. They `throw`, `new ApiError(status, code, message, extra?)` for a domain code, or a Hono `HTTPException(status, { message })` for a standard one, and the central `errorHandler` in `api/hono/src/lib/error.ts` (registered via `app.onError`) is the single place that turns any thrown error into the envelope (via the internal `jsonError` builder). `errorHandler` dispatches in order: `ApiError` (its own code) → `ZodError` (400) → `HTTPException` (status-mapped code) → `500`. Middleware and `notFound` may still call `jsonError` directly.
 
 ### Consuming responses on the client
 
@@ -82,7 +82,7 @@ When a Zod validation fails, the response includes the full issues array:
 }
 ```
 
-Route-level validators (e.g. `sValidator` on the waitlist `POST`) `throw new ApiError(400, "VALIDATION_ERROR", message, { issues })` on failure, so `onError` shapes the 400 in one place. Note that Hono's validator only parses the body when its content-type matches (JSON validators ignore a non-JSON body and validate `{}`), so a wrong content-type surfaces as a normal field-level issue.
+Route-level validators (e.g. `sValidator` on the waitlist `POST`) `throw new ApiError(400, "VALIDATION_ERROR", message, { issues })` on failure, so `errorHandler` shapes the 400 in one place. Note that Hono's validator only parses the body when its content-type matches (JSON validators ignore a non-JSON body and validate `{}`), so a wrong content-type surfaces as a normal field-level issue.
 
 A body that is present but unparseable (malformed JSON, malformed form-data) is a client error, not a server error: Hono throws an `HTTPException`, and `errorHandler` returns it with the thrown status (`400 BAD_REQUEST`) instead of masking it as a `500`.
 
@@ -168,6 +168,7 @@ Applied to protected routes (e.g., `/api/v1/*`):
 /api/docs               → Scalar API documentation UI
 /api/auth/*             → Better Auth handlers (session, OAuth, etc.)
 /api/auth/get-session   → Session endpoint hit by the Next server-side auth.api.getSession helper
+/api/auth/providers     → Enabled OAuth providers (configured-provider list the sign-in UI reads)
 /api/agents/*           → Agent sign-in (local only, trusted Origin)
 /api/v1/*               → Protected routes (requires auth middleware)
   /api/v1/session       → Current session data
@@ -212,7 +213,7 @@ export const v1Router = new Hono<{ Variables: Session }>().use("/*", authMiddlew
 
 The `new Hono<{ Variables: Session }>()` generic (with `import type { Session } from "@packages/auth"`) is what makes `c.get("user")` and `c.get("session")` typed, matching the real `v1Router`. The `authMiddleware` populates those context variables.
 
-To emit an error from a handler, `throw new ApiError(status, code, message)` (a domain code) or `throw new HTTPException(status, { message })` (a standard one); `onError` builds the envelope, so never construct it inline.
+To emit an error from a handler, `throw new ApiError(status, code, message)` (a domain code) or `throw new HTTPException(status, { message })` (a standard one); `errorHandler` builds the envelope, so never construct it inline.
 
 2. Register in `api/hono/src/index.ts` if it's a new router. The app sets `.basePath("/api")`, so the route path is relative to `/api`:
 
@@ -243,7 +244,7 @@ describeRoute({
 
 ### Documenting error responses
 
-A route should only advertise the error statuses it can actually return, so the docs stay honest. The `defaultOptions` in `index.ts` apply `globalErrorResponses` (429, 500, the only statuses reachable on any matched route, via the global rate limiter and `onError`) to every GET/POST. A route then adds the rest in its own `responses` (which merge over the defaults), using the helpers in `api/hono/src/lib/error.ts`:
+A route should only advertise the error statuses it can actually return, so the docs stay honest. The `defaultOptions` in `index.ts` apply `globalErrorResponses` (429, 500, the only statuses reachable on any matched route, via the global rate limiter and `errorHandler`) to every GET/POST. A route then adds the rest in its own `responses` (which merge over the defaults), using the helpers in `api/hono/src/lib/error.ts`:
 
 - `authErrorResponses` (401), spread into routes behind `authMiddleware` (e.g. `/api/v1/*`).
 - `validationErrorResponses` (400), spread into routes with a request validator (e.g. the waitlist `POST`).

--- a/web/next/content/docs/manage/dashboard.mdx
+++ b/web/next/content/docs/manage/dashboard.mdx
@@ -8,6 +8,8 @@ description: Protected dashboard with authentication, organization management, a
 
 The dashboard is a protected area at `/dashboard` that requires authentication. It includes organization switching, user management, and a collapsible sidebar. The layout is defined in `web/next/src/app/(protected)/layout.tsx`.
 
+Page content is wrapped in the `DashboardShell` + `DashboardHeader` components (see [Page content](#page-content)). The privileged `/console` area shares the same `SidebarShell` and the same wrappers.
+
 ## Authentication Guard
 
 The protected layout checks for a valid session server-side:
@@ -45,9 +47,34 @@ Located at `web/next/src/components/sidebar/dashboard/org-switcher.tsx`:
 Located at `web/next/src/components/sidebar/dashboard/user-actions.tsx`:
 
 - Links to documentation, with a version badge
+- Surfaces a "Dashboard" cross-link to `/console` when the user is an admin (`canAccessConsole`)
 - Renders the shared `SidebarUserMenu`
 
 The user avatar, name, and email, the optional feedback link (shown when `NEXT_PUBLIC_USERJOT_URL` is set), and the sign-out action all live in the shared `SidebarUserMenu` component at `web/next/src/components/sidebar/user-menu.tsx`. Sign-out redirects to the home page.
+
+## Page content
+
+Protected pages wrap their content in two components so pages never hand-roll centering, width, padding, or the header layout:
+
+- **`DashboardShell`** (`web/next/src/components/dashboard/shell.tsx`): the content container. Owns `mx-auto`, width, and `p-4 sm:p-6` padding via a `size` variant — `sm` (`max-w-2xl`), `md` (`max-w-4xl`, the default), `lg` (`max-w-6xl`), `full` (`max-w-none`).
+- **`DashboardHeader`** (`web/next/src/components/dashboard/header.tsx`): the title row. Takes `title`, an optional `description`, and optional `actions` (a right-aligned node, e.g. a button), and renders the page's single `<h1>`.
+
+Both `/dashboard` and `/console` currently render a minimal header (a "Welcome back." greeting) — they are the starting points you extend:
+
+```tsx
+import { DashboardHeader } from "@/components/dashboard/header"
+import { DashboardShell } from "@/components/dashboard/shell"
+
+export default function Page() {
+  return (
+    <DashboardShell>
+      <DashboardHeader title="Dashboard" description="Welcome back." />
+    </DashboardShell>
+  )
+}
+```
+
+Add your content as children of `DashboardShell`, below the header.
 
 ## Adding Dashboard Pages
 
@@ -57,31 +84,37 @@ The user avatar, name, and email, the optional feedback link (shown when `NEXT_P
 web/next/src/app/(protected)/
 ├── layout.tsx          ← Auth guard + sidebar
 ├── dashboard/
-│   └── page.tsx        ← Main dashboard (currently empty)
+│   └── page.tsx        ← Dashboard home (DashboardShell + DashboardHeader)
 └── settings/           ← illustrative example, not in the repo
     └── page.tsx        ← New page example
 ```
 
 2. The page automatically inherits the authenticated layout with sidebar.
 
-3. Access session data in your page:
+3. Wrap content in the shell + header, reading session data server-side as needed:
 
-```ts
+```tsx
+import { DashboardHeader } from "@/components/dashboard/header"
+import { DashboardShell } from "@/components/dashboard/shell"
 import { auth } from "@/lib/auth"
 
 export default async function SettingsPage() {
   const session = await auth.api.getSession()
-  return <div>Welcome, {session?.user.name}</div>
+  return (
+    <DashboardShell>
+      <DashboardHeader title="Settings" description={`Signed in as ${session?.user.name}`} />
+    </DashboardShell>
+  )
 }
 ```
 
 ## Sidebar Configuration
 
-The sidebar chrome is not built inline in the layout. It lives in the shared `SidebarShell` component at `web/next/src/components/sidebar/shell.tsx`, which is reused by both the dashboard and console layouts. The dashboard layout passes in `header` and `footer`; `SidebarShell` owns the provider, header brand, content, footer, and rail. (The optional `badge` prop is used by the console layout, not the dashboard.)
+The sidebar chrome is not built inline in the layout. It lives in the shared `SidebarShell` component at `web/next/src/components/sidebar/shell.tsx`, which is reused by both the dashboard and console layouts. The dashboard layout passes in `header` and `footer`; `SidebarShell` owns the provider, header brand, content, footer, and rail. The optional `badge` and `homeHref` props are set by the console layout (`badge` for the "Console" tag, `homeHref="/console"` to point the brand link at the console home); both default to dashboard values (no badge, `homeHref="/"`).
 
 The shell uses the shadcn/ui `Sidebar` component with `collapsible="icon"` mode. It consists of:
 
-- **Header**: brand (`site.name`, optionally with the `badge`), the sidebar trigger, and the caller's `header` node (for the dashboard, the org switcher)
+- **Header**: brand (`site.name`, linking to `homeHref`, optionally with the `badge`), the sidebar trigger, and the caller's `header` node (for the dashboard, the org switcher)
 - **Content**: the caller's `nav` node (empty for the dashboard; add navigation items here)
 - **Footer**: the caller's `footer` node (for the dashboard, the user actions)
 

--- a/web/next/content/docs/manage/llms-txt.mdx
+++ b/web/next/content/docs/manage/llms-txt.mdx
@@ -38,7 +38,7 @@ Only the per-page `.md`/`.txt` aliases under `/docs/*` and `/blog/*` are rewritt
 Two route handlers back these endpoints, and both are `force-static` with `revalidate = 60`:
 
 - `web/next/src/app/(llms.txt)/llms.txt/[[...slug]]/route.ts` serves `/llms.txt` and the `/llms.txt/docs` and `/llms.txt/blog` index views, plus every per-page alias rewritten from `/docs/*` and `/blog/*`. It uses `docsSource` and `blogSource` from Fumadocs, sorts docs by `meta.json` order, and lists only published blog posts via `getPublishedBlogPosts()`. Console docs are deliberately excluded (privacy boundary).
-- `web/next/src/app/(llms.txt)/llms-full.txt/route.ts` serves `/llms-full.txt`: every docs and blog page concatenated into one file, prefixed with `site.llmsFullPreamble` from `packages/config/src/site.ts`.
+- `web/next/src/app/(llms.txt)/llms-full.txt/route.ts` serves `/llms-full.txt`: a `# {site.name}` title and `> {site.description}` blockquote, then `site.llmsFullPreamble` (from `packages/config/src/site.ts`), then every docs and blog page concatenated with `---` separators.
 
 Page bodies come from `getLLMText` in `web/next/src/lib/llms.ts`, which:
 

--- a/web/next/content/docs/manage/theming.mdx
+++ b/web/next/content/docs/manage/theming.mdx
@@ -44,6 +44,7 @@ Theme colors are defined in `web/next/src/app/globals.css` using OKLch color spa
   --primary: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
   --border: oklch(0.922 0 0);
+  --success: oklch(0.627 0.194 149.214);
   /* ... */
 }
 
@@ -51,11 +52,12 @@ Theme colors are defined in `web/next/src/app/globals.css` using OKLch color spa
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --primary: oklch(0.922 0 0);
+  --success: oklch(0.723 0.219 149.579);
   /* ... */
 }
 ```
 
-These variables are consumed by Tailwind utility classes like `bg-background`, `text-foreground`, `border-border`, etc.
+These variables are consumed by Tailwind utility classes like `bg-background`, `text-foreground`, `border-border`, etc. The `--success` token (green, mirroring `--destructive`) backs `text-success`, `bg-success/10`, and `border-success/20`.
 
 ## Tailwind Configuration
 


### PR DESCRIPTION
## Docs sync: close the documentation gaps (phase 1 of the sync goal)

A whole-codebase docs-vs-code audit (6 parallel passes) found the docs had drifted from this session's shipped work (v0.0.67-70). This syncs them.

### Fixed
- **`manage/dashboard.mdx`** (the headline): documented the `DashboardShell`/`DashboardHeader` wrappers (new **Page content** section), fixed the "currently empty" line + the bare-`<div>` "Adding Pages" example, noted `/console` renders content, added the `homeHref` prop.
- **`getting-started/project-structure.mdx`**: added `components/route/`, `navbar/`, `blog/`; `hire`/`resume` pages; `fonts.ts`/`utils.ts`/`hooks/`; clarified the fork-only waitlist redirect (the upstream home is the marketing page); alphabetized the components list.
- **`manage/theming.mdx`**: added the `--success` token (light + dark) + its utilities.
- **`manage/api-conventions.mdx`**: `onError` → `errorHandler` (its real name; 4 spots, kept the legit TanStack `onError` callback); added `/api/auth/providers` to the route tree.
- **`getting-started/setup.mdx`**: OAuth env vars marked optional ("leave blank to hide the button").
- **`manage/llms-txt.mdx`**: corrected the `/llms-full.txt` header description (title + blockquote + preamble + pages).
- **`README.md`**: added `/api/waitlist` (alphabetized the route list) + a Public Waitlist feature bullet.

### Verified
All 6 changed doc pages render (200); the dashboard rewrite confirmed in-browser (Page-content section present, "empty" gone, `/console` mentioned).

### Out of scope / forward-flags
- **CLI `sync` doc** — deferred to phase 2 (the `sync` command is a stub; belongs with the CLI work).
- **`defineRoute`/`ok`/`validate`** — on the unmerged `feat/hono-define-route` branch; api-conventions/type-safe-api need a pass *when it merges*.

![rewritten dashboard doc](https://litter.catbox.moe/vn4vm5.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded setup, architecture, and project-structure docs to reflect the latest app routes and folder layout, including the waitlist flow and backend endpoints.
  * Clarified optional GitHub and Google sign-in setup, including how to hide those buttons.
  * Improved dashboard and console guidance, shared layout usage, and sidebar behavior.
  * Updated API and error-handling docs, plus added theming guidance for the new success color token.
  * Refined the `/llms-full.txt` endpoint description to match its current output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->