### PR TITLE
fix(cli): reuse a running local Postgres on init and wait for readiness

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -72,16 +72,20 @@ export const hasPostgresUrl = (dir: string): boolean => {
   return exists(envPath) && getEnvVar(envPath, "POSTGRES_URL") !== ""
 }
 
-// A launched (or reused) local Postgres: the connection URL and its Docker container name.
-type Launch = { url: string; container: string }
+// A launched (or reused) local Postgres: the connection URL, its Docker container name, and whether pglaunch reused an already-running container (reused) rather than starting a new one.
+type Launch = { url: string; container: string; reused: boolean }
 
-// Pull the connection URL and container name out of pglaunch's output. pglaunch prints both whether it just started a container (`... name "<name> :<port>" started ...`) or, on a name collision, reports an already-running one (`... similar name "<name>" running ...`); the URL line is ANSI-colored. Returns null when no URL is present.
+// Pull the connection URL and container name out of pglaunch's output. pglaunch prints both whether it just started a container (`... name "<name> :<port>" started ...`) or, on a name collision, reports an already-running one (`... similar name "<name>" running ...`); the URL line is ANSI-colored. reused is true unless we saw an explicit "started" line, so an ambiguous output is treated as a reuse and never abandoned. Returns null when no URL is present.
 export const parseLaunch = (out: string): Launch | null => {
   const url = out.match(/postgres(?:ql)?:\/\/[\w.:@\-/%?=&]+/)
   if (!url) return null
   const started = out.match(/name "([^" ]+) :\d+" started/)
   const similar = out.match(/similar name "([^"]+)"/)
-  return { url: url[0], container: started ? started[1] : similar ? similar[1] : "" }
+  return {
+    url: url[0],
+    container: started ? started[1] : similar ? similar[1] : "",
+    reused: !started,
+  }
 }
 
 // Run pglaunch (-k keeps the container) and return what it launched, or null when it prints no URL. On a name collision pglaunch exits non-zero but still prints the already-running container's URL, so we reuse that instead of failing. Passing confirm adds -c to force a brand-new container even when a similar-named one is already running.
@@ -117,7 +121,7 @@ const waitForPostgres = (container: string): void => {
   }
 }
 
