### PR TITLE
style: alphabetize the PRESERVE_ON_SYNC directive paths

### DIFF
--- a/.gitpickignore
+++ b/.gitpickignore
@@ -3,7 +3,7 @@
 
 # sync restores these fork-owned paths after the overlay (init seeds them, a re-baseline keeps them).
 # packages/db/drizzle + src/schema are the fork's own applied DB state; overlaying the starter's would corrupt its migration history.
-# PRESERVE_ON_SYNC - AUDIT.md, web/next/src/app/favicon.ico, web/next/src/app/icon.svg, packages/db/drizzle/, packages/db/src/schema/
+# PRESERVE_ON_SYNC - AUDIT.md, packages/db/drizzle/, packages/db/src/schema/, web/next/src/app/favicon.ico, web/next/src/app/icon.svg
 
 # custom directories
 .github/assets/


### PR DESCRIPTION
Order the `PRESERVE_ON_SYNC` paths alphabetically per the repo convention. `parsePreserve` is order-agnostic, so no behavior change. Follow-up to #616.