### PR TITLE
fix(cli): close sync/init preserve-and-leak gaps

### DIFF
--- a/.gitpickignore
+++ b/.gitpickignore
@@ -3,7 +3,8 @@
 
 # sync restores these fork-owned paths after the overlay (init seeds them, a re-baseline keeps them).
 # packages/db/drizzle + src/schema are the fork's own applied DB state; overlaying the starter's would corrupt its migration history.
-# PRESERVE_ON_SYNC - AUDIT.md, packages/db/drizzle/, packages/db/src/schema/, web/next/src/app/favicon.ico, web/next/src/app/icon.svg
+# docs.config.ts describes the fork's own content/docs (also preserved); overlaying the starter's lists docs the fork lacks and fails the strict docs build.
+# PRESERVE_ON_SYNC - AUDIT.md, packages/db/drizzle/, packages/db/src/schema/, web/next/docs.config.ts, web/next/src/app/favicon.ico, web/next/src/app/icon.svg
 
 # custom directories
 .github/assets/

--- a/.gitpickignore
+++ b/.gitpickignore
@@ -4,7 +4,7 @@
 # sync restores these fork-owned paths after the overlay (init seeds them, a re-baseline keeps them).
 # packages/db/drizzle + src/schema are the fork's own applied DB state; overlaying the starter's would corrupt its migration history.
 # docs.config.ts describes the fork's own content/docs (also preserved); overlaying the starter's lists docs the fork lacks and fails the strict docs build.
-# PRESERVE_ON_SYNC - AUDIT.md, packages/db/drizzle/, packages/db/src/schema/, web/next/docs.config.ts, web/next/src/app/favicon.ico, web/next/src/app/icon.svg
+# PRESERVE_ON_SYNC - packages/db/drizzle/, packages/db/src/schema/, web/next/docs.config.ts, web/next/src/app/favicon.ico
 
 # custom directories
 .github/assets/
@@ -23,8 +23,10 @@ web/next/public/
 .infisical.json
 .coderabbit.yaml
 AGENTS.md
+AUDIT.md
 bun.lock
 CHANGELOG.md
 LICENSE.md
 packages/config/src/site.ts
 README.md
+web/next/src/app/icon.svg

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -28,11 +28,13 @@ export const fetchGitpickignore = async (ref = "main"): Promise<string> => {
 export const gitIsClean = (dir: string): boolean =>
   run("git", ["status", "--porcelain"], dir).trim() === ""
 
-// Restore the committed version of paths in `dir` (binary-safe); skips paths the fork does not track.
+// Restore each path in `dir` to its committed state (binary-safe) and remove any untracked files under it; skips a path the fork does not track.
 export const gitRestore = (dir: string, paths: string[]): void => {
   for (const path of paths) {
     try {
       run("git", ["checkout", "--", path], dir)
+      // drop overlay-added files the fork does not track (e.g. a starter migration under a preserved dir)
+      run("git", ["clean", "-fd", "--", path], dir)
     } catch {
       // not tracked in the fork; keep the overlaid version
     }

--- a/packages/cli/test/git.test.ts
+++ b/packages/cli/test/git.test.ts
@@ -63,6 +63,18 @@ test("gitRestore restores a committed path and skips an untracked one", () => {
   expect(readFileSync(join(dir, "keep.txt"), "utf8")).toBe("orig")
 })
 
+test("gitRestore drops overlay-added untracked files under a preserved dir", () => {
+  mkdirSync(join(dir, "db"))
+  writeFileSync(join(dir, "db/0000.sql"), "base")
+  gitCommitAll(dir, "init")
+  // simulate the overlay: overwrite the tracked migration and add a starter one the fork never had
+  writeFileSync(join(dir, "db/0000.sql"), "overlaid")
+  writeFileSync(join(dir, "db/0001_orphan.sql"), "starter")
+  gitRestore(dir, ["db"])
+  expect(readFileSync(join(dir, "db/0000.sql"), "utf8")).toBe("base")
+  expect(existsSync(join(dir, "db/0001_orphan.sql"))).toBe(false)
+})
+
 test("gitResetHard restores tracked files, removes untracked, keeps gitignored", () => {
   writeFileSync(join(dir, ".gitignore"), "ignored/\n")
   writeFileSync(join(dir, "src.txt"), "orig")

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -47,7 +47,7 @@ bun run db:migrate
 
 ## `zerostarter sync`
 
-`bunx zerostarter sync` re-baselines an **existing fork** on ZeroStarter's latest scaffold. A gitpick overlay updates the starter files while your content, `public/marketing`, branding (`site.ts`), `package.json` identity, database migrations and schema (`packages/db/drizzle`, `packages/db/src/schema`), and favicon are preserved and the files you added are untouched. It requires a clean tree and lands as a reviewable diff you commit yourself (no auto-commit); if the overlay or reconciliation fails it rolls the tree back to your last commit, while a later dependency-install failure leaves the synced files in place for you to re-run `bun install`.
+`bunx zerostarter sync` re-baselines an **existing fork** on ZeroStarter's latest scaffold. A gitpick overlay updates the starter files while your content, `public/marketing`, branding (`site.ts`), `package.json` identity, database migrations and schema (`packages/db/drizzle`, `packages/db/src/schema`), the docs config (`docs.config.ts`, which describes your own docs), and favicon are preserved and the files you added are untouched. It requires a clean tree and lands as a reviewable diff you commit yourself (no auto-commit); if the overlay or reconciliation fails it rolls the tree back to your last commit, while a later dependency-install failure leaves the synced files in place for you to re-run `bun install`.
 
 ## `bun run dev`
 


### PR DESCRIPTION
Closes the sync/init preserve-and-leak gaps surfaced re-baselining the dalonic-ai/cafe forks.

**Sync overwrote fork-owned config (broke the build):**
- `docs.config.ts` — overlay replaced it with the starter's full docs tree; the strict docs build then failed on every starter doc the fork lacks. Added to `PRESERVE_ON_SYNC`.

**init/reinit seeded starter-only files into forks (leaks):**
- `AUDIT.md` (the starter's `bun audit` report) and `web/next/src/app/icon.svg` (the starter's generic icon, which overrides a fork's `favicon.ico`) were in `PRESERVE_ON_SYNC` (seed-at-init). Moved to the gitpick **excludes** — never seeded at init, and a fork's own is still preserved on sync.

**Sync left orphans:**
- `gitRestore` only ran `git checkout`, so overlay-added files under a preserved dir (the starter's `0001_waitlist.sql` under `packages/db/drizzle`) stayed as untracked orphans. Added `git clean`.

`.gitpickignore` changes are fetched from main at runtime (honored by the published `0.0.14`); the `gitRestore` change ships in the next CLI release. 62 CLI tests pass. Follow-up to #616.