### PR TITLE
chore: rename ensure-remote-main to ensure-remote-branches

### DIFF
--- a/.github/scripts/ensure-remote-branches.ts
+++ b/.github/scripts/ensure-remote-branches.ts
@@ -82,7 +82,7 @@ const printPermsInstructions = (remote: string): void => {
   console.error("  4. Click Save")
 }
 
-const ensureRemoteMain = (remote: string): void => {
+const ensureRemoteBranches = (remote: string): void => {
   if (done(remote)) return
   if (!hasLocalBranch("main")) return
   if (!repoSlug(remoteUrl(remote))) return // not a GitHub remote: the release flow does not apply, so do not interfere
@@ -123,4 +123,4 @@ const ensureRemoteMain = (remote: string): void => {
   markDone(remote)
 }
 
-if (import.meta.main) ensureRemoteMain(process.argv[2] || "origin")
+if (import.meta.main) ensureRemoteBranches(process.argv[2] || "origin")

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,5 +19,5 @@ pre-push:
       run: bun audit --audit-level high
       only:
         - ref: canary
-    ensure-main:
-      run: bun .github/scripts/ensure-remote-main.ts {1}
+    ensure-branches:
+      run: bun .github/scripts/ensure-remote-branches.ts {1}

--- a/packages/cli/test/ensure-remote-branches.test.ts
+++ b/packages/cli/test/ensure-remote-branches.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 
-import { markerKey, repoSlug, settingsUrl } from "../../../.github/scripts/ensure-remote-main"
+import { markerKey, repoSlug, settingsUrl } from "../../../.github/scripts/ensure-remote-branches"
 
 test("settingsUrl builds the Actions settings URL from an SSH remote", () => {
   expect(settingsUrl("git@github.com:acme/widgets.git")).toBe(

--- a/web/next/content/docs/manage/code-quality.mdx
+++ b/web/next/content/docs/manage/code-quality.mdx
@@ -64,15 +64,15 @@ pre-push:
       run: bun audit --audit-level high
       only:
         - ref: canary
-    ensure-main:
-      run: bun .github/scripts/ensure-remote-main.ts {1}
+    ensure-branches:
+      run: bun .github/scripts/ensure-remote-branches.ts {1}
 ```
 
 **pre-commit**: [lint-staged](https://github.com/lint-staged/lint-staged) formats then lints only your staged files (`oxfmt`, then `oxlint`); `stage_fixed: true` re-stages anything the formatter rewrote, so the fix rides along in the same commit. Then a full `bun run build` has to pass. A commit that lands is formatted, linted, and building.
 
 **commit-msg**: [Commitlint](https://commitlint.js.org) checks the message against Conventional Commits (below).
 
-**pre-push**: `bun audit --audit-level high` runs, but only from `canary` (`only: ref: canary`), so a vulnerable dependency is caught before the branch leaves your machine without blocking your offline commits. `ensure-remote-main.ts` seeds the `main` branch that drives the release PR (see [Releases](/docs/manage/release)).
+**pre-push**: `bun audit --audit-level high` runs, but only from `canary` (`only: ref: canary`), so a vulnerable dependency is caught before the branch leaves your machine without blocking your offline commits. `ensure-remote-branches.ts` seeds the `main` branch that drives the release PR (see [Releases](/docs/manage/release)).
 
 <Callout type="warn" title="The local build sees your real .env">
 

--- a/web/next/content/docs/manage/release.mdx
+++ b/web/next/content/docs/manage/release.mdx
@@ -24,7 +24,7 @@ Under **Settings → Actions → General → Workflow permissions** (the pre-pus
 
 ![GitHub Workflow permissions: Read and write permissions selected and Allow GitHub Actions to create and approve pull requests checked](/marketing/docs/release/workflow-permissions.png)
 
-On a brand-new empty repo, push `canary` first (`git push origin canary`) so GitHub makes it the default branch. The pre-push hook (`.github/scripts/ensure-remote-main.ts`) then seeds `main` on your next push (a separate ref, so it never collides) and the release PR opens on its own. No `gh` and no repo-admin required.
+On a brand-new empty repo, push `canary` first (`git push origin canary`) so GitHub makes it the default branch. The pre-push hook (`.github/scripts/ensure-remote-branches.ts`) then seeds `main` on your next push (a separate ref, so it never collides) and the release PR opens on its own. No `gh` and no repo-admin required.
 
 ## Land work on canary with squash-merge
 


### PR DESCRIPTION
## What

Renames the "ensure main" pre-push mechanism to "ensure branches", since the hook ensures the whole **canary + main** branch topology on the remote (it detects canary and seeds main), not just `main`:

- lefthook hook: `ensure-main` → `ensure-branches`
- script: `.github/scripts/ensure-remote-main.ts` → `ensure-remote-branches.ts` (git mv, history preserved)
- function: `ensureRemoteMain` → `ensureRemoteBranches`
- test: `ensure-remote-main.test.ts` → `ensure-remote-branches.test.ts` (+ import path)
- docs: `manage/release.mdx`, `manage/code-quality.mdx`

## Not renamed (deliberate)

The internal git-config marker `zerostarter.mainSeeded.<remote>` is kept. It precisely tracks that the **main** branch was seeded (canary is created by the user's own push, not seeded by the hook), so `mainSeeded` is more accurate than `branchesSeeded` — and renaming it would churn every existing fork's local git config for no gain (an idempotent one-time re-run).

## Verification

Pure rename, no behavior change. No leftover `ensure-remote-main` / `ensureRemoteMain` references; 8 tests pass; lint + typecheck green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pre-push workflow to use the renamed branch-check script.
  * Kept the same remote-branch behavior during push, including seeding the release branch when needed.
* **Documentation**
  * Refreshed setup and release guides to match the new hook name and command.
  * Clarified the branch-push flow for new repositories.
* **Tests**
  * Adjusted coverage to align with the updated branch-check module name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->