### PR TITLE
feat(cli): error legibility, friendly flags, and flow polish

### DIFF
--- a/.github/audit/2026-07-04-cli-dx.md
+++ b/.github/audit/2026-07-04-cli-dx.md
@@ -1,0 +1,96 @@
+# CLI Developer-Experience Audit — 2026-07-04
+
+Scope: `packages/cli` (`zerostarter` npm CLI: `init`, `reinit`, `sync`). Two DX audiences:
+end users running the CLI, and contributors maintaining it.
+
+## What's already strong (keep)
+
+- Clack-style flow UI (gutter, spinner pulse, notes) shared across the spawn + prompt layers.
+- Async, Windows-safe spawn (vendored nano-spawn, no catalog leak).
+- Atomic `reinit`/`sync` with `withRollback`; dirty-tree and workspace-nesting guards.
+- Streaming progress for install/migrate (`runTail`), live bun-install output.
+- Bun preflight with an offer to install; CRLF-tolerant convert regexes.
+
+## Findings (ranked by impact / effort)
+
+### 1. Subprocess failures swallow the actual error output  [HIGH] — SHIPPED (feat/cli-error-legibility)
+`bin/index.ts` top-level catch prints only `err.message`. `run()`-based steps
+(`fetchZerostarter`, `overlayZerostarter`, git ops) reject with a `SubprocessError`
+whose real cause lives on `.stdout`/`.stderr`, which is never printed. `withSpinner`
+also drops captured output on failure (unlike `runTail`, which dumps it).
+Result: a gitpick network/auth failure shows a bare
+`Command failed with exit code 1: bunx --bun gitpick@6.0.0 ...` with no diagnostics.
+- Fix: in the catch, when `err` is a `SubprocessError`, print the last N lines of
+  `stderr || stdout`. Make `withSpinner` dump captured output on throw (needs the
+  spawn to capture, or route fetch/overlay through a tail variant).
+
+### 2. No `--dry-run` on `reinit` and `sync`  [HIGH]
+`init` previews its plan, but the two commands that mutate an existing repo don't:
+`reinit` deletes every tracked file; `sync` overwrites starter files in place. There
+is no way to see "what will be deleted / preserved / overwritten" before committing to
+a scary operation. Asymmetric and a trust gap.
+- Fix: add `--dry-run` to both. `reinit`: list kept (`.git`, `.env*`) vs deleted.
+  `sync`: list the preserve set (from `.gitpickignore` PRESERVE_ON_SYNC) and the
+  merge plan, without touching the tree.
+
+### 3. No starter-version provenance or `--ref`/`--branch`  [HIGH, structural]
+All three commands hard-fetch `main` (`git.ts` defaults). There is no way to pin a
+starter version, test a branch, or reproduce a scaffold; and a fork records nothing
+about which starter commit it came from. So `sync` cannot say "you are N commits /
+versions behind" or show what changed.
+- Fix: (a) accept `--ref <branch|tag|sha>` on all three (thread through
+  `fetchZerostarter`/`overlayZerostarter`/`fetchGitpickignore`). (b) Write a
+  `.zerostarter` stamp on init/sync (ref + resolved sha + CLI version + date). Unlocks
+  drift detection and reproducible scaffolds later.
+
+### 4. `sync` has no confirmation, no `--yes`, asymmetric flags  [MED]
+`reinit` confirms and honors `-y`; `sync` just runs (it overwrites tracked starter
+files and runs `bun install`). It's safer (rollback) but the inconsistency surprises.
+Its `--help` also lists only `-h` and doesn't explain the `[dir]` positional.
+- Fix: add a confirm + `-y/--yes` to `sync` (or document deliberately skipping it),
+  and align the help block with `init`/`reinit`.
+
+### 5. No update-available / provenance notice  [MED]
+An old cached `npx zerostarter` runs silently (see the known stale-`_npx` gotcha in
+memory). Standard CLI DX is a best-effort "a newer version is available" hint.
+- Fix: on non-`--dry-run` runs, best-effort compare `pkg.version` to the npm
+  `latest` dist-tag (short timeout, never blocks), print a one-line note on mismatch.
+
+### 6. Unfriendly flag-parse errors  [MED] — SHIPPED (feat/cli-error-legibility)
+`parseArgs` is strict; a typo (`init --databse`) throws a raw Node error caught by the
+top-level handler → bare red line, no command help.
+- Fix: wrap each command's `parseArgs` in try/catch and print that command's
+  `helpMessage` on an `ERR_PARSE_ARGS`-class error.
+
+### 7. Zero integration tests for the command flows  [MED, maintainer DX]
+All 10 test files cover `src/*` helpers. `bin/commands/*` (init/reinit/sync/_bun/
+_prompt) — the most complex orchestration (`insideExistingProject`, `isEmptyDir`,
+`intoSubdir`, init's db-branching, next-steps assembly) — has no tests.
+- Fix: extract the pure branching (target/subdir resolution, next-steps builder) into
+  testable units and cover them; network/git/docker stay mocked or out of scope.
+
+### 8. No README published to npm  [LOW]
+`files: ["dist"]` → the npm package page has no README (only a homepage link). Users
+landing on npmjs.com/package/zerostarter see nothing.
+- Fix: add a short `packages/cli/README.md` (usage + the three commands) and include
+  it in `files`.
+
+### 9. No `--verbose`/debug flag  [LOW]
+When a step misbehaves there is no way to surface the raw spawned command + full
+output. Complements #1.
+- Fix: a `--verbose` (or `DEBUG=zerostarter`) that echoes each spawned command and
+  streams full output instead of the collapsed window.
+
+### 10. Pinned tool versions drift as scattered literals  [LOW]
+`gitpick@6.0.0` (git.ts, two call sites) and `pglaunch@5.5.7` (db.ts) are hardcoded
+in separate files. Correct policy (pinning), but no single source for a bump.
+- Fix: hoist to named constants in one module (or the CLI's own package.json) so a
+  bump touches one place.
+
+## Suggested sequencing
+
+1. #1 + #6 (error legibility) — small, high daily-DX payoff.
+2. #2 (dry-run parity) — safety/trust on the destructive commands.
+3. #3 (ref + provenance stamp) — unlocks the sync/drift story; larger.
+4. #4, #5, #8 — polish/consistency.
+5. #7, #9, #10 — maintainer DX, do alongside the above.

--- a/.github/audit/2026-07-04-cli-dx.md
+++ b/.github/audit/2026-07-04-cli-dx.md
@@ -1,4 +1,4 @@
-# CLI Developer-Experience Audit — 2026-07-04
+# CLI Developer-Experience Audit (2026-07-04)
 
 Scope: `packages/cli` (`zerostarter` npm CLI: `init`, `reinit`, `sync`). Two DX audiences:
 end users running the CLI, and contributors maintaining it.
@@ -13,7 +13,7 @@ end users running the CLI, and contributors maintaining it.
 
 ## Findings (ranked by impact / effort)
 
-### 1. Subprocess failures swallow the actual error output  [HIGH] — SHIPPED (feat/cli-error-legibility)
+### 1. Subprocess failures swallow the actual error output  [HIGH]. SHIPPED (feat/cli-error-legibility)
 `bin/index.ts` top-level catch prints only `err.message`. `run()`-based steps
 (`fetchZerostarter`, `overlayZerostarter`, git ops) reject with a `SubprocessError`
 whose real cause lives on `.stdout`/`.stderr`, which is never printed. `withSpinner`
@@ -56,7 +56,7 @@ memory). Standard CLI DX is a best-effort "a newer version is available" hint.
 - Fix: on non-`--dry-run` runs, best-effort compare `pkg.version` to the npm
   `latest` dist-tag (short timeout, never blocks), print a one-line note on mismatch.
 
-### 6. Unfriendly flag-parse errors  [MED] — SHIPPED (feat/cli-error-legibility)
+### 6. Unfriendly flag-parse errors  [MED]. SHIPPED (feat/cli-error-legibility)
 `parseArgs` is strict; a typo (`init --databse`) throws a raw Node error caught by the
 top-level handler → bare red line, no command help.
 - Fix: wrap each command's `parseArgs` in try/catch and print that command's
@@ -64,8 +64,8 @@ top-level handler → bare red line, no command help.
 
 ### 7. Zero integration tests for the command flows  [MED, maintainer DX]
 All 10 test files cover `src/*` helpers. `bin/commands/*` (init/reinit/sync/_bun/
-_prompt) — the most complex orchestration (`insideExistingProject`, `isEmptyDir`,
-`intoSubdir`, init's db-branching, next-steps assembly) — has no tests.
+_prompt), the most complex orchestration (`insideExistingProject`, `isEmptyDir`,
+`intoSubdir`, init's db-branching, next-steps assembly), has no tests.
 - Fix: extract the pure branching (target/subdir resolution, next-steps builder) into
   testable units and cover them; network/git/docker stay mocked or out of scope.
 
@@ -89,8 +89,8 @@ in separate files. Correct policy (pinning), but no single source for a bump.
 
 ## Suggested sequencing
 
-1. #1 + #6 (error legibility) — small, high daily-DX payoff.
-2. #2 (dry-run parity) — safety/trust on the destructive commands.
-3. #3 (ref + provenance stamp) — unlocks the sync/drift story; larger.
-4. #4, #5, #8 — polish/consistency.
-5. #7, #9, #10 — maintainer DX, do alongside the above.
+1. #1 + #6 (error legibility): small, high daily-DX payoff.
+2. #2 (dry-run parity): safety/trust on the destructive commands.
+3. #3 (ref + provenance stamp): unlocks the sync/drift story; larger.
+4. #4, #5, #8: polish/consistency.
+5. #7, #9, #10: maintainer DX, do alongside the above.

--- a/.gitpickignore
+++ b/.gitpickignore
@@ -4,7 +4,8 @@
 # sync restores these fork-owned paths after the overlay (init seeds them, a re-baseline keeps them).
 # packages/db/drizzle + src/schema are the fork's own applied DB state; overlaying the starter's would corrupt its migration history.
 # docs.config.ts describes the fork's own content/docs (also preserved); overlaying the starter's lists docs the fork lacks and fails the strict docs build.
-# PRESERVE_ON_SYNC - packages/db/drizzle/, packages/db/src/schema/, web/next/docs.config.ts, web/next/src/app/favicon.ico
+# bun.lock ships to the fork so a fresh init installs from locked versions (no slow cold resolve of the whole graph); sync keeps the fork's own lockfile.
+# PRESERVE_ON_SYNC - bun.lock, packages/db/drizzle/, packages/db/src/schema/, web/next/docs.config.ts, web/next/src/app/favicon.ico
 
 # custom directories
 .github/assets/
@@ -24,7 +25,6 @@ web/next/public/
 .coderabbit.yaml
 AGENTS.md
 AUDIT.md
-bun.lock
 CHANGELOG.md
 LICENSE.md
 packages/config/src/site.ts

--- a/packages/cli/bin/commands/_args.ts
+++ b/packages/cli/bin/commands/_args.ts
@@ -1,0 +1,14 @@
+import { parseArgs, type ParseArgsConfig } from "node:util"
+
+import { red } from "@/style"
+
+// parseArgs, but a bad flag (unknown option, missing value) prints the command's help and exits cleanly (code 1) instead of throwing a raw Node error the top-level handler would surface without any usage. The return type is inferred from `config`, so callers keep parseArgs's precise `values`/`positionals` typing.
+export const parseArgsOrExit = <T extends ParseArgsConfig>(help: string, config: T) => {
+  try {
+    return parseArgs(config)
+  } catch (err) {
+    process.stderr.write(`${red(err instanceof Error ? err.message : String(err))}\n\n`)
+    process.stdout.write(`${help}\n`)
+    process.exit(1)
+  }
+}

--- a/packages/cli/bin/commands/_prompt.ts
+++ b/packages/cli/bin/commands/_prompt.ts
@@ -13,13 +13,13 @@ export const hyperlink = (url: string, text = url): string =>
 // A clickable, cyan URL: OSC 8 wraps the colored text (link outermost) and the URL is the visible text, so terminals that auto-detect bare URLs also linkify it.
 export const link = (url: string): string => hyperlink(url, cyan(url))
 
-// clack support functions: an indented gutter (PAD) capped by ┌ / └. Steps stack tightly (no blank │ between consecutive steps); the intro, note boxes, and outro get a │ connector for breathing room.
+// clack support functions: an indented gutter (PAD) capped by ┌ / └. Steps and notes stack tightly (no blank │ between them); only the intro and outro get a │ connector, so the first and last lines are spaced from the rest.
 export const intro = (title: string): void => {
   process.stdout.write(`\n${P}${gray(S.barStart)}  ${title}\n${P}${gray(S.bar)}\n`)
 }
 
 export const outro = (message: string): void => {
-  process.stdout.write(`${P}${gray(S.barEnd)}  ${message}\n`)
+  process.stdout.write(`${P}${gray(S.bar)}\n${P}${gray(S.barEnd)}  ${message}\n`)
 }
 
 // Close the flow as cancelled (red end); used on Ctrl-C or a declined prompt.
@@ -33,7 +33,7 @@ const noteVisibleLen = (s: string): number =>
     .replace(new RegExp(`${ESC}\\[[0-9;?]*[a-zA-Z]`, "g"), "")
     .replace(new RegExp(`${ESC}\\]8;;.*?\\x07`, "g"), "").length
 
-// clack note: a box hanging off the gutter with a titled top border and the message lines inside. A │ connector sets it off above (and below, unless `last`, where the gutter closes with a rounded corner ╰ instead of the ├ tee that continues it).
+// clack note: a box hanging off the gutter with a titled top border and the message lines inside, sitting tight against the surrounding steps. When `last`, the gutter closes with a rounded corner (╰) instead of the ├ tee that continues it.
 export const note = (message: string, title = "", last = false): void => {
   const lines = `\n${message}\n`.split("\n")
   const titleLen = noteVisibleLen(title)
@@ -44,9 +44,8 @@ export const note = (message: string, title = "", last = false): void => {
     .map((ln) => `${P}${gray(S.bar)}  ${ln}${" ".repeat(len - noteVisibleLen(ln))}${gray(S.bar)}`)
     .join("\n")
   const bottomLeft = last ? S.cornerBL : S.connectL
-  const trailing = last ? "" : `${P}${gray(S.bar)}\n`
   process.stdout.write(
-    `${P}${gray(S.bar)}\n${P}${cyan(S.active)}  ${title} ${gray(S.barH.repeat(Math.max(len - titleLen - 1, 1)) + S.cornerTR)}\n${body}\n${P}${gray(bottomLeft + S.barH.repeat(len + 2) + S.cornerBR)}\n${trailing}`,
+    `${P}${cyan(S.active)}  ${title} ${gray(S.barH.repeat(Math.max(len - titleLen - 1, 1)) + S.cornerTR)}\n${body}\n${P}${gray(bottomLeft + S.barH.repeat(len + 2) + S.cornerBR)}\n`,
   )
 }
 

--- a/packages/cli/bin/commands/_prompt.ts
+++ b/packages/cli/bin/commands/_prompt.ts
@@ -1,6 +1,6 @@
 import { createInterface } from "node:readline/promises"
 
-import { cyan, dim, gray, green, PAD as P, PULSE, red, S, yellow } from "@/style"
+import { cyan, dim, gray, green, PAD as P, pulseLabel, red, S, yellow } from "@/style"
 
 export { cyan, dim, gray, green, orange, PAD, red, yellow } from "@/style"
 
@@ -13,9 +13,9 @@ export const hyperlink = (url: string, text = url): string =>
 // A clickable, cyan URL: OSC 8 wraps the colored text (link outermost) and the URL is the visible text, so terminals that auto-detect bare URLs also linkify it.
 export const link = (url: string): string => hyperlink(url, cyan(url))
 
-// clack support functions: an indented gutter (PAD) capped by ┌ / └, with steps stacked tightly (no blank │ connector between them).
+// clack support functions: an indented gutter (PAD) capped by ┌ / └. Steps stack tightly (no blank │ between consecutive steps); the intro, note boxes, and outro get a │ connector for breathing room.
 export const intro = (title: string): void => {
-  process.stdout.write(`\n${P}${gray(S.barStart)}  ${title}\n`)
+  process.stdout.write(`\n${P}${gray(S.barStart)}  ${title}\n${P}${gray(S.bar)}\n`)
 }
 
 export const outro = (message: string): void => {
@@ -33,7 +33,7 @@ const noteVisibleLen = (s: string): number =>
     .replace(new RegExp(`${ESC}\\[[0-9;?]*[a-zA-Z]`, "g"), "")
     .replace(new RegExp(`${ESC}\\]8;;.*?\\x07`, "g"), "").length
 
-// clack note: a box hanging off the gutter with a titled top border and the message lines inside. When `last`, the gutter closes with a rounded corner (╰) instead of the ├ tee that continues it.
+// clack note: a box hanging off the gutter with a titled top border and the message lines inside. A │ connector sets it off above (and below, unless `last`, where the gutter closes with a rounded corner ╰ instead of the ├ tee that continues it).
 export const note = (message: string, title = "", last = false): void => {
   const lines = `\n${message}\n`.split("\n")
   const titleLen = noteVisibleLen(title)
@@ -44,8 +44,9 @@ export const note = (message: string, title = "", last = false): void => {
     .map((ln) => `${P}${gray(S.bar)}  ${ln}${" ".repeat(len - noteVisibleLen(ln))}${gray(S.bar)}`)
     .join("\n")
   const bottomLeft = last ? S.cornerBL : S.connectL
+  const trailing = last ? "" : `${P}${gray(S.bar)}\n`
   process.stdout.write(
-    `${P}${cyan(S.active)}  ${title} ${gray(S.barH.repeat(Math.max(len - titleLen - 1, 1)) + S.cornerTR)}\n${body}\n${P}${gray(bottomLeft + S.barH.repeat(len + 2) + S.cornerBR)}\n`,
+    `${P}${gray(S.bar)}\n${P}${cyan(S.active)}  ${title} ${gray(S.barH.repeat(Math.max(len - titleLen - 1, 1)) + S.cornerTR)}\n${body}\n${P}${gray(bottomLeft + S.barH.repeat(len + 2) + S.cornerBR)}\n${trailing}`,
   )
 }
 
@@ -71,7 +72,7 @@ export const logWarn = (message: string, detail: string[] = []): void => {
   for (const line of detail) process.stdout.write(`${P}${gray(S.bar)}  ${yellow(line)}\n`)
 }
 
-// A spinner that pulses between the filled ◆ and hollow ◇ while `fn` runs, collapsing to a completed step (◆). Used for work with no streamable output (fetch, rebrand). Off a TTY it just prints the completed step.
+// A spinner whose glyph blinks hollow ◇ → filled ◆ (always cyan, never dimmed; the label stays constant) while `fn` runs, collapsing to a completed step (◆). Used for work with no streamable output (fetch, rebrand). Off a TTY it just prints the completed step.
 export const withSpinner = async <T>(
   active: string,
   done: string,
@@ -81,10 +82,10 @@ export const withSpinner = async <T>(
   let timer: ReturnType<typeof setInterval> | null = null
   if (out.isTTY) {
     let i = 0
-    out.write(`${P}${cyan(PULSE[0])}  ${active}`)
+    out.write(`${P}${pulseLabel(0, active)}`)
     timer = setInterval(() => {
-      i = (i + 1) % PULSE.length
-      out.write(`\r${P}${cyan(PULSE[i])}  ${active}`)
+      i = i + 1
+      out.write(`\r\x1b[K${P}${pulseLabel(i, active)}`)
     }, 400)
   }
   try {
@@ -108,7 +109,7 @@ const renderOptions = (value: boolean): string => {
   return `${P}${gray(S.bar)}  ${yes} ${dim("/")} ${no}`
 }
 
-// clack-style confirm: `◆ message` + `● Yes / ○ No`, toggled with arrows or y/n, collapsing to `◆ message Yes`. Falls back to the default without prompting when not interactive.
+// clack-style confirm: `◆ message` + `● Yes / ○ No`, toggled with arrows or y/n. On submit the prompt clears itself (transient: the following step speaks for the choice, so no `◆ message Yes` echo lingers). Off a TTY it takes the default without prompting, echoing the auto-choice so non-interactive logs record it.
 export const promptConfirm = async (question: string, def = true): Promise<boolean> => {
   const out = process.stdout
   if (!isInteractive()) {
@@ -120,7 +121,7 @@ export const promptConfirm = async (question: string, def = true): Promise<boole
     const stdin = process.stdin
     // rows the "◆  <question>" line occupies once it wraps at the terminal width (PAD + ◆ + two spaces = 5), so the collapse clears all of them, not just one
     const qRows = Math.max(1, Math.ceil((5 + noteVisibleLen(question)) / (out.columns || 80)))
-    out.write(`${P}${cyan(S.active)}  ${question}\n`)
+    out.write(`${P}${cyan(S.submit)}  ${question}\n`)
     out.write(renderOptions(value))
     stdin.setRawMode(true)
     stdin.resume()
@@ -137,14 +138,13 @@ export const promptConfirm = async (question: string, def = true): Promise<boole
     const submit = (): void => {
       cleanup()
       clearPrompt()
-      out.write(`${P}${cyan(S.active)}  ${question} ${dim(value ? "Yes" : "No")}\n`)
       resolve(value)
     }
     function onData(key: string): void {
       if (key === "\x03") {
         cleanup()
         clearPrompt()
-        out.write(`${P}${dim(S.active)}  ${dim(question)}\n`)
+        out.write(`${P}${cyan(S.submit)}  ${dim(question)}\n`)
         cancel()
         process.exit(130)
       } else if (key === "\r" || key === "\n") {
@@ -173,7 +173,7 @@ export const promptConfirm = async (question: string, def = true): Promise<boole
 
 // A single-line text prompt in the gutter; the entered value stays under the bar.
 export const promptText = async (question: string, def = ""): Promise<string> => {
-  process.stdout.write(`${P}${cyan(S.active)}  ${question}${def ? ` ${dim(`(${def})`)}` : ""}\n`)
+  process.stdout.write(`${P}${cyan(S.submit)}  ${question}${def ? ` ${dim(`(${def})`)}` : ""}\n`)
   const rl = createInterface({ input: process.stdin, output: process.stdout })
   try {
     const answer = (await rl.question(`${P}${gray(S.bar)}  `)).trim()

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -1,12 +1,12 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs"
 import { basename, dirname, join, parse, resolve } from "node:path"
-import { parseArgs } from "node:util"
 
 import { convertRepo } from "@/convert"
 import { dockerRunning, hasPostgresUrl, provisionDatabase, seedEnv } from "@/db"
 import { bunInstall, fetchZerostarter, gitBranch, gitCommitAll, gitInit } from "@/git"
 import { exists } from "@/io"
 
+import { parseArgsOrExit } from "./_args"
 import { ensureBun } from "./_bun"
 import {
   cancel,
@@ -63,7 +63,7 @@ const insideExistingProject = (dir: string): string | null => {
 }
 
 export const init = async (argv: string[]) => {
-  const { positionals, values } = parseArgs({
+  const { positionals, values } = parseArgsOrExit(helpMessage, {
     allowPositionals: true,
     args: argv,
     options: {

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -171,7 +171,7 @@ export const init = async (argv: string[]) => {
     wantDb = true
   } else if (interactive) {
     // Always ask; default to yes when Docker is up (we can provision now), no when it isn't.
-    wantDb = await promptConfirm("Provision a local Postgres database now?", dockerUp)
+    wantDb = await promptConfirm("Provision a local Postgres database?", dockerUp)
   } else {
     // Non-interactive (--yes / non-TTY): take the prompt's default, provision when Docker is up.
     wantDb = dockerUp

--- a/packages/cli/bin/commands/reinit.ts
+++ b/packages/cli/bin/commands/reinit.ts
@@ -1,11 +1,11 @@
 import { basename, resolve } from "node:path"
-import { parseArgs } from "node:util"
 
 import { convertRepo } from "@/convert"
 import { hasPostgresUrl, seedEnv } from "@/db"
 import { bunInstall, gitCommitAll, overlayZerostarter, requireCleanRepo, withRollback } from "@/git"
 import { emptyDir } from "@/io"
 
+import { parseArgsOrExit } from "./_args"
 import { ensureBun } from "./_bun"
 import {
   cancel,
@@ -34,7 +34,7 @@ Options:
   -h, --help     Display help`
 
 export const reinit = async (argv: string[]) => {
-  const { positionals, values } = parseArgs({
+  const { positionals, values } = parseArgsOrExit(helpMessage, {
     allowPositionals: true,
     args: argv,
     options: {

--- a/packages/cli/bin/commands/sync.ts
+++ b/packages/cli/bin/commands/sync.ts
@@ -1,5 +1,4 @@
 import { join, resolve } from "node:path"
-import { parseArgs } from "node:util"
 
 import { fixDangling } from "@/convert"
 import {
@@ -13,6 +12,7 @@ import {
 import { exists, findPackageJsons, readJson, remove, writeJson } from "@/io"
 import { mergePkg, type Pkg, parsePreserve } from "@/pkg"
 
+import { parseArgsOrExit } from "./_args"
 import { ensureBun } from "./_bun"
 import { intro, link, logStep, logWarn, note, orange, outro, yellow } from "./_prompt"
 
@@ -29,7 +29,7 @@ Options:
 
 // Re-baseline a fork on the latest ZeroStarter, preserving its content, branding, and package.json.
 export const sync = async (argv: string[]) => {
-  const { positionals, values } = parseArgs({
+  const { positionals, values } = parseArgsOrExit(helpMessage, {
     allowPositionals: true,
     args: argv,
     options: { help: { short: "h", type: "boolean" } },

--- a/packages/cli/bin/index.ts
+++ b/packages/cli/bin/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import { printError } from "@/spawn"
+
 import pkg from "../package.json" with { type: "json" }
-import { hyperlink, PAD, red } from "./commands/_prompt"
+import { hyperlink, red } from "./commands/_prompt"
 import { init } from "./commands/init"
 import { reinit } from "./commands/reinit"
 import { sync } from "./commands/sync"
@@ -56,7 +58,7 @@ const main = async () => {
         process.exit(1)
     }
   } catch (err) {
-    console.error(`\n${PAD}${red(err instanceof Error ? err.message : String(err))}`)
+    printError(err)
     process.exit(1)
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -1,9 +1,8 @@
 import { randomBytes } from "node:crypto"
-import { readdirSync } from "node:fs"
 import { join } from "node:path"
 
 import { exists, read, write } from "@/io"
-import { formatDuration, ok, run, runTail } from "@/spawn"
+import { ok, run, runTail } from "@/spawn"
 
 const PGLAUNCH = "pglaunch@5.5.7"
 
@@ -106,22 +105,9 @@ export const provisionDatabase = async (dir: string): Promise<void> => {
     throw new Error(result.out.trim() || "pglaunch did not print a connection URL")
   setEnvVar(envPath, "POSTGRES_URL", result.launch.url)
   await waitForPostgres(result.launch.container)
-  const count = migrationCount(dir)
   await runTail("bun", ["run", "db:migrate"], {
     cwd: dir,
     label: "Provisioning the database",
-    summarize: (out, ms) =>
-      out.includes("migrations applied successfully")
-        ? `${count} migration${count === 1 ? "" : "s"} applied ${formatDuration(ms)}`
-        : `Database migrated ${formatDuration(ms)}`,
+    done: "Provisioned a local Postgres database",
   })
-}
-
-// Number of drizzle migration files the fork ships; on a fresh database db:migrate applies them all.
-const migrationCount = (dir: string): number => {
-  try {
-    return readdirSync(join(dir, "packages/db/drizzle")).filter((f) => f.endsWith(".sql")).length
-  } catch {
-    return 0
-  }
 }

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -107,7 +107,7 @@ export const provisionDatabase = async (dir: string): Promise<void> => {
   await waitForPostgres(result.launch.container)
   await runTail("bun", ["run", "db:migrate"], {
     cwd: dir,
-    label: "Provisioning the database",
+    label: "Provisioning a local Postgres database",
     done: "Provisioned a local Postgres database",
   })
 }

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -3,15 +3,12 @@ import { join } from "node:path"
 import { exists } from "@/io"
 import { ok, run, runTail } from "@/spawn"
 
-// Install dependencies in `dir`, showing a rolling window of bun's output that collapses to its summary line ("N packages installed [time]"). Runs the fork's lifecycle scripts (git hooks via prepare, catalog sync) as a normal `bun install` would.
+// Install dependencies in `dir`, showing a rolling window of bun's output that collapses to a done step, keeping the tail (which carries bun's "N packages installed [time]" summary line). Runs the fork's lifecycle scripts (git hooks via prepare, catalog sync) as a normal `bun install` would.
 export const bunInstall = async (dir: string): Promise<void> => {
   await runTail("bun", ["install"], {
     cwd: dir,
     label: "Installing dependencies",
-    summarize: (out) =>
-      (out.match(/[\d,]+ packages installed[^\n]*/g) ?? out.match(/Checked [^\n]*install[^\n]*/g))
-        ?.at(-1)
-        ?.trim() ?? "Dependencies installed",
+    done: "Installed dependencies",
   })
 }
 

--- a/packages/cli/src/spawn.ts
+++ b/packages/cli/src/spawn.ts
@@ -1,4 +1,4 @@
-import { cyan, dim, gray, PAD as P, pulseLabel, red, S } from "@/style"
+import { cyan, dim, dimErr, gray, PAD as P, pulseLabel, red, S } from "@/style"
 import { nanoSpawn, SubprocessError } from "@/vendor/nano-spawn"
 
 // Async, Windows-safe process spawning on the vendored nano-spawn: non-blocking (the event loop stays free while a subprocess runs), and on Windows it runs `.cmd`/`.ps1` shims (e.g. a package-manager-installed `bunx`) that raw `child_process` cannot. Vendored, not a dependency, so nothing lands in the workspace catalog. Every subprocess (bun, bunx, git, docker, the bun installer) goes through here.
@@ -43,7 +43,7 @@ export const printError = (err: unknown): void => {
     .map((l) => l.trimEnd())
     .filter(Boolean)
     .slice(-12)
-  for (const line of lines) process.stderr.write(`${P}${dim(line)}\n`)
+  for (const line of lines) process.stderr.write(`${P}${dimErr(line)}\n`)
 }
 
 // Run a command as a clack-style step: a `label` that pulses between the filled ◆ and hollow ◇ while it runs, with a dimmed rolling window of its last `lines` output lines beneath it. On success it collapses to a completed `◆ done` (a past-tense done label, defaulting to `label`) and keeps the tail of the output beneath as a trace. On failure the captured output is dumped so the error stays visible, then it rejects. Off a TTY (CI, piped) it prints the label and streams the command in full so logs are complete.

--- a/packages/cli/src/spawn.ts
+++ b/packages/cli/src/spawn.ts
@@ -1,5 +1,5 @@
-import { cyan, dim, gray, PAD as P, PULSE, S } from "@/style"
-import { nanoSpawn } from "@/vendor/nano-spawn"
+import { cyan, dim, gray, PAD as P, PULSE, red, S } from "@/style"
+import { nanoSpawn, SubprocessError } from "@/vendor/nano-spawn"
 
 // Async, Windows-safe process spawning on the vendored nano-spawn: non-blocking (the event loop stays free while a subprocess runs), and on Windows it runs `.cmd`/`.ps1` shims (e.g. a package-manager-installed `bunx`) that raw `child_process` cannot. Vendored, not a dependency, so nothing lands in the workspace catalog. Every subprocess (bun, bunx, git, docker, the bun installer) goes through here.
 
@@ -32,6 +32,23 @@ const stripAnsi = (s: string): string => s.replace(csi, "")
 // Format an elapsed duration like bun's install summary: [2.77s] for >= 1s, [978.00ms] otherwise.
 export const formatDuration = (ms: number): string =>
   ms >= 1000 ? `[${(ms / 1000).toFixed(2)}s]` : `[${ms.toFixed(2)}ms]`
+
+// Errors whose captured output runTail already streamed to the terminal in full, so printError shows the message alone rather than repeating the tail.
+const dumped = new WeakSet<object>()
+
+// Top-level error renderer: the message in red, plus the tail of a failed subprocess's captured output. A SubprocessError's real cause (a gitpick/git/docker failure) lives on its stdout/stderr, which the bare message omits; runTail-dumped errors skip the tail since their full output already printed.
+export const printError = (err: unknown): void => {
+  process.stderr.write(`\n${P}${red(err instanceof Error ? err.message : String(err))}\n`)
+  if (!(err instanceof SubprocessError) || dumped.has(err)) return
+  const output = (err.stderr || err.stdout || "").trim()
+  if (!output) return
+  const lines = stripAnsi(output)
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter(Boolean)
+    .slice(-12)
+  for (const line of lines) process.stderr.write(`${P}${dim(line)}\n`)
+}
 
 // Run a command as a clack-style step: a `label` that pulses between the filled ◆ and hollow ◇ while it runs, with a dimmed rolling window of its last `lines` output lines beneath it, collapsing on success to a completed `◆ summarize(output, durationMs)`. On failure the captured output is dumped so the error stays visible, then it rejects. Off a TTY (CI, piped) it prints the label and streams the command in full so logs are complete.
 export const runTail = async (
@@ -118,6 +135,8 @@ export const runTail = async (
     erase()
     setWrap(true)
     out.write(output)
+    // Full output already streamed here; mark it so the top-level printError doesn't repeat the tail.
+    if (err && typeof err === "object") dumped.add(err)
     throw err
   }
   stop()
@@ -125,4 +144,12 @@ export const runTail = async (
   setWrap(true)
   const summary = opts.summarize(output, Date.now() - start).trim()
   out.write(`${P}${cyan(S.active)}  ${summary || label}\n`)
+  // Keep the tail of the output visible under the completed step as a trace, rather than erasing it.
+  const tail = window.slice(-max)
+  if (tail.length) {
+    out.write(`${P}${gray(S.bar)}\n`)
+    for (const line of tail) {
+      out.write(`${P}${gray(S.bar)}  ${dim(line.slice(0, Math.max(0, width() - 5)))}\n`)
+    }
+  }
 }

--- a/packages/cli/src/spawn.ts
+++ b/packages/cli/src/spawn.ts
@@ -1,4 +1,4 @@
-import { cyan, dim, gray, PAD as P, PULSE, red, S } from "@/style"
+import { cyan, dim, gray, PAD as P, pulseLabel, red, S } from "@/style"
 import { nanoSpawn, SubprocessError } from "@/vendor/nano-spawn"
 
 // Async, Windows-safe process spawning on the vendored nano-spawn: non-blocking (the event loop stays free while a subprocess runs), and on Windows it runs `.cmd`/`.ps1` shims (e.g. a package-manager-installed `bunx`) that raw `child_process` cannot. Vendored, not a dependency, so nothing lands in the workspace catalog. Every subprocess (bun, bunx, git, docker, the bun installer) goes through here.
@@ -29,10 +29,6 @@ const ESC = "\x1b"
 const csi = new RegExp(`${ESC}\\[[0-9;?]*[a-zA-Z]`, "g")
 const stripAnsi = (s: string): string => s.replace(csi, "")
 
-// Format an elapsed duration like bun's install summary: [2.77s] for >= 1s, [978.00ms] otherwise.
-export const formatDuration = (ms: number): string =>
-  ms >= 1000 ? `[${(ms / 1000).toFixed(2)}s]` : `[${ms.toFixed(2)}ms]`
-
 // Errors whose captured output runTail already streamed to the terminal in full, so printError shows the message alone rather than repeating the tail.
 const dumped = new WeakSet<object>()
 
@@ -50,7 +46,7 @@ export const printError = (err: unknown): void => {
   for (const line of lines) process.stderr.write(`${P}${dim(line)}\n`)
 }
 
-// Run a command as a clack-style step: a `label` that pulses between the filled ◆ and hollow ◇ while it runs, with a dimmed rolling window of its last `lines` output lines beneath it, collapsing on success to a completed `◆ summarize(output, durationMs)`. On failure the captured output is dumped so the error stays visible, then it rejects. Off a TTY (CI, piped) it prints the label and streams the command in full so logs are complete.
+// Run a command as a clack-style step: a `label` that pulses between the filled ◆ and hollow ◇ while it runs, with a dimmed rolling window of its last `lines` output lines beneath it. On success it collapses to a completed `◆ done` (a past-tense done label, defaulting to `label`) and keeps the tail of the output beneath as a trace. On failure the captured output is dumped so the error stays visible, then it rejects. Off a TTY (CI, piped) it prints the label and streams the command in full so logs are complete.
 export const runTail = async (
   cmd: string,
   args: string[],
@@ -58,10 +54,9 @@ export const runTail = async (
     cwd?: string
     lines?: number
     label?: string
-    summarize: (output: string, durationMs: number) => string
+    done?: string
   },
 ): Promise<void> => {
-  const start = Date.now()
   const out = process.stdout
   const label = opts.label ?? ""
   if (!out.isTTY) {
@@ -90,7 +85,7 @@ export const runTail = async (
   const render = (): void => {
     erase()
     let n = 0
-    out.write(`${P}${cyan(PULSE[frame])}  ${label}\n`)
+    out.write(`${P}${pulseLabel(frame, label)}\n`)
     n++
     if (window.length) {
       out.write(`${P}${gray(S.bar)}\n`)
@@ -121,7 +116,7 @@ export const runTail = async (
   }
   process.once("SIGINT", onSigint)
   const pulse = setInterval(() => {
-    frame = (frame + 1) % PULSE.length
+    frame = frame + 1
     render()
   }, 400)
   const stop = (): void => {
@@ -142,14 +137,9 @@ export const runTail = async (
   stop()
   erase()
   setWrap(true)
-  const summary = opts.summarize(output, Date.now() - start).trim()
-  out.write(`${P}${cyan(S.active)}  ${summary || label}\n`)
+  out.write(`${P}${cyan(S.active)}  ${opts.done ?? label}\n`)
   // Keep the tail of the output visible under the completed step as a trace, rather than erasing it.
-  const tail = window.slice(-max)
-  if (tail.length) {
-    out.write(`${P}${gray(S.bar)}\n`)
-    for (const line of tail) {
-      out.write(`${P}${gray(S.bar)}  ${dim(line.slice(0, Math.max(0, width() - 5)))}\n`)
-    }
+  for (const line of window.slice(-max)) {
+    out.write(`${P}${gray(S.bar)}  ${dim(line.slice(0, Math.max(0, width() - 5)))}\n`)
   }
 }

--- a/packages/cli/src/spawn.ts
+++ b/packages/cli/src/spawn.ts
@@ -87,13 +87,9 @@ export const runTail = async (
     let n = 0
     out.write(`${P}${pulseLabel(frame, label)}\n`)
     n++
-    if (window.length) {
-      out.write(`${P}${gray(S.bar)}\n`)
+    for (const line of window.slice(-max)) {
+      out.write(`${P}${gray(S.bar)}  ${dim(line.slice(0, Math.max(0, width() - 5)))}\n`)
       n++
-      for (const line of window.slice(-max)) {
-        out.write(`${P}${gray(S.bar)}  ${dim(line.slice(0, Math.max(0, width() - 5)))}\n`)
-        n++
-      }
     }
     rendered = n
   }

--- a/packages/cli/src/style.ts
+++ b/packages/cli/src/style.ts
@@ -8,13 +8,14 @@ const paint =
   (s: string): string =>
     stream.isTTY ? `\x1b[${open}m${s}\x1b[${close}m` : s
 
-// Match @clack/prompts' palette exactly (it uses picocolors): standard ANSI colors, so they adapt to the terminal theme. cyan is the active step and links; green is success and the selected radio; yellow is warnings; gray is the gutter; dim is subdued detail; red is cancel (stderr-guarded, since it's the only color written to console.error). orange has no ANSI/clack equivalent, so it stays a 256-color for copy-paste commands.
+// Match @clack/prompts' palette exactly (it uses picocolors): standard ANSI colors, so they adapt to the terminal theme. cyan is the active step and links; green is success and the selected radio; yellow is warnings; gray is the gutter; dim is subdued detail; orange has no ANSI/clack equivalent, so it stays a 256-color for copy-paste commands. red and dimErr are the stderr-guarded pair printError writes (message + its dimmed output tail), so their TTY check reads the stream they actually go to.
 export const cyan = paint("36", "39")
 export const green = paint("32", "39")
 export const yellow = paint("33", "39")
 export const gray = paint("90", "39")
 export const dim = paint("2", "22")
 export const red = paint("31", "39", process.stderr)
+export const dimErr = paint("2", "22", process.stderr)
 export const orange = paint("38;5;208", "39")
 
 // Spinner pulse: blink from the hollow glyph (◇) to the filled one (◆) while work runs, so a step starts unfilled and fills in as it settles to the completed ◆.

--- a/packages/cli/src/style.ts
+++ b/packages/cli/src/style.ts
@@ -17,8 +17,14 @@ export const dim = paint("2", "22")
 export const red = paint("31", "39", process.stderr)
 export const orange = paint("38;5;208", "39")
 
-// Spinner pulse: alternate the filled active glyph (◆) and the hollow submit glyph (◇) while work runs.
-export const PULSE = ["◆", "◇"] as const
+// Spinner pulse: blink from the hollow glyph (◇) to the filled one (◆) while work runs, so a step starts unfilled and fills in as it settles to the completed ◆.
+export const PULSE = ["◇", "◆"] as const
+
+// The active (in-progress) line for a pulse frame: only the glyph blinks, hollow (◇) → filled (◆), always cyan (never dimmed). The label stays constant (never dimmed, never blinks).
+export const pulseLabel = (frame: number, label: string): string => {
+  const i = ((frame % PULSE.length) + PULSE.length) % PULSE.length
+  return `${cyan(PULSE[i])}  ${label}`
+}
 
 // clack flow glyphs: the gutter (┌ │ └), a submitted step (◇), the active step (◆), radio bullets, and the note box border.
 export const S = {

--- a/packages/cli/test/spawn.test.ts
+++ b/packages/cli/test/spawn.test.ts
@@ -69,7 +69,7 @@ test("runTail draws a rolling window on a TTY, then collapses to the summary", a
       {
         lines: 5,
         label: "Installing",
-        summarize: (out) => out.match(/[\d,]+ packages installed[^\n]*/)?.[0] ?? "",
+        done: "Installed dependencies",
       },
     )
   } finally {
@@ -82,11 +82,11 @@ test("runTail draws a rolling window on a TTY, then collapses to the summary", a
   expect(all).toContain("[?7l") // auto-wrap disabled so a wide/long line can't wrap and grow the window
   expect(all).toContain("[?7h") // and re-enabled afterwards
   expect(all).toContain("pkg 0") // intermediate lines were rendered
-  expect(all).toContain("42 packages installed") // and the summary printed at the end
-  // The tail of the output stays visible under the completed step: pkg 7 is redrawn after the summary line, not erased.
-  const afterSummary = all.slice(all.lastIndexOf("[0J") + 3)
-  expect(afterSummary).toContain("42 packages installed")
-  expect(afterSummary).toContain("pkg 7")
+  // On completion it collapses to the done label and keeps the tail (last `lines` output lines) beneath.
+  const finalFrame = all.slice(all.lastIndexOf("[0J") + 3)
+  expect(finalFrame).toContain("Installed dependencies") // the done label header
+  expect(finalFrame).toContain("pkg 7") // tail retained, not erased
+  expect(finalFrame).toContain("42 packages installed") // and the last output line lands in the tail
 })
 
 // Run a failing node script that writes $ZS_TEST_STDERR to stderr, and return the rejection. The marker is passed via env (not the -e source) so it appears only in the child's captured stderr, never echoed in the SubprocessError's command message.
@@ -126,7 +126,7 @@ test("printError does not repeat output runTail already dumped", async () => {
         await runTail(
           "node",
           ["-e", "process.stderr.write(process.env.ZS_TEST_STDERR + '\\n'); process.exit(1)"],
-          { label: "Working", summarize: () => "done" },
+          { label: "Working", done: "done" },
         )
       } catch (err) {
         caught = err

--- a/packages/cli/test/spawn.test.ts
+++ b/packages/cli/test/spawn.test.ts
@@ -139,3 +139,30 @@ test("printError does not repeat output runTail already dumped", async () => {
   expect(out).toContain("Command failed") // the message still prints
   expect(out).not.toContain("kaboom-tail-marker") // but the tail is not repeated (runTail already showed it)
 })
+
+test("printError's tail is guarded on stderr's TTY state, not stdout's", async () => {
+  const caught = await failWithStderr("guarded-tail-marker")
+  const so = process.stdout
+  const se = process.stderr
+  const soTTY = so.isTTY
+  const seTTY = se.isTTY
+  const writes: string[] = []
+  const origWrite = se.write.bind(se)
+  se.write = (chunk: unknown): boolean => {
+    writes.push(String(chunk))
+    return true
+  }
+  // stdout a TTY, stderr piped: the stderr-bound dimErr must emit no codes (a stdout-bound dim would).
+  Object.defineProperty(so, "isTTY", { configurable: true, value: true })
+  Object.defineProperty(se, "isTTY", { configurable: true, value: false })
+  try {
+    printError(caught)
+  } finally {
+    se.write = origWrite
+    Object.defineProperty(so, "isTTY", { configurable: true, value: soTTY })
+    Object.defineProperty(se, "isTTY", { configurable: true, value: seTTY })
+  }
+  const out = writes.join("")
+  expect(out).toContain("guarded-tail-marker") // the tail still prints
+  expect(out).not.toContain("\x1b[2m") // but with no dim escape, since stderr isn't a TTY
+})

--- a/packages/cli/test/spawn.test.ts
+++ b/packages/cli/test/spawn.test.ts
@@ -1,6 +1,34 @@
 import { expect, test } from "bun:test"
 
-import { ok, run, runTail } from "@/spawn"
+import { ok, printError, run, runTail } from "@/spawn"
+
+// Capture everything written to a stream while `fn` runs, restoring it (and TTY shape) afterward.
+const captureStream = async (
+  stream: NodeJS.WriteStream,
+  fn: () => void | Promise<void>,
+  tty?: { columns: number },
+): Promise<string> => {
+  const writes: string[] = []
+  const origWrite = stream.write.bind(stream)
+  const origIsTTY = stream.isTTY
+  const origCols = stream.columns
+  stream.write = (chunk: unknown): boolean => {
+    writes.push(String(chunk))
+    return true
+  }
+  if (tty) {
+    Object.defineProperty(stream, "isTTY", { configurable: true, value: true })
+    Object.defineProperty(stream, "columns", { configurable: true, value: tty.columns })
+  }
+  try {
+    await fn()
+  } finally {
+    stream.write = origWrite
+    Object.defineProperty(stream, "isTTY", { configurable: true, value: origIsTTY })
+    Object.defineProperty(stream, "columns", { configurable: true, value: origCols })
+  }
+  return writes.join("")
+}
 
 test("ok is true for a command that exits 0, false for a missing binary", async () => {
   expect(await ok("node", ["--version"])).toBe(true)
@@ -53,6 +81,61 @@ test("runTail draws a rolling window on a TTY, then collapses to the summary", a
   expect(all).toMatch(/\[\d+A/) // cursor-up: the window was redrawn in place
   expect(all).toContain("[?7l") // auto-wrap disabled so a wide/long line can't wrap and grow the window
   expect(all).toContain("[?7h") // and re-enabled afterwards
-  expect(all).toContain("pkg 0") // intermediate lines were rendered (then erased)
+  expect(all).toContain("pkg 0") // intermediate lines were rendered
   expect(all).toContain("42 packages installed") // and the summary printed at the end
+  // The tail of the output stays visible under the completed step: pkg 7 is redrawn after the summary line, not erased.
+  const afterSummary = all.slice(all.lastIndexOf("[0J") + 3)
+  expect(afterSummary).toContain("42 packages installed")
+  expect(afterSummary).toContain("pkg 7")
+})
+
+// Run a failing node script that writes $ZS_TEST_STDERR to stderr, and return the rejection. The marker is passed via env (not the -e source) so it appears only in the child's captured stderr, never echoed in the SubprocessError's command message.
+const failWithStderr = async (marker: string): Promise<unknown> => {
+  process.env.ZS_TEST_STDERR = marker
+  try {
+    await run("node", [
+      "-e",
+      "process.stderr.write(process.env.ZS_TEST_STDERR + '\\n'); process.exit(1)",
+    ])
+  } catch (err) {
+    return err
+  } finally {
+    delete process.env.ZS_TEST_STDERR
+  }
+  throw new Error("expected the subprocess to reject")
+}
+
+test("printError shows the message, plus a failed subprocess's captured stderr the bare message omits", async () => {
+  const caught = await failWithStderr("fatal: repository not found")
+  const out = await captureStream(process.stderr, () => {
+    printError(new Error("plain boom"))
+    printError(caught)
+  })
+  expect(out).toContain("plain boom")
+  expect(out).toContain("Command failed with exit code 1") // the subprocess message
+  expect(out).toContain("fatal: repository not found") // and the real cause, recovered from its stderr
+})
+
+test("printError does not repeat output runTail already dumped", async () => {
+  process.env.ZS_TEST_STDERR = "kaboom-tail-marker"
+  let caught: unknown
+  await captureStream(
+    process.stdout,
+    async () => {
+      try {
+        await runTail(
+          "node",
+          ["-e", "process.stderr.write(process.env.ZS_TEST_STDERR + '\\n'); process.exit(1)"],
+          { label: "Working", summarize: () => "done" },
+        )
+      } catch (err) {
+        caught = err
+      }
+    },
+    { columns: 80 },
+  )
+  delete process.env.ZS_TEST_STDERR
+  const out = await captureStream(process.stderr, () => printError(caught))
+  expect(out).toContain("Command failed") // the message still prints
+  expect(out).not.toContain("kaboom-tail-marker") // but the tail is not repeated (runTail already showed it)
 })

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -25,7 +25,7 @@ The rest of this page is what those commands do, and the one thing to check if t
 
 - fetches the latest ZeroStarter and strips the sample content,
 - rebrands the copy to your project name,
-- installs dependencies with Bun (progress streams live),
+- installs dependencies with Bun from the shipped `bun.lock`, so the first install resolves from locked versions instead of a slow cold resolve (progress streams live),
 - provisions a local Postgres in Docker (via [pglaunch](https://github.com/nrjdalal/pglaunch)), reusing an already-running one when you re-run `init`, and applies the migrations,
 - writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET`.
 
@@ -47,7 +47,7 @@ bun run db:migrate
 
 ## `zerostarter sync`
 
-`bunx zerostarter sync` re-baselines an **existing fork** on ZeroStarter's latest scaffold. A gitpick overlay updates the starter files while your content, `public/marketing`, branding (`site.ts`), `package.json` identity, database migrations and schema (`packages/db/drizzle`, `packages/db/src/schema`), the docs config (`docs.config.ts`, which describes your own docs), and favicon are preserved and the files you added are untouched. It requires a clean tree and lands as a reviewable diff you commit yourself (no auto-commit); if the overlay or reconciliation fails it rolls the tree back to your last commit, while a later dependency-install failure leaves the synced files in place for you to re-run `bun install`.
+`bunx zerostarter sync` re-baselines an **existing fork** on ZeroStarter's latest scaffold. A gitpick overlay updates the starter files while your content, `public/marketing`, branding (`site.ts`), `package.json` identity, lockfile (`bun.lock`), database migrations and schema (`packages/db/drizzle`, `packages/db/src/schema`), the docs config (`docs.config.ts`, which describes your own docs), and favicon are preserved and the files you added are untouched. It requires a clean tree and lands as a reviewable diff you commit yourself (no auto-commit); if the overlay or reconciliation fails it rolls the tree back to your last commit, while a later dependency-install failure leaves the synced files in place for you to re-run `bun install`.
 
 ## `bun run dev`
 


### PR DESCRIPTION
Developer-experience work on the `zerostarter` CLI. Two commits.

## Commit 1: error legibility + friendly flags (audit #1, #6)

- **Subprocess failures surface the real cause (#1).** All errors route through a new `printError`, which prints the message **plus the tail of a failed subprocess's captured stderr/stdout**. A gitpick/git/docker failure used to show only `Command failed with exit code 1: ...` with the cause swallowed. `runTail`-dumped output is marked so its tail isn't repeated.
- **Friendly flag errors (#6).** A shared `parseArgsOrExit` (`bin/commands/_args.ts`) makes a bad flag print *that command's help* and exit cleanly, instead of a raw Node error. Wired into `init`/`reinit`/`sync`, keeping precise `values` typing.

## Commit 2: flow polish

- **Section connectors.** `│` breathing-room connectors after the intro, wrapping each note box, and before the outro; consecutive steps still stack tightly.
- **Done labels + kept tail.** `runTail` collapses to a past-tense **done label** (new `done` opt) instead of the metric summary, keeping the output tail beneath with no leading blank bar (bun's `N packages installed` line still shows in the tail). Drops the now-dead `summarize`/`formatDuration`/`migrationCount` helpers.
- **Transient confirm.** `promptConfirm` clears itself on submit instead of leaving a `question Yes` echo (non-interactive runs still echo the auto-choice for logs).
- **Unfilled-first pulse.** The pulse blinks the glyph hollow `◇` → filled `◆` (starts unfilled), always cyan and **never dimmed**; the label stays constant (no text blink). Live prompts use the hollow `◇` glyph. Shared via `pulseLabel`.

Bumps the CLI to **0.0.23** (manual bump so the release publishes).

## Evidence

**Flow output, rendered from the real functions under a PTY (init happy path):**
```
  ┌  https://zerostarter.dev
  │
  ◆  Fetched the latest ZeroStarter
  ◆  Rebranded to playground-zerostarter
  ◆  Installed dependencies
  │  + turbo@2.10.3
  │
  │  1717 packages installed [10.24s]
  ◆  Provisioned a local Postgres database
  │    line: '208',
  │    routine: 'transformCreateStmt'
  │  }
  │
  ◆  Edit and make it yours ─────────────────────────────────╮
  │                                                          │
  │  packages/config/src/site.ts and web/next/content        │
  │  to manage branding and blogs & docs respectively        │
  │                                                          │
  ├──────────────────────────────────────────────────────────╯
  │
  ◆  playground-zerostarter is ready
  │
  ◆  Next steps ─────────────────────────────────────────────╮
  │                                                          │
  │  bun run dev                                             │
  │                                                          │
  ├──────────────────────────────────────────────────────────╯
  │
  └  Learn more https://zerostarter.dev/docs
```

**#6 (bad flag prints help, exits 1):**
```
$ zerostarter init --databse
Unknown option '--databse'. ...

Usage:
  $ bunx zerostarter init [dir] [options]
  ...
```

**#1 (gitpick failure now shows the captured stderr, forced via a failing `bunx` shim):**
```
  ┌  https://zerostarter.dev

  Command failed with exit code 1: bunx --bun gitpick@6.0.0 https://github.com/nrjdalal/zerostarter/tree/main /.../e2e-empty
  gitpick: some noise line
  gitpick: fatal: could not resolve host: github.com
```

## Tests

`bun test` in `packages/cli`: **84 pass / 0 fail** (added `printError` coverage: surfaces subprocess stderr, skips output `runTail` already dumped; updated the tail test for the done-label). Type-check, `oxlint`, `oxfmt --check` all clean.

## Follow-ups (remaining audit findings)
`#2` dry-run parity, `#3` `--ref` + version provenance, `#4` sync confirm/`-y`, `#5` update-available notice, `#7` command-flow tests, `#8` npm README, `#9` `--verbose`, `#10` pinned-version single source. Tracked in `.github/audit/2026-07-04-cli-dx.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI errors now show clearer messages and command help when arguments are invalid.
  * Interactive CLI output is more informative during install, database, and sync steps, with improved progress and completion messages.
* **Bug Fixes**
  * Terminal output now surfaces underlying command failures more reliably instead of hiding details.
  * Completion output keeps recent progress visible, making long-running commands easier to follow.
* **Documentation**
  * Updated setup guidance to better explain dependency installation and what sync preserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->