### PR TITLE
fix(cli): reinit no longer chokes on an embedded git repo in the tree

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",

--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -17,16 +17,20 @@ export const remove = (path: string): void => {
 // Build output and vendored deps: wiped or skipped wholesale by emptyDir/findPackageJsons.
 const HEAVY_DIRS = new Set(["node_modules", ".next", ".turbo", "dist"])
 
-// Remove everything except .git and .env* files (any depth) outside the heavy build dirs, which are wiped wholesale.
-export const emptyDir = (dir: string): void => {
+// Remove everything except the repo's top-level .git and .env* files (any depth) outside the heavy build dirs, which are wiped wholesale. Only the top-level .git is kept: a nested .git is an embedded git repo (e.g. a gitignored test fixture) and is wiped like any other directory, so a later `git add -A` does not choke on it.
+export const emptyDir = (dir: string, isRoot = true): void => {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name === ".git") continue
     const path = join(dir, entry.name)
+    if (entry.name === ".git") {
+      if (isRoot) continue
+      rmSync(path, { force: true, recursive: true })
+      continue
+    }
     if (entry.isDirectory()) {
       if (HEAVY_DIRS.has(entry.name)) {
         rmSync(path, { force: true, recursive: true })
       } else {
-        emptyDir(path)
+        emptyDir(path, false)
         if (readdirSync(path).length === 0) rmSync(path, { force: true, recursive: true })
       }
     } else if (!entry.name.startsWith(".env")) {

--- a/packages/cli/test/io.test.ts
+++ b/packages/cli/test/io.test.ts
@@ -68,7 +68,7 @@ describe("removeMatch", () => {
 })
 
 describe("emptyDir", () => {
-  test("keeps .git and .env* at any depth, wipes everything else", () => {
+  test("keeps the top-level .git and .env* at any depth, wipes everything else", () => {
     execFileSync("git", ["init", "-q"], { cwd: dir })
     writeFileSync(join(dir, ".env"), "ROOT=1")
     writeFileSync(join(dir, ".env.production.local"), "PROD=1")
@@ -92,6 +92,20 @@ describe("emptyDir", () => {
     write(join(dir, "src/a.ts"), "x")
     emptyDir(dir)
     expect(exists(join(dir, "src"))).toBe(false)
+  })
+
+  test("wipes a nested .git (embedded repo) but keeps the top-level .git", () => {
+    execFileSync("git", ["init", "-q"], { cwd: dir })
+    // A leftover embedded repo, e.g. a gitignored test fixture; its nested .git
+    // must be wiped so a later `git add -A` does not choke on it.
+    write(join(dir, ".test-artifacts/cli/61/.git/HEAD"), "ref: refs/heads/main\n")
+    write(join(dir, "app.ts"), "code")
+
+    emptyDir(dir)
+
+    expect(exists(join(dir, ".git"))).toBe(true)
+    expect(exists(join(dir, ".test-artifacts"))).toBe(false)
+    expect(exists(join(dir, "app.ts"))).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What

`npx zerostarter@latest reinit` aborted when the working tree contained an embedded git repo (a nested `.git`, e.g. a gitignored test fixture):

```
reinit failed; restored your committed files (deleted gitignored files, except .env*, are gone).
Command failed: git add -A
error: '.test-artifacts/cli/61/' does not have a commit checked out
error: unable to index file '.test-artifacts/cli/61/'
fatal: adding files failed
```

## Root cause

`emptyDir` (`packages/cli/src/io.ts`) recurses the tree and skips **any** entry named `.git` at **every** depth. A nested `.git` (an embedded repo) was therefore preserved, leaving its parent directory non-empty and containing a repo with no commit checked out. `reinit`'s subsequent `git add -A` then choked on it and rolled back.

Since `.test-artifacts/` is gitignored in the affected repo, `requireCleanRepo` (which reads `git status`) never flagged it, so reinit proceeded straight into the failure.

## Fix

`emptyDir` now keeps only the repo's **top-level** `.git`; a nested `.git` is wiped like any other directory. `.env*` preservation at any depth is unchanged.

## Verification

- Reproduced the exact `git add -A` error with an embedded repo present, then confirmed the fixed `emptyDir` removes it so `git add -A` and commit succeed. Root `.git`, root `.env`, and a nested `.env.local` are all preserved.
- New regression test in `io.test.ts` for the embedded-repo case. Full CLI suite: 67 pass. `lint`, `check-types`, `build` green.

Bumps the CLI to **0.0.17**.