-// Provision a local database, point .env at it, and apply the shipped migrations (a fresh fork ships its migration files, so db:generate is not needed). Reuses an already-running local Postgres when one exists, and only starts a fresh container if the reused database rejects the migrations.
+// Provision a local database, point .env at it, and apply the shipped migrations (a fresh fork ships its migration files, so db:generate is not needed). Reuses an already-running local Postgres when one exists.
 export const provisionDatabase = (dir: string): void => {
   const envPath = ensureEnv(dir)
   const migrate = (l: Launch): void => {
@@ -127,12 +131,20 @@ export const provisionDatabase = (dir: string): void => {
   }
 
   const launched = runPglaunch(dir, false)
+
+  // Reused an already-running database: migrate in place and let any failure surface, rather than abandoning a database that may hold data for a fresh, empty one.
+  if (launched && launched.reused) {
+    migrate(launched)
+    return
+  }
+
+  // A container we just created: if it rejects the migrations, replace it with a clean one (nothing to lose since it is empty).
   if (launched) {
     try {
       migrate(launched)
       return
     } catch {
-      // The reused database rejected the migrations; start a clean container below.
+      // Fall through to a fresh container below.
     }
   }
 

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -72,17 +72,71 @@ export const hasPostgresUrl = (dir: string): boolean => {
   return exists(envPath) && getEnvVar(envPath, "POSTGRES_URL") !== ""
 }
 
-// Launch a kept local Postgres via pglaunch and return the URL it prints (e.g. `postgres://postgres:postgres@localhost:<port>/postgres`; the postgresql:// scheme and query params are also accepted).
-const launchPostgres = (dir: string): string => {
-  const out = capture("bunx", [PGLAUNCH, "-k"], dir)
-  const match = out.match(/postgres(?:ql)?:\/\/[\w.:@\-/%?=&]+/)
-  if (!match) throw new Error("pglaunch did not print a connection URL")
-  return match[0]
+// A launched (or reused) local Postgres: the connection URL and its Docker container name.
+type Launch = { url: string; container: string }
+
+// Pull the connection URL and container name out of pglaunch's output. pglaunch prints both whether it just started a container (`... name "<name> :<port>" started ...`) or, on a name collision, reports an already-running one (`... similar name "<name>" running ...`); the URL line is ANSI-colored. Returns null when no URL is present.
+export const parseLaunch = (out: string): Launch | null => {
+  const url = out.match(/postgres(?:ql)?:\/\/[\w.:@\-/%?=&]+/)
+  if (!url) return null
+  const started = out.match(/name "([^" ]+) :\d+" started/)
+  const similar = out.match(/similar name "([^"]+)"/)
+  return { url: url[0], container: started ? started[1] : similar ? similar[1] : "" }
 }
 
-// Provision a local database, point .env at it, and apply the shipped migrations (a fresh fork ships its migration files, so db:generate is not needed).
+// Run pglaunch (-k keeps the container) and return what it launched, or null when it prints no URL. On a name collision pglaunch exits non-zero but still prints the already-running container's URL, so we reuse that instead of failing. Passing confirm adds -c to force a brand-new container even when a similar-named one is already running.
+const runPglaunch = (dir: string, confirm: boolean): Launch | null => {
+  const args = confirm ? [PGLAUNCH, "-k", "-c"] : [PGLAUNCH, "-k"]
+  let out: string
+  try {
+    out = capture("bunx", args, dir)
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string }
+    out = [e.stdout, e.stderr].filter(Boolean).join("\n")
+  }
+  return parseLaunch(out)
+}
+
+// Block for `ms` milliseconds (provisionDatabase runs synchronously, so this can't be an async delay).
+const sleep = (ms: number): void => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+// Wait until the container's Postgres accepts connections. pglaunch returns as soon as `docker run` starts, but the server needs a moment to finish booting, so migrating immediately races and fails. pglaunch containers are postgres:alpine, which ships pg_isready. Best-effort: returns once ready or after the attempts are exhausted.
+const waitForPostgres = (container: string): void => {
+  if (!container) return
+  for (let i = 0; i < 30; i++) {
+    try {
+      execFileSync("docker", ["exec", container, "pg_isready", "-U", "postgres"], {
+        stdio: "ignore",
+      })
+      return
+    } catch {
+      sleep(1000)
+    }
+  }
+}
+
+// Provision a local database, point .env at it, and apply the shipped migrations (a fresh fork ships its migration files, so db:generate is not needed). Reuses an already-running local Postgres when one exists, and only starts a fresh container if the reused database rejects the migrations.
 export const provisionDatabase = (dir: string): void => {
   const envPath = ensureEnv(dir)
-  setEnvVar(envPath, "POSTGRES_URL", launchPostgres(dir))
-  capture("bun", ["run", "db:migrate"], dir)
+  const migrate = (l: Launch): void => {
+    setEnvVar(envPath, "POSTGRES_URL", l.url)
+    waitForPostgres(l.container)
+    capture("bun", ["run", "db:migrate"], dir)
+  }
+
+  const launched = runPglaunch(dir, false)
+  if (launched) {
+    try {
+      migrate(launched)
+      return
+    } catch {
+      // The reused database rejected the migrations; start a clean container below.
+    }
+  }
+
+  const fresh = runPglaunch(dir, true)
+  if (!fresh) throw new Error("pglaunch did not print a connection URL")
+  migrate(fresh)
 }

--- a/packages/cli/test/db.test.ts
+++ b/packages/cli/test/db.test.ts
@@ -50,17 +50,18 @@ test("hasPostgresUrl reflects whether POSTGRES_URL is set", () => {
   expect(hasPostgresUrl(dir)).toBe(true)
 })
 
-test("parseLaunch reads the URL and container from a fresh-container launch", () => {
+test("parseLaunch reads a freshly started container and marks it not reused", () => {
   const out =
     '- A container with name "my-app-a1B2 :5433" started successfully.\n\n' +
     "  POSTGRES_URL=postgres://postgres:postgres@localhost:5433/postgres"
   expect(parseLaunch(out)).toEqual({
     url: "postgres://postgres:postgres@localhost:5433/postgres",
     container: "my-app-a1B2",
+    reused: false,
   })
 })
 
-test("parseLaunch reuses the URL and container pglaunch prints on a name collision", () => {
+test("parseLaunch reuses the container pglaunch reports on a name collision", () => {
   // pglaunch exits non-zero but prints the already-running container's URL (ANSI-wrapped).
   const out =
     '- A container by similar name "my-app-pDtx" running at port 4611.\n\n' +
@@ -69,6 +70,15 @@ test("parseLaunch reuses the URL and container pglaunch prints on a name collisi
   expect(parseLaunch(out)).toEqual({
     url: "postgres://postgres:postgres@localhost:4611/postgres",
     container: "my-app-pDtx",
+    reused: true,
+  })
+})
+
+test("parseLaunch treats a URL with no start line as a reuse (never abandoned)", () => {
+  expect(parseLaunch("POSTGRES_URL=postgres://postgres:postgres@localhost:7000/postgres")).toEqual({
+    url: "postgres://postgres:postgres@localhost:7000/postgres",
+    container: "",
+    reused: true,
   })
 })
 

--- a/packages/cli/test/db.test.ts
+++ b/packages/cli/test/db.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { hasPostgresUrl, seedEnv } from "@/db"
+import { hasPostgresUrl, parseLaunch, seedEnv } from "@/db"
 
 let dir: string
 
@@ -48,4 +48,30 @@ test("hasPostgresUrl reflects whether POSTGRES_URL is set", () => {
   expect(hasPostgresUrl(dir)).toBe(false)
   writeFileSync(join(dir, ".env"), "POSTGRES_URL=postgres://x@localhost:5432/db\n")
   expect(hasPostgresUrl(dir)).toBe(true)
+})
+
+test("parseLaunch reads the URL and container from a fresh-container launch", () => {
+  const out =
+    '- A container with name "my-app-a1B2 :5433" started successfully.\n\n' +
+    "  POSTGRES_URL=postgres://postgres:postgres@localhost:5433/postgres"
+  expect(parseLaunch(out)).toEqual({
+    url: "postgres://postgres:postgres@localhost:5433/postgres",
+    container: "my-app-a1B2",
+  })
+})
+
+test("parseLaunch reuses the URL and container pglaunch prints on a name collision", () => {
+  // pglaunch exits non-zero but prints the already-running container's URL (ANSI-wrapped).
+  const out =
+    '- A container by similar name "my-app-pDtx" running at port 4611.\n\n' +
+    "  \x1b[31mPOSTGRES_URL=postgres://postgres:postgres@localhost:4611/postgres\x1b[39m\n" +
+    "  Error:\n  - Specify a different name with the `-n` flag, e.g. -n my-project."
+  expect(parseLaunch(out)).toEqual({
+    url: "postgres://postgres:postgres@localhost:4611/postgres",
+    container: "my-app-pDtx",
+  })
+})
+
+test("parseLaunch returns null when no URL is present", () => {
+  expect(parseLaunch("- Docker is installed but not running.")).toBeNull()
 })

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -26,7 +26,7 @@ The rest of this page is what those commands do, and the one thing to check if t
 - fetches the latest ZeroStarter and strips the sample content,
 - rebrands the copy to your project name,
 - installs dependencies with Bun,
-- provisions a local Postgres in Docker (via [pglaunch](https://github.com/nrjdalal/pglaunch)) and applies the migrations,
+- provisions a local Postgres in Docker (via [pglaunch](https://github.com/nrjdalal/pglaunch)), reusing an already-running one when you re-run `init`, and applies the migrations,
 - writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET`.
 
 Everything else has a working default, so the scaffold runs as-is. The database step defaults to yes when Docker is running; pass `--db` to provision it without the prompt.


### PR DESCRIPTION
## What

`npx zerostarter@latest init` aborted the database step on a re-run:

```
Provisioning a local database with pglaunch and migrating ...
  Database setup failed; set POSTGRES_URL in .env yourself.
  Error:
  - Specify a different name with the `-n` flag, e.g. -n my-project.
  - Or use `-c` flag to start another container with a similar name.
```

pglaunch names its container after the directory (`<dir>-<rand4>`) and, on a
second run, refuses a similar-named container unless `-c` is passed, exiting
non-zero. The old `provisionDatabase` let that failure propagate.

## Fix

`provisionDatabase` (`packages/cli/src/db.ts`) now:

1. **Reuses the already-running Postgres.** On a name collision pglaunch still
   prints the existing container's `POSTGRES_URL`; we parse it and point `.env`
   there instead of failing. Re-running `init` is now idempotent.
2. **Waits for readiness before migrating.** pglaunch returns the moment
   `docker run` starts, so migrating immediately raced the Postgres boot and
   failed even on a clean first launch. We now poll `pg_isready` in the
   container (postgres:alpine ships it) before running `db:migrate`.
3. **Falls back to a fresh container** (`pglaunch -k -c`) only if the reused
   database rejects the migrations.

## Verification

- New unit tests for `parseLaunch` cover the fresh-launch line, the
  ANSI-colored collision line, and the no-URL case. Full CLI suite: 65 pass.
- End-to-end against Docker: a fresh launch now waits out the boot and migrates
  cleanly (previously exit 1), and a re-run reuses the same container (one
  container, same URL, idempotent migrate). `lint`, `check-types`, `build` green.

Bumps the CLI to **0.0.16** (manual bump so `cli-release` publishes on merge to main).

Docs: `setup.mdx` now notes that re-running `init` reuses an already-running local Postgres.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local database setup so re-running initialization can reuse an existing PostgreSQL container when available.
  * Added a safer fallback to create a fresh container if the first attempt doesn’t work, helping setup complete more reliably.

* **Documentation**
  * Clarified the getting-started guide to explain how local database provisioning behaves during setup.

* **Chores**
  * Bumped the CLI package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->