### PR TITLE
chore(cli): collapse a two-line test comment to one line

### DIFF
--- a/packages/cli/test/io.test.ts
+++ b/packages/cli/test/io.test.ts
@@ -96,8 +96,7 @@ describe("emptyDir", () => {
 
   test("wipes a nested .git (embedded repo) but keeps the top-level .git", () => {
     execFileSync("git", ["init", "-q"], { cwd: dir })
-    // A leftover embedded repo, e.g. a gitignored test fixture; its nested .git
-    // must be wiped so a later `git add -A` does not choke on it.
+    // A leftover embedded repo (a gitignored test fixture) whose nested .git must be wiped so a later `git add -A` does not choke on it.
     write(join(dir, ".test-artifacts/cli/61/.git/HEAD"), "ref: refs/heads/main\n")
     write(join(dir, "app.ts"), "code")
 


### PR DESCRIPTION
Follow-up to #627. The regression test's comment spanned two `//` lines, violating the repo rule (CLAUDE.md) to keep comments on a single line. Collapsed to one line. Test-only, no runtime change, no version bump; `@latest` stays 0.0.17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal test comment for clarity around handling leftover repository data in a cleanup scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->