### PR TITLE
feat(auth): add passkey sign-in and management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ HONO_RATE_LIMIT_WINDOW_MS=60000 # 1 minute (default)
 # Generate using `openssl rand -base64 32`
 BETTER_AUTH_SECRET=
 
+# Optional: WebAuthn rpID for passkeys. Defaults to HONO_APP_URL's host; set for split app./api. subdomains (use the shared parent, e.g. example.com).
+BETTER_AUTH_RP_ID=
+
 # Optional: GitHub OAuth (`https://github.com/settings/developers`). Leave blank to hide the button.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Every item below is wired and working out of the box, not just a dependency in `
 - **Backend**: [Hono](https://hono.dev) with OpenAPI and an interactive [Scalar](https://scalar.com) reference at `/api/docs`
 - **Type-Safe RPC**: [Hono Client](https://hono.dev/docs/guides/rpc) for end-to-end types from the backend to the frontend
 - **Database**: [PostgreSQL](https://www.postgresql.org) with [Drizzle ORM](https://orm.drizzle.team) and migrations
-- **Authentication**: [Better Auth](https://better-auth.com) with GitHub and Google OAuth, organizations, and teams
+- **Authentication**: [Better Auth](https://better-auth.com) with GitHub and Google OAuth, passkeys, organizations, and teams
 - **Authorization**: a role-gated admin console at `/console`, backed by the Better Auth admin plugin
 - **Public Waitlist**: a waitlist landing + signup API (`/api/waitlist`) with an approximate count; the default home for a fresh fork
 - **Rate Limiting**: [hono-rate-limiter](https://www.npmjs.com/package/hono-rate-limiter) keyed per user, API key, or IP (with [Arcjet](https://arcjet.com) IP detection)
@@ -47,7 +47,7 @@ Every item below is wired and working out of the box, not just a dependency in `
 ├── web/
 │   └── next/      # Frontend (Next.js App Router): dashboard, admin console, docs, blog
 └── packages/
-    ├── auth/      # Better Auth instance (OAuth, organizations, teams, admin)
+    ├── auth/      # Better Auth instance (OAuth, passkeys, organizations, teams, admin)
     ├── db/        # Drizzle ORM schema and PostgreSQL client
     ├── env/       # Type-safe environment variables (t3-oss/env + Zod)
     └── config/    # Shared config: TS/tsdown bases and the `site` brand identity
@@ -123,7 +123,7 @@ That is the whole setup. When Docker is running, `init` provisions a local Postg
 ## 📚 Documentation
 
 - **[Getting Started](https://zerostarter.dev/docs)**: introduction, architecture, and project structure
-- **[Authentication & Organizations](https://zerostarter.dev/docs/manage/authentication)**: OAuth, orgs, teams, and roles
+- **[Authentication & Organizations](https://zerostarter.dev/docs/manage/authentication)**: OAuth, passkeys, orgs, teams, and roles
 - **[Type-Safe API](https://zerostarter.dev/docs/getting-started/type-safe-api)**: the Hono RPC client
 - **[Database](https://zerostarter.dev/docs/manage/database)**: schema and migrations
 - **[Environment Variables](https://zerostarter.dev/docs/manage/environment)**: configuration

--- a/bun.lock
+++ b/bun.lock
@@ -54,8 +54,10 @@
       "name": "@packages/auth",
       "version": "0.0.0",
       "dependencies": {
+        "@better-auth/passkey": "catalog:",
         "@packages/db": "workspace:*",
         "@packages/env": "workspace:*",
+        "@simplewebauthn/server": "catalog:",
         "better-auth": "catalog:",
       },
       "devDependencies": {
@@ -68,7 +70,7 @@
     },
     "packages/cli": {
       "name": "zerostarter",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "bin": {
         "zerostarter": "dist/bin/index.mjs",
       },
@@ -127,6 +129,7 @@
       "dependencies": {
         "@api/hono": "workspace:*",
         "@base-ui/react": "catalog:",
+        "@better-auth/passkey": "catalog:",
         "@packages/auth": "workspace:*",
         "@packages/config": "workspace:*",
         "@packages/env": "workspace:*",
@@ -195,6 +198,7 @@
   "catalog": {
     "@arcjet/ip": "^1.5.0",
     "@base-ui/react": "^1.6.0",
+    "@better-auth/passkey": "^1.6.22",
     "@commitlint/cli": "^21.1.0",
     "@commitlint/config-conventional": "^21.1.0",
     "@hono/standard-validator": "^0.2.2",
@@ -203,6 +207,7 @@
     "@remixicon/react": "^4.9.0",
     "@scalar/hono-api-reference": "^0.11.6",
     "@shadcn/react": "^0.1.0",
+    "@simplewebauthn/server": "^13.2.3",
     "@t3-oss/env-core": "^0.13.11",
     "@tailwindcss/postcss": "^4.3.1",
     "@takumi-rs/core-darwin-arm64": "^1.8.7",
@@ -352,6 +357,8 @@
 
     "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.22", "", { "peerDependencies": { "@better-auth/core": "^1.6.22", "@better-auth/utils": "0.4.2", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-OYnfySHlVkIx7y6XNBsCHjKhl6IYGprRkFwifc/TAuPBVjoRKhLKRAXuzMdWTQYFt4FYb6holbhjNUrXxPIWcw=="],
 
+    "@better-auth/passkey": ["@better-auth/passkey@1.6.23", "", { "dependencies": { "@simplewebauthn/browser": "^13.2.2", "@simplewebauthn/server": "^13.2.3", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.23", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "better-auth": "^1.6.23", "better-call": "1.3.7", "nanostores": "^1.0.1" } }, "sha512-nr5tKaNd/huUwTYX4DUm4HcXgBkixj0lXrRHdy9azY4fFjF49Tyif4sPyRMWnQJYxlRJ1HVEMJq2nGyr5CLXQg=="],
+
     "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.22", "", { "peerDependencies": { "@better-auth/core": "^1.6.22", "@better-auth/utils": "0.4.2", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-I6lWQwLva732V600u5dLM2kRcQ94pRZOVVfZ87+Ow9RBxMUnV+I+YQ5h2yggdN2tmsmITacZTy1DSZbDxGu0LQ=="],
 
     "@better-auth/telemetry": ["@better-auth/telemetry@1.6.22", "", { "peerDependencies": { "@better-auth/core": "^1.6.22", "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1" } }, "sha512-glq/oEk9qP+zGh9k/WUH5+pwvBCMolNNhaAVBCtYQrkADFee2gP3VoPs1YeO9coNuOmBhc+AYSIHs+fL9DoJnw=="],
@@ -478,6 +485,8 @@
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.5", "", { "peerDependencies": { "@tailwindcss/oxide": "^4.0.0", "tailwindcss": "^4.0.0" }, "optionalPeers": ["@tailwindcss/oxide", "tailwindcss"] }, "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ=="],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hono/standard-validator": ["@hono/standard-validator@0.2.2", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=3.9.0" } }, "sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw=="],
@@ -545,6 +554,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -694,6 +705,32 @@
 
     "@packages/env": ["@packages/env@workspace:packages/env"],
 
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
+
     "@posthog/core": ["@posthog/core@1.38.0", "", { "dependencies": { "@posthog/types": "^1.391.1" } }, "sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w=="],
 
     "@posthog/react": ["@posthog/react@1.10.3", "", { "peerDependencies": { "@types/react": ">=16.8.0", "posthog-js": ">=1.257.2", "react": ">=16.8.0" }, "optionalPeers": ["@types/react"] }, "sha512-Qu//fGQmVlX0B9kTA3LLg67e7AYLEmeuA0Bf1qSyUM0uUILcRQGjQezhNQPLYSTakOqvXEnl6fM2iQBF6Toxrw=="],
@@ -841,6 +878,10 @@
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.2", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0" } }, "sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw=="],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.2.0", "", {}, "sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA=="],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.2", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
@@ -1043,6 +1084,8 @@
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
     "array-ify": ["array-ify@1.0.0", "", {}, "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "ast-kit": ["ast-kit@3.0.0", "", { "dependencies": { "@babel/parser": "^8.0.0", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ=="],
 
@@ -1880,6 +1923,10 @@
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
@@ -1929,6 +1976,8 @@
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 
     "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
@@ -2107,6 +2156,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "turbo": ["turbo@2.10.0", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.0", "@turbo/darwin-arm64": "2.10.0", "@turbo/linux-64": "2.10.0", "@turbo/linux-arm64": "2.10.0", "@turbo/windows-64": "2.10.0", "@turbo/windows-arm64": "2.10.0" }, "bin": { "turbo": "bin/turbo" } }, "sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw=="],
 
@@ -2323,6 +2374,8 @@
     "shadcn/ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "catalog": {
     "@arcjet/ip": "^1.5.0",
     "@base-ui/react": "^1.6.0",
+    "@better-auth/passkey": "^1.6.22",
     "@commitlint/cli": "^21.1.0",
     "@commitlint/config-conventional": "^21.1.0",
     "@hono/standard-validator": "^0.2.2",
@@ -75,6 +76,7 @@
     "@remixicon/react": "^4.9.0",
     "@scalar/hono-api-reference": "^0.11.6",
     "@shadcn/react": "^0.1.0",
+    "@simplewebauthn/server": "^13.2.3",
     "@t3-oss/env-core": "^0.13.11",
     "@tailwindcss/postcss": "^4.3.1",
     "@takumi-rs/core-darwin-arm64": "^1.8.7",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -13,8 +13,10 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@better-auth/passkey": "catalog:",
     "@packages/db": "workspace:*",
     "@packages/env": "workspace:*",
+    "@simplewebauthn/server": "catalog:",
     "better-auth": "catalog:"
   },
   "devDependencies": {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,9 +1,12 @@
+import { passkey as passkeyPlugin } from "@better-auth/passkey"
+import { site } from "@packages/config/site"
 import {
   account,
   db,
   invitation,
   member,
   organization,
+  passkey,
   session,
   team,
   teamMember,
@@ -11,10 +14,16 @@ import {
   verification,
 } from "@packages/db"
 import { env } from "@packages/env/auth"
+import type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+} from "@simplewebauthn/server"
 import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import {
   admin as adminPlugin,
+  lastLoginMethod as lastLoginMethodPlugin,
   openAPI as openAPIPlugin,
   organization as organizationPlugin,
 } from "better-auth/plugins"
@@ -23,9 +32,24 @@ import { getCookieDomain, getCookiePrefix } from "@/lib/utils"
 
 const cookieDomain = getCookieDomain(env.HONO_APP_URL)
 const cookiePrefix = getCookiePrefix(env.HONO_APP_URL)
+const trustedOrigins = env.HONO_TRUSTED_ORIGINS
+const rpID = env.BETTER_AUTH_RP_ID ?? new URL(env.HONO_APP_URL).hostname
+
+function isOriginInRpIDScope(origin: string, rpID: string) {
+  const hostname = new URL(origin).hostname
+  return hostname === rpID || hostname.endsWith(`.${rpID}`)
+}
+
+const incompatibleOrigin = trustedOrigins.find((origin) => !isOriginInRpIDScope(origin, rpID))
+
+if (incompatibleOrigin) {
+  throw new Error(
+    `BETTER_AUTH_RP_ID (${rpID}) must be equal to, or a parent domain of, every trusted origin. ${incompatibleOrigin} is outside that WebAuthn scope.`,
+  )
+}
 
 export type SocialProvider = "github" | "google"
-export type AuthProvider = SocialProvider | "magic-link"
+export type AuthProvider = SocialProvider | "magic-link" | "passkey"
 
 // A provider is enabled only when both of its OAuth credentials are set; a fork can ship with any subset (or none, relying on magic link).
 export const enabledSocialProviders: SocialProvider[] = [
@@ -35,7 +59,7 @@ export const enabledSocialProviders: SocialProvider[] = [
 
 export const auth = betterAuth({
   baseURL: env.HONO_APP_URL,
-  trustedOrigins: env.HONO_TRUSTED_ORIGINS,
+  trustedOrigins,
   database: drizzleAdapter(db, {
     provider: "pg",
     schema: {
@@ -43,6 +67,7 @@ export const auth = betterAuth({
       invitation,
       member,
       organization,
+      passkey,
       session,
       team,
       teamMember,
@@ -65,6 +90,16 @@ export const auth = betterAuth({
       teams: { enabled: true },
     }),
     adminPlugin(),
+    lastLoginMethodPlugin(),
+    passkeyPlugin({
+      rpID,
+      rpName: site.name,
+      origin: trustedOrigins,
+      authenticatorSelection: {
+        residentKey: "required",
+        userVerification: "preferred",
+      },
+    }),
   ],
   socialProviders: {
     ...(env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET
@@ -90,10 +125,21 @@ export const magicLinkEnabled = (auth.options.plugins ?? []).some(
   (p) => (p.id as string) === "magic-link",
 )
 
+export const passkeyEnabled = (auth.options.plugins ?? []).some(
+  (p) => (p.id as string) === "passkey",
+)
+
 // The unified list of enabled sign-in providers the UI reads: social providers plus magic link when its server plugin is registered.
 export const enabledProviders: AuthProvider[] = [
   ...enabledSocialProviders,
   ...(magicLinkEnabled ? (["magic-link"] as const) : []),
+  ...(passkeyEnabled ? (["passkey"] as const) : []),
 ]
 
 export type Session = typeof auth.$Infer.Session
+
+export type {
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+}

--- a/packages/config/src/site.ts
+++ b/packages/config/src/site.ts
@@ -33,7 +33,7 @@ export const site = {
 A Bun + Turborepo monorepo with two deployable apps and four shared packages:
 - \`api/hono/\` - backend API (Hono). Routers live in \`src/routers/\` and are served under \`/api\`: \`/api/v1\` (app API), \`/api/auth\` (Better Auth handler), \`/api/agents\` (local-only dev sign-in), \`/api/waitlist\` (public waitlist signup + count), \`/api/docs\` (Scalar reference).
 - \`web/next/\` - frontend (Next.js App Router). Route groups: \`(protected)\` (auth-gated dashboard) and \`(console)\` (admin console). Docs and blog are MDX under \`content/\`.
-- \`packages/auth/\` - the Better Auth instance (shared server config + plugins).
+- \`packages/auth/\` - the Better Auth instance (shared server config + plugins, including passkeys).
 - \`packages/db/\` - Drizzle ORM schema + client (PostgreSQL via Bun's SQL driver).
 - \`packages/env/\` - type-safe environment variables (t3-oss/env + Zod); one validated entrypoint per consumer.
 - \`packages/config/\` - shared config: the TypeScript/tsdown base configs, and \`site\` (brand identity + injectable content).
@@ -42,7 +42,7 @@ A Bun + Turborepo monorepo with two deployable apps and four shared packages:
 
 - Backend RPC types: \`import type { AppType } from "@api/hono"\`
 - Auth instance: \`import { auth } from "@packages/auth"\`
-- DB client + schema tables: \`import { db, user, session } from "@packages/db"\`
+- DB client + schema tables: \`import { db, user, session, passkey } from "@packages/db"\`
 - Env, per consumer: \`import { env } from "@packages/env/web-next"\` (also \`/api-hono\`, \`/db\`, \`/auth\`)
 - Brand/site config: \`import { site } from "@packages/config/site"\`
 
@@ -52,7 +52,7 @@ Major versions are listed where they matter; see the root \`package.json\` catal
 - **Runtime & tooling:** Bun (runtime + package manager), Turborepo, tsdown (bundler for backend packages), Oxlint + Oxfmt (lint/format), TypeScript, Lefthook + Commitlint (git hooks).
 - **Frontend (\`web/next\`):** Next.js 16 (App Router, Turbopack), React 19, Tailwind CSS v4, shadcn/ui on Base UI primitives, TanStack Query (data) with TanStack Form (forms), Remixicon, Fumadocs (docs), takumi-js (dynamic OG images), PostHog (analytics).
 - **Backend (\`api/hono\`):** Hono with end-to-end type-safe RPC, Zod + @hono/standard-validator, hono-rate-limiter with Arcjet IP detection, OpenAPI + Scalar reference.
-- **Data & auth:** PostgreSQL + Drizzle ORM (Bun SQL driver). Better Auth with the Organizations (organizations + teams) and Admin (role-based access; \`role === "admin"\` gates \`/console\`) plugins.
+- **Data & auth:** PostgreSQL + Drizzle ORM (Bun SQL driver). Better Auth with passkeys, the Organizations (organizations + teams) plugin, and the Admin plugin (role-based access; \`role === "admin"\` gates \`/console\`).
 
 ## Conventions & Rules
 

--- a/packages/db/drizzle/0002_passkey.sql
+++ b/packages/db/drizzle/0002_passkey.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "passkey" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text,
+	"public_key" text NOT NULL,
+	"user_id" text NOT NULL,
+	"credential_id" text NOT NULL,
+	"counter" integer NOT NULL,
+	"device_type" text NOT NULL,
+	"backed_up" boolean NOT NULL,
+	"transports" text,
+	"aaguid" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "passkey_userId_idx" ON "passkey" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "passkey_credentialID_idx" ON "passkey" USING btree ("credential_id");

--- a/packages/db/drizzle/meta/0002_snapshot.json
+++ b/packages/db/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1004 @@
+{
+  "id": "924788ab-d068-4fe9-b09b-369143d93cc4",
+  "prevId": "534c5aa7-591a-416e-88a1-d7b2b9f96022",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_slug_uidx": {
+          "name": "organization_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team": {
+      "name": "team",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "team_organizationId_idx": {
+          "name": "team_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_organization_id_organization_id_fk": {
+          "name": "team_organization_id_organization_id_fk",
+          "tableFrom": "team",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_member": {
+      "name": "team_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "teamMember_teamId_idx": {
+          "name": "teamMember_teamId_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teamMember_userId_idx": {
+          "name": "teamMember_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_member_team_id_team_id_fk": {
+          "name": "team_member_team_id_team_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "team",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_member_user_id_user_id_fk": {
+          "name": "team_member_user_id_user_id_fk",
+          "tableFrom": "team_member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "waitlist_email_unique": {
+          "name": "waitlist_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1782038910452,
       "tag": "0001_waitlist",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1782569899122,
+      "tag": "0002_passkey",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm"
-import { boolean, index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
+import { boolean, index, integer, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core"
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -78,6 +78,29 @@ export const verification = pgTable(
       .notNull(),
   },
   (table) => [index("verification_identifier_idx").on(table.identifier)],
+)
+
+export const passkey = pgTable(
+  "passkey",
+  {
+    id: text("id").primaryKey(),
+    name: text("name"),
+    publicKey: text("public_key").notNull(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    credentialID: text("credential_id").notNull(),
+    counter: integer("counter").notNull(),
+    deviceType: text("device_type").notNull(),
+    backedUp: boolean("backed_up").notNull(),
+    transports: text("transports"),
+    aaguid: text("aaguid"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    index("passkey_userId_idx").on(table.userId),
+    index("passkey_credentialID_idx").on(table.credentialID),
+  ],
 )
 
 export const organization = pgTable(

--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -8,6 +8,7 @@ export const env = createEnv({
   server: {
     NODE_ENV,
     BETTER_AUTH_SECRET: z.string().min(1),
+    BETTER_AUTH_RP_ID: z.string().min(1).optional(),
     GITHUB_CLIENT_ID: z.string().min(1).optional(),
     GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
     GOOGLE_CLIENT_ID: z.string().min(1).optional(),
@@ -21,6 +22,7 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+    BETTER_AUTH_RP_ID: process.env.BETTER_AUTH_RP_ID,
     GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
     GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,

--- a/web/next/content/docs/getting-started/architecture.mdx
+++ b/web/next/content/docs/getting-started/architecture.mdx
@@ -57,7 +57,7 @@ You feel this most when you refactor: the compiler walks you from the database t
 **Data & auth**
 
 - [PostgreSQL](https://www.postgresql.org) with [Drizzle ORM](https://orm.drizzle.team) on Bun's SQL driver, and migrations.
-- [Better Auth](https://better-auth.com): GitHub and Google OAuth, organizations and teams, and an `admin` role that gates `/console`.
+- [Better Auth](https://better-auth.com): GitHub and Google OAuth, passkeys, organizations and teams, and an `admin` role that gates `/console`.
 
 **Everything else, wired**
 

--- a/web/next/content/docs/getting-started/project-structure.mdx
+++ b/web/next/content/docs/getting-started/project-structure.mdx
@@ -45,7 +45,7 @@ Standard App Router, grouped by concern: `(content)/` for docs and blog, `(prote
 
 ## The packages
 
-- **`auth`**, the Better Auth config: optional GitHub/Google OAuth, the organizations + teams plugin, and the `admin` plugin that gates `/console`. Exports session types.
+- **`auth`**, the Better Auth config: optional GitHub/Google OAuth, passkeys, the organizations + teams plugin, and the `admin` plugin that gates `/console`. Exports session types.
 - **`db`**: Drizzle schema under `src/schema/` (`auth.ts`, `waitlist.ts`) and generated migrations under `drizzle/`.
 - **`env`**: every environment variable, validated with [@t3-oss/env-core](https://env.t3.gg) and split per surface (`api-hono.ts`, `auth.ts`, `db.ts`, `web-next.ts`).
 - **`config`**: the TypeScript base every package extends, the `tsdown` factory, and `src/site.ts`, the single file a fork edits to rebrand.

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -41,6 +41,10 @@ bun run db:migrate
 
 </Callout>
 
+ZeroStarter comes with Better Auth, optional GitHub/Google OAuth, and passkey sign-in. You can extend the auth package as needed.
+
+Passkeys work on `localhost` without extra configuration. `BETTER_AUTH_RP_ID` defaults to the `HONO_APP_URL` host and must match, or be a parent domain of, every trusted origin. For deployments where the app and API live on split subdomains, set `BETTER_AUTH_RP_ID` to the shared parent domain used for WebAuthn credentials.
+
 ## `bun run dev`
 
 Turborepo starts both apps together:

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -4,7 +4,7 @@ title: Auth & Organizations
 description: Better Auth with OAuth, organizations, teams, and the role gate behind /console.
 ---
 
-[Better Auth](https://better-auth.com) owns the whole auth surface (sign-in methods, sessions, organizations, and roles) as one config in `packages/auth/src/index.ts`, backed by the same Drizzle schema as the rest of your data. It runs in-process against your own Postgres, so no user records leave your database and there is no separate auth service to keep in sync.
+ZeroStarter uses [Better Auth](https://better-auth.com) for authentication, configured in the `@packages/auth` package. It supports multiple sign-in methods, passkeys, multi-tenant organizations with teams, and session management with cross-subdomain cookie support. The Better Auth OpenAPI plugin is also enabled, exposing an auth API reference at `/api/auth/reference`.
 
 ## Sign-in methods
 
@@ -17,13 +17,21 @@ The sign-in dialog renders itself from whatever is configured. It fetches `GET /
 
 `packages/auth/src/index.ts` builds `socialProviders` conditionally from those vars and exports the resulting `enabledSocialProviders`. Adding a brand-new provider is a small code change: register it conditionally there, then add a button in `web/next/src/components/access.tsx`.
 
+### Passkeys
+
+Passkey sign-in is enabled with the Better Auth passkey plugin in `packages/auth/src/index.ts` and the `passkeyClient()` plugin in `web/next/src/lib/auth/client.ts`. The public `GET /api/auth/providers` route advertises `passkey`, so the sign-in dialog renders a passkey button and enables conditional WebAuthn autofill on the email field (`autocomplete="username webauthn"`) when the browser supports it.
+
+Signed-in users can manage passkeys at `/dashboard/settings/passkeys`, linked from the dashboard user menu. The page supports listing passkeys, adding a new passkey, renaming a passkey, and deleting one. Passkey records are stored in the `passkey` table and cascade when their owning user is deleted.
+
+`rpID` defaults to the `HONO_APP_URL` host and must match, or be a parent domain of, every configured trusted origin. For local development this resolves to `localhost` and needs no extra config. For split subdomains, set `BETTER_AUTH_RP_ID` to the shared parent domain you want WebAuthn credentials scoped to.
+
 **Magic link is off by default.** The client plugin is registered but the server `magicLink` plugin is not, so the email field stays hidden rather than showing a dead control. To enable it, add `magicLink({ sendMagicLink })` to the `plugins` array in `packages/auth/src/index.ts` and implement `sendMagicLink` to deliver the email.
 
 **Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, gated to the `local` environment and a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
 
 <Callout type="warn" title="Configure at least one method before shipping">
 
-A deployed fork with no OAuth providers and no magic link shows "No sign-in options are configured yet." in the sign-in dialog; the agent sign-in is hidden in production. Wire up a provider or magic link before exposing a login surface.
+A deployed fork with no OAuth providers, magic link, or passkeys renders a "No sign-in options are configured yet." message in the sign-in dialog (the local-only agent sign-in is hidden in production). Configure at least one provider, or wire up magic link, before shipping a login surface.
 
 </Callout>
 

--- a/web/next/content/docs/manage/database.mdx
+++ b/web/next/content/docs/manage/database.mdx
@@ -16,7 +16,7 @@ Drizzle is not a query builder wrapped around SQL strings. Because the schema is
 
 Two files under `packages/db/src/schema/`, both re-exported from `index.ts`:
 
-- **`auth.ts`**, the Better Auth tables: `user`, `session`, `account`, `verification`, plus `organization`, `member`, `team`, `teamMember`, and `invitation`, with their Drizzle relations and foreign-key indexes. See [Auth & Organizations](/docs/manage/authentication) for what each one holds.
+- **`auth.ts`**, the Better Auth tables: `user`, `session`, `account`, `verification`, `passkey`, plus `organization`, `member`, `team`, `teamMember`, and `invitation`, with their Drizzle relations and foreign-key indexes. See [Auth & Organizations](/docs/manage/authentication) for what each one holds.
 - **`waitlist.ts`**: a standalone `waitlist` table (no foreign keys) behind the public `/waitlist` page.
 
 Conventions across the schema: `text` primary keys, `snake_case` column names, `timestamp("created_at").defaultNow().notNull()`, `CASCADE` on foreign-key deletes, and an index on every foreign-key column.

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@api/hono": "workspace:*",
     "@base-ui/react": "catalog:",
+    "@better-auth/passkey": "catalog:",
     "@packages/auth": "workspace:*",
     "@packages/config": "workspace:*",
     "@packages/env": "workspace:*",

--- a/web/next/src/app/(protected)/dashboard/settings/passkeys/page.tsx
+++ b/web/next/src/app/(protected)/dashboard/settings/passkeys/page.tsx
@@ -1,0 +1,308 @@
+"use client"
+
+import {
+  RiAddLine,
+  RiDeleteBinLine,
+  RiErrorWarningLine,
+  RiKey2Line,
+  RiPencilLine,
+} from "@remixicon/react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { type ReactElement, useState } from "react"
+import { toast } from "sonner"
+
+import { DashboardHeader } from "@/components/dashboard/header"
+import { DashboardShell } from "@/components/dashboard/shell"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty"
+import { Field, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item"
+import { Spinner } from "@/components/ui/spinner"
+import { authClient } from "@/lib/auth/client"
+
+type Passkey = NonNullable<
+  Awaited<ReturnType<typeof authClient.passkey.listUserPasskeys>>["data"]
+>[number]
+
+function passkeyLabel(passkey: Passkey) {
+  return passkey.name || "Passkey"
+}
+
+function PasskeyNameDialog({
+  mode,
+  initialName,
+  trigger,
+  onSubmit,
+}: {
+  mode: "add" | "rename"
+  initialName: string
+  trigger: ReactElement
+  onSubmit: (name: string) => Promise<void>
+}) {
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState(initialName)
+
+  const mutation = useMutation({
+    mutationFn: onSubmit,
+    onSuccess: () => {
+      toast.success(mode === "add" ? "Passkey added" : "Passkey renamed")
+      queryClient.invalidateQueries({ queryKey: ["passkeys"] })
+      setOpen(false)
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    },
+  })
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (next) setName(initialName)
+      }}
+    >
+      <DialogTrigger render={trigger} />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{mode === "add" ? "Add a passkey" : "Rename passkey"}</DialogTitle>
+        </DialogHeader>
+        <form
+          className="space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault()
+            mutation.mutate(name.trim())
+          }}
+        >
+          <Field>
+            <FieldLabel htmlFor="passkey-name">Name</FieldLabel>
+            <Input
+              id="passkey-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={mode === "add" ? "e.g. MacBook Touch ID" : "Passkey name"}
+              disabled={mutation.isPending}
+            />
+          </Field>
+          <DialogFooter>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? <Spinner /> : null}
+              {mode === "add" ? "Create passkey" : "Save"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function AddPasskeyDialog() {
+  return (
+    <PasskeyNameDialog
+      mode="add"
+      initialName=""
+      trigger={
+        <Button>
+          <RiAddLine />
+          Add passkey
+        </Button>
+      }
+      onSubmit={async (name) => {
+        const res = await authClient.passkey.addPasskey(name ? { name } : {})
+        if (res.error) throw new Error(res.error.message || "Failed to add passkey")
+      }}
+    />
+  )
+}
+
+function RenamePasskeyDialog({ passkey }: { passkey: Passkey }) {
+  return (
+    <PasskeyNameDialog
+      mode="rename"
+      initialName={passkey.name ?? ""}
+      trigger={
+        <Button variant="ghost" size="icon" aria-label="Rename passkey">
+          <RiPencilLine />
+        </Button>
+      }
+      onSubmit={async (name) => {
+        if (!name) throw new Error("Name cannot be empty")
+        const res = await authClient.passkey.updatePasskey({ id: passkey.id, name })
+        if (res.error) throw new Error(res.error.message || "Failed to rename passkey")
+      }}
+    />
+  )
+}
+
+function DeletePasskeyButton({ passkey }: { passkey: Passkey }) {
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+
+  const deletePasskey = useMutation({
+    mutationFn: async () => {
+      const res = await authClient.passkey.deletePasskey({ id: passkey.id })
+      if (res.error) throw new Error(res.error.message || "Failed to delete passkey")
+    },
+    onSuccess: () => {
+      toast.success("Passkey removed")
+      queryClient.invalidateQueries({ queryKey: ["passkeys"] })
+      setOpen(false)
+    },
+    onError: (error: Error) => {
+      toast.error(error.message)
+    },
+  })
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-destructive"
+            aria-label="Delete passkey"
+          />
+        }
+      >
+        <RiDeleteBinLine />
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete passkey?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Permanently removes this passkey ({passkeyLabel(passkey)}). If it is your only sign-in
+            method, make sure you can still sign in another way.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deletePasskey.isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="destructive"
+            disabled={deletePasskey.isPending}
+            onClick={() => deletePasskey.mutate()}
+          >
+            {deletePasskey.isPending ? <Spinner /> : null}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export default function PasskeysSettingsPage() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["passkeys"],
+    queryFn: async () => {
+      const res = await authClient.passkey.listUserPasskeys()
+      if (res.error) throw new Error(res.error.message || "Failed to load passkeys")
+      return res.data
+    },
+  })
+
+  const passkeys = data ?? []
+
+  return (
+    <DashboardShell size="sm">
+      <DashboardHeader
+        title="Passkeys"
+        description="Sign in without a password using Touch ID, Face ID, or a security key."
+        actions={<AddPasskeyDialog />}
+      />
+
+      {isLoading ? (
+        <div className="text-muted-foreground flex items-center justify-center py-12">
+          <Spinner />
+        </div>
+      ) : isError ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <RiErrorWarningLine />
+            </EmptyMedia>
+            <EmptyTitle>Unable to load passkeys</EmptyTitle>
+            <EmptyDescription>
+              Something went wrong loading your passkeys. Refresh the page to try again.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : passkeys.length === 0 ? (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <RiKey2Line />
+            </EmptyMedia>
+            <EmptyTitle>No passkeys yet</EmptyTitle>
+            <EmptyDescription>
+              Add a passkey to sign in faster and more securely on this device.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <AddPasskeyDialog />
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <ItemGroup>
+          {passkeys.map((passkey) => (
+            <Item key={passkey.id} variant="outline">
+              <ItemMedia variant="icon">
+                <RiKey2Line />
+              </ItemMedia>
+              <ItemContent>
+                <div className="flex items-center gap-2">
+                  <ItemTitle>{passkeyLabel(passkey)}</ItemTitle>
+                  <Badge variant="secondary">{passkey.backedUp ? "Synced" : "This device"}</Badge>
+                </div>
+                <ItemDescription>
+                  Added {new Date(passkey.createdAt).toLocaleDateString()}
+                </ItemDescription>
+              </ItemContent>
+              <ItemActions>
+                <RenamePasskeyDialog passkey={passkey} />
+                <DeletePasskeyButton passkey={passkey} />
+              </ItemActions>
+            </Item>
+          ))}
+        </ItemGroup>
+      )}
+    </DashboardShell>
+  )
+}

--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { site } from "@packages/config/site"
-import { RiGithubFill, RiGoogleFill, RiLayoutGridFill } from "@remixicon/react"
+import { RiGithubFill, RiGoogleFill, RiKey2Line, RiLayoutGridFill } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { useQuery } from "@tanstack/react-query"
 import { usePathname } from "next/navigation"
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { z } from "zod"
 
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -30,7 +31,7 @@ const formSchema = z.object({
 
 export function Access() {
   const pathname = usePathname()
-  const [loader, setLoader] = useState<"email" | "github" | "google" | null>(null)
+  const [loader, setLoader] = useState<"email" | "github" | "google" | "passkey" | null>(null)
   const [open, setOpen] = useState(false)
   // Next inlines NODE_ENV at build time: "development" only under `next dev`,
   // "production" for any `next build`. Auto-hides in deployments.
@@ -49,13 +50,50 @@ export function Access() {
   const githubEnabled = data?.providers.includes("github") ?? false
   const googleEnabled = data?.providers.includes("google") ?? false
   const magicLinkEnabled = data?.providers.includes("magic-link") ?? false
-  const hasAlternatives = isDev || githubEnabled || googleEnabled
+  const passkeyEnabled = data?.providers.includes("passkey") ?? false
+  const hasAlternatives = isDev || githubEnabled || googleEnabled || passkeyEnabled
   const hasNoProviders = !magicLinkEnabled && !hasAlternatives
+  const [passkeyWasLast, setPasskeyWasLast] = useState(false)
+
+  useEffect(() => {
+    setPasskeyWasLast(authClient.isLastUsedLoginMethod("passkey"))
+  }, [])
 
   useEffect(() => {
     setLoader(null)
     setOpen(false)
   }, [pathname])
+
+  useEffect(() => {
+    if (!open || !passkeyEnabled || !magicLinkEnabled || typeof window === "undefined") return
+    if (
+      typeof PublicKeyCredential === "undefined" ||
+      typeof PublicKeyCredential.isConditionalMediationAvailable !== "function"
+    ) {
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      let available = false
+      try {
+        available = await PublicKeyCredential.isConditionalMediationAvailable()
+      } catch {
+        return
+      }
+      if (cancelled || !available) return
+      void authClient.signIn.passkey({
+        autoFill: true,
+        fetchOptions: {
+          onSuccess: () => {
+            window.location.href = `${config.app.url}/dashboard`
+          },
+        },
+      })
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [magicLinkEnabled, open, passkeyEnabled])
 
   const form = useForm({
     defaultValues: {
@@ -120,6 +158,7 @@ export function Access() {
                           id={field.name}
                           type="email"
                           name={field.name}
+                          autoComplete="username webauthn"
                           className="focus:placeholder:opacity-0"
                           value={field.state.value}
                           onBlur={field.handleBlur}
@@ -161,6 +200,36 @@ export function Access() {
                     Login (agents)
                   </Button>
                 </form>
+              )}
+              {passkeyEnabled && (
+                <Button
+                  variant="outline"
+                  type="button"
+                  className="w-full"
+                  onClick={async () => {
+                    setLoader("passkey")
+                    const res = await authClient.signIn.passkey({
+                      fetchOptions: {
+                        onSuccess: () => {
+                          window.location.href = `${config.app.url}/dashboard`
+                        },
+                      },
+                    })
+                    if (res?.error) {
+                      toast.error(res.error.message)
+                      setLoader(null)
+                    }
+                  }}
+                  disabled={loader === "passkey"}
+                >
+                  {loader === "passkey" ? <Spinner /> : <RiKey2Line className="size-5" />}
+                  Sign in with a passkey
+                  {passkeyWasLast && (
+                    <Badge variant="secondary" className="ml-auto">
+                      Last used
+                    </Badge>
+                  )}
+                </Button>
               )}
               {githubEnabled && (
                 <Button

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -4,10 +4,12 @@ import { env } from "@packages/env/web-next"
 import {
   RiArrowRightSLine,
   RiDashboardLine,
+  RiKey2Line,
   RiLogoutBoxLine,
   RiMessage2Line,
   RiTerminalBoxLine,
 } from "@remixicon/react"
+import { useQuery } from "@tanstack/react-query"
 import { type User } from "better-auth/types"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -18,6 +20,7 @@ import { SidebarDropdownMenu } from "@/components/sidebar/dropdown-menu"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu"
 import { SidebarMenuItem } from "@/components/ui/sidebar"
+import { apiClient, unwrap } from "@/lib/api/client"
 import { authClient } from "@/lib/auth/client"
 
 function getInitials(name: string) {
@@ -30,6 +33,16 @@ function getInitials(name: string) {
 export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard" | "console" }) {
   const router = useRouter()
   const [signingOut, setSigningOut] = useState(false)
+  const { data } = useQuery({
+    queryKey: ["auth-providers"],
+    staleTime: Infinity,
+    queryFn: async () => {
+      const { data, error } = await unwrap(apiClient.auth.providers.$get())
+      if (error) throw new Error(error.message)
+      return data
+    },
+  })
+  const passkeyEnabled = data?.providers.includes("passkey") ?? false
 
   // The user menu is shared, so the cross-link points at the other workspace: dashboard -> console, console -> dashboard.
   const crossLink =
@@ -59,6 +72,14 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
             </DropdownMenuItem>
             <DropdownMenuSeparator />
           </>
+        )}
+        {passkeyEnabled && (
+          <DropdownMenuItem
+            render={<Link href="/dashboard/settings/passkeys" className="cursor-pointer" />}
+          >
+            <RiKey2Line />
+            Passkeys
+          </DropdownMenuItem>
         )}
         {env.NEXT_PUBLIC_USERJOT_URL && (
           <DropdownMenuItem

--- a/web/next/src/lib/auth/client.ts
+++ b/web/next/src/lib/auth/client.ts
@@ -1,9 +1,19 @@
-import { magicLinkClient, organizationClient } from "better-auth/client/plugins"
+import { passkeyClient } from "@better-auth/passkey/client"
+import {
+  lastLoginMethodClient,
+  magicLinkClient,
+  organizationClient,
+} from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
 
 import { config } from "@/lib/config"
 
 export const authClient = createAuthClient({
   baseURL: `${config.api.url}/api/auth`,
-  plugins: [magicLinkClient(), organizationClient({ teams: { enabled: true } })],
+  plugins: [
+    lastLoginMethodClient(),
+    magicLinkClient(),
+    organizationClient({ teams: { enabled: true } }),
+    passkeyClient(),
+  ],
 })


### PR DESCRIPTION
  ## Summary

  Closes #594.

  Adds Better Auth passkey (WebAuthn) support across the stack:
  - registers the server passkey plugin with rpID/origin derived from app config
  - adds the Better Auth `passkey` table and additive Drizzle migration
  - exposes `passkey` through `/api/auth/providers`
  - adds passkey sign-in plus conditional WebAuthn autofill
  - adds `/dashboard/settings/passkeys` for list/add/rename/delete
  - links passkey management from the dashboard user menu
  - documents passkey setup, rpID configuration, schema, and usage

  ## Verification

  Passed:
  - `bun audit --audit-level high`
  - `bun --cwd packages/cli test` (`16 pass, 0 fail`)
  - `bun run format:check`
  - `bun run lint`
  - `bun .github/scripts/docs.ts --strict`
  - `SKIP_ENV_VALIDATION=true ... bun --cwd packages/db drizzle-kit generate`
  - `SKIP_ENV_VALIDATION=true ... bun run check-types`
  - non-web package builds for config/env/db/auth/api/cli
  - provider discovery check returns `["passkey"]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passkey sign-in across the app, including conditional autofill and a “last used” indicator when available.
  * Added a Passkeys settings page to view, add, rename, and delete passkeys.
  * Added a new optional environment variable to configure the WebAuthn relying party ID for split-subdomain deployments.
* **Documentation**
  * Updated setup, authentication, architecture, and database docs to cover passkeys, the new configuration option, and related provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->