### PR TITLE
chore(lint): trim inert ignore patterns from oxlint and oxfmt configs

### DIFF
--- a/.oxfmtrc.jsonc
+++ b/.oxfmtrc.jsonc
@@ -3,5 +3,5 @@
   "semi": false,
   "experimentalSortImports": {},
   "experimentalTailwindcss": {},
-  "ignorePatterns": ["**/*.lock", ".agents/**", ".claude/**"],
+  "ignorePatterns": [".agents/**"],
 }

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -1,4 +1,3 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["**/*.lock", ".agents/**", ".claude/**"],
 }


### PR DESCRIPTION
## What

Trims dead `ignorePatterns` from both `.oxlintrc.jsonc` and `.oxfmtrc.jsonc` — but treats them differently because the two tools handle files differently.

## oxlint — remove all three (all inert)

`.oxlintrc.jsonc` drops the whole `ignorePatterns` line.

| Pattern | Why inert |
| --- | --- |
| `**/*.lock` | oxlint only lints JS/TS by extension; `oxlint bun.lock` → "No files found", exit 0. |
| `.agents/**` | `.agents/` is markdown-only; `oxlint .agents` → "No files found to lint." |
| `.claude/**` | No lintable files (gitignored settings + a skills symlink). |

oxlint already respects `.gitignore` and skips non-JS by extension. Verified `oxlint` stays clean.

## oxfmt — keep `.agents/**`, drop the other two

`.oxfmtrc.jsonc` keeps only `.agents/**`.

**oxfmt formats markdown**, so `.agents/**` is *load-bearing* — without it, oxfmt reformats the 12 skill `SKILL.md` files (4 currently differ). It alone covers the `.claude/skills` and `.github/skills` symlink views too, since oxfmt matches the canonical `.agents/` path.

| Pattern | Verdict |
| --- | --- |
| `.agents/**` | **keep** — protects the skill markdown from reformatting |
| `**/*.lock` | drop — lockfiles aren't a format target |
| `.claude/**` | drop — real files there are gitignored; skills covered by `.agents/**` |

Verified via the real `format:check`: same clean 276-file scan with just `.agents/**`; removing it jumps to 288 files and flags 4 `SKILL.md`.

## Verification

- `oxlint` → clean, exit 0
- `bun run format:check` → "All matched files use the correct format" (276 files)

Follow-ups (separate PRs, sequential): stack plugins, real lint gate (`maxWarnings`) + `check-types` in CI, jsx-a11y cleanup, type-aware linting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)