### PR TITLE
fix(cli): normalize path separators in findPackageJsons test for Windows

### DIFF
--- a/packages/cli/test/io.test.ts
+++ b/packages/cli/test/io.test.ts
@@ -24,7 +24,9 @@ afterEach(() => {
   rmSync(dir, { force: true, recursive: true })
 })
 
-const rel = (paths: string[]) => paths.map((p) => p.slice(dir.length + 1)).sort()
+// Normalize to forward slashes so the assertion holds on Windows (findPackageJsons returns native paths).
+const rel = (paths: string[]) =>
+  paths.map((p) => p.slice(dir.length + 1).replaceAll("\\", "/")).sort()
 
 describe("file helpers", () => {
   test("write creates parent dirs; read/exists round-trip", () => {


### PR DESCRIPTION
The `findPackageJsons` test compared native paths to forward-slash literals, so `test (windows-latest)` failed in cli-release.yml, which skipped the `release` job and blocked the `zerostarter@0.0.14` publish (ubuntu/macos passed).

`findPackageJsons` correctly returns native paths (sync relies on `=== rootPkg`), so the fix normalizes separators in the test assertion only. Unblocks the 0.0.14 publish.

Follow-up to #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)