### PR TITLE
chore(cli): bump to 0.0.15

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",


### PR DESCRIPTION
Bumps the CLI npm version so `cli-release` publishes the `gitRestore` orphan-clean fix from #620 (that code landed on main but the version was unchanged, so the publish was skipped). Follow-up to #620.