### PR TITLE
fix(access): spinner while providers load, surface error state

### DIFF
--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -37,7 +37,7 @@ export function Access() {
   const isDev = process.env.NODE_ENV === "development"
 
   // Render only the sign-in providers the API reports as enabled (GET /api/auth/providers); deploy-static so cached for the session and prefetched on mount, so the dialog (whose content mounts on open) paints the final state with no flash.
-  const { data, isError } = useQuery({
+  const { data, isError, isPending } = useQuery({
     queryKey: ["auth-providers"],
     staleTime: Infinity,
     queryFn: async () => {
@@ -212,7 +212,11 @@ export function Access() {
             </div>
           )}
           {hasNoProviders &&
-            (isError ? (
+            (isPending ? (
+              <div className="text-muted-foreground flex justify-center">
+                <Spinner className="size-5" />
+              </div>
+            ) : isError ? (
               <p className="text-muted-foreground text-center text-sm">
                 Could not load sign-in options. Refresh to try again.
               </p>


### PR DESCRIPTION
## Problem

In `components/access.tsx`, the sign-in dialog derives `hasNoProviders` from `data` that is `undefined` until the `["auth-providers"]` query settles. The query has no `retry` override, so React Query's default **3 retries** apply.

Two consequences:

- **Loading is shown as empty.** While the query is fetching/retrying, `data` is `undefined` → all providers read as `false` → `hasNoProviders` is `true`, so the dialog renders **"No sign-in options are configured yet."** even though it's just still loading.
- **The error state is largely masked.** `isError` only becomes `true` after all 3 retries exhaust, so the `"Could not load sign-in options. Refresh to try again."` copy almost never appears — the misleading "configured yet" message shows for the whole retry window instead.

(In dev this whole block is unreachable anyway: `isDev` forces `hasAlternatives` → `hasNoProviders` is always `false`. That's fine by design.)

## Fix

Add an `isPending` branch so loading is visually distinct from settled-empty:

```diff
-  const { data, isError } = useQuery({
+  const { data, isError, isPending } = useQuery({
   ...
   {hasNoProviders &&
-    (isError ? (
+    (isPending ? (
+      <div className="text-muted-foreground flex justify-center">
+        <Spinner className="size-5" />
+      </div>
+    ) : isError ? (
        <p>Could not load sign-in options. Refresh to try again.</p>
      ) : (
        <p>No sign-in options are configured yet.</p>
      ))}
```

Now: spinner while loading/retrying → error copy once retries exhaust → "configured yet" only on a genuinely settled-empty result.

Found while re-baselining a downstream product (Dalonic AI) on v0.0.71; the same fix is applied there to keep `access.tsx` byte-identical with the scaffold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sign-in dialog so it shows a loading spinner while authentication options are being fetched.
  * Prevents users from briefly seeing an empty or error state before the available sign-in options have finished loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->