### PR TITLE
fix(cli): preserve the fork's DB migrations and schema on sync

### DIFF
--- a/.gitpickignore
+++ b/.gitpickignore
@@ -1,8 +1,9 @@
 # directories/files that a scaffolded or synced ZeroStarter fork does not take from the starter.
 # only affects gitpick fetches; a plain `git clone` of this repo still gets everything.
 
-# sync restores these fork-owned paths after the overlay (init seeds them, a re-baseline keeps them):
-# PRESERVE_ON_SYNC - AUDIT.md, web/next/src/app/favicon.ico, web/next/src/app/icon.svg
+# sync restores these fork-owned paths after the overlay (init seeds them, a re-baseline keeps them).
+# packages/db/drizzle + src/schema are the fork's own applied DB state; overlaying the starter's would corrupt its migration history.
+# PRESERVE_ON_SYNC - AUDIT.md, web/next/src/app/favicon.ico, web/next/src/app/icon.svg, packages/db/drizzle/, packages/db/src/schema/
 
 # custom directories
 .github/assets/

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -47,7 +47,7 @@ bun run db:migrate
 
 ## `zerostarter sync`
 
-`bunx zerostarter sync` re-baselines an **existing fork** on ZeroStarter's latest scaffold. A gitpick overlay updates the starter files while your content, `public/marketing`, branding (`site.ts`), `package.json` identity, and favicon are preserved and the files you added are untouched. It requires a clean tree and lands as a reviewable diff you commit yourself (no auto-commit); if the overlay or reconciliation fails it rolls the tree back to your last commit, while a later dependency-install failure leaves the synced files in place for you to re-run `bun install`.
+`bunx zerostarter sync` re-baselines an **existing fork** on ZeroStarter's latest scaffold. A gitpick overlay updates the starter files while your content, `public/marketing`, branding (`site.ts`), `package.json` identity, database migrations and schema (`packages/db/drizzle`, `packages/db/src/schema`), and favicon are preserved and the files you added are untouched. It requires a clean tree and lands as a reviewable diff you commit yourself (no auto-commit); if the overlay or reconciliation fails it rolls the tree back to your last commit, while a later dependency-install failure leaves the synced files in place for you to re-run `bun install`.
 
 ## `bun run dev`
 


### PR DESCRIPTION
`sync`'s gitpick overlay overwrote `packages/db/drizzle/` — replacing the fork's migration journal with the starter's baseline and orphaning the fork's own migrations (`0000` rewritten, fork's `0001-0004` dropped from the journal). That corrupts an existing fork's applied migration history.

Add `packages/db/drizzle/` and `packages/db/src/schema/` to `PRESERVE_ON_SYNC` so `gitRestore` restores the fork's DB state after the overlay. The preserve list is fetched from `main` at runtime, so the published `zerostarter@0.0.14` honors it with no republish.

Found by comparing a manual re-baseline of dalonic.com against the programmatic sync. Follow-up to #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified what content is preserved when running sync, including database migrations and schema files.
  * Updated setup guidance to better explain which project assets remain intact after syncing.

* **Chores**
  * Added a note to the sync ignore rules to reflect the expanded preservation list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->