### PR TITLE
feat(web): keep the dashboard brand in-app, add a home menu link, and polish shell copy and landing CTAs

### DIFF
--- a/web/next/content/docs/manage/dashboard.mdx
+++ b/web/next/content/docs/manage/dashboard.mdx
@@ -6,7 +6,7 @@ description: "The protected app shell: sidebar, org switcher, and the layout wra
 
 <Callout type="warn" title="This is a shell, not a product">
 
-The `/dashboard` page renders a single "Welcome back." header and nothing else. It is an empty, auth-gated starting point. The sidebar, org switching, and layout wrappers are real and wired; the _content_ is yours to build.
+The `/dashboard` page renders a single "Intentionally empty." header and nothing else. It is an empty, auth-gated starting point. The sidebar, org switching, and layout wrappers are real and wired; the _content_ is yours to build.
 
 </Callout>
 
@@ -62,7 +62,7 @@ import { DashboardShell } from "@/components/dashboard/shell"
 export default function Page() {
   return (
     <DashboardShell>
-      <DashboardHeader title="Dashboard" description="Welcome back." />
+      <DashboardHeader title="Dashboard" description="Your first feature starts here." />
       {/* your content here */}
     </DashboardShell>
   )

--- a/web/next/content/docs/manage/dashboard.mdx
+++ b/web/next/content/docs/manage/dashboard.mdx
@@ -6,7 +6,7 @@ description: "The protected app shell: sidebar, org switcher, and the layout wra
 
 <Callout type="warn" title="This is a shell, not a product">
 
-The `/dashboard` page renders a single "Intentionally empty." header and nothing else. It is an empty, auth-gated starting point. The sidebar, org switching, and layout wrappers are real and wired; the _content_ is yours to build.
+The `/dashboard` page renders a single "Dashboard" heading with its "Intentionally empty." description and nothing else. It is an empty, auth-gated starting point. The sidebar, org switching, and layout wrappers are real and wired; the _content_ is yours to build.
 
 </Callout>
 
@@ -62,7 +62,10 @@ import { DashboardShell } from "@/components/dashboard/shell"
 export default function Page() {
   return (
     <DashboardShell>
-      <DashboardHeader title="Dashboard" description="Your first feature starts here." />
+      <DashboardHeader
+        title="Dashboard"
+        description="Intentionally empty. Auth, orgs, and the API are wired; this page is where your product begins."
+      />
       {/* your content here */}
     </DashboardShell>
   )

--- a/web/next/content/docs/manage/dashboard.mdx
+++ b/web/next/content/docs/manage/dashboard.mdx
@@ -44,7 +44,7 @@ So a user returns to the same org context every session.
 
 ### User actions
 
-The footer (`web/next/src/components/sidebar/dashboard/user-actions.tsx`) holds a docs link with a version badge, a cross-link to `/console` when the user is an admin (`canAccessConsole`), and the shared `SidebarUserMenu` (`web/next/src/components/sidebar/user-menu.tsx`): avatar, name, email, a Landing link back to `/` (the sidebar brand stays inside the app, so this is the one way back to the landing page), an optional feedback link (only when `NEXT_PUBLIC_USERJOT_URL` is set), and sign-out (which returns to the home page).
+The footer (`web/next/src/components/sidebar/dashboard/user-actions.tsx`) holds a docs link with a version badge, a cross-link to `/console` when the user is an admin (`canAccessConsole`), and the shared `SidebarUserMenu` (`web/next/src/components/sidebar/user-menu.tsx`): avatar, name, email, a Home link back to `/` (the sidebar brand stays inside the app, so this is the one way back to the landing page), an optional feedback link (only when `NEXT_PUBLIC_USERJOT_URL` is set), and sign-out (which returns to the home page).
 
 ## Page content
 

--- a/web/next/content/docs/manage/dashboard.mdx
+++ b/web/next/content/docs/manage/dashboard.mdx
@@ -27,7 +27,7 @@ if (!session?.user) redirect("/")
 
 The chrome is not inlined in the layout. It lives in `SidebarShell` (`web/next/src/components/sidebar/shell.tsx`), a shadcn/ui `Sidebar` in `collapsible="icon"` mode, shared by both the dashboard and console layouts. The layout fills three slots:
 
-- **Header**: the brand (`site.name`, linking to `homeHref`), the collapse trigger, and a caller node: for the dashboard, the org switcher.
+- **Header**: the brand (`site.name`, linking to `homeHref`, which stays inside the app: `/dashboard` by default), the collapse trigger, and a caller node: for the dashboard, the org switcher.
 - **Content**: a caller `nav` node. Empty for the dashboard; add your navigation items here.
 - **Footer**: a caller node: for the dashboard, the user actions.
 
@@ -44,7 +44,7 @@ So a user returns to the same org context every session.
 
 ### User actions
 
-The footer (`web/next/src/components/sidebar/dashboard/user-actions.tsx`) holds a docs link with a version badge, a cross-link to `/console` when the user is an admin (`canAccessConsole`), and the shared `SidebarUserMenu` (`web/next/src/components/sidebar/user-menu.tsx`): avatar, name, email, an optional feedback link (only when `NEXT_PUBLIC_USERJOT_URL` is set), and sign-out (which returns to the home page).
+The footer (`web/next/src/components/sidebar/dashboard/user-actions.tsx`) holds a docs link with a version badge, a cross-link to `/console` when the user is an admin (`canAccessConsole`), and the shared `SidebarUserMenu` (`web/next/src/components/sidebar/user-menu.tsx`): avatar, name, email, a Landing link back to `/` (the sidebar brand stays inside the app, so this is the one way back to the landing page), an optional feedback link (only when `NEXT_PUBLIC_USERJOT_URL` is set), and sign-out (which returns to the home page).
 
 ## Page content
 

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "bun ../../.github/scripts/compress-images.ts && bun ../../.github/scripts/docs.ts --strict && fumadocs-mdx && next build",
-    "check-types": "tsc --noEmit",
+    "check-types": "fumadocs-mdx && tsc --noEmit",
     "dev": "bun ../../.github/scripts/docs.ts && next dev",
     "start": "bun .next/standalone/web/next/server.js"
   },

--- a/web/next/src/app/(console)/console/page.tsx
+++ b/web/next/src/app/(console)/console/page.tsx
@@ -4,7 +4,10 @@ import { DashboardShell } from "@/components/dashboard/shell"
 export default function Page() {
   return (
     <DashboardShell>
-      <DashboardHeader title="Console" description="Welcome back." />
+      <DashboardHeader
+        title="Console"
+        description="Intentionally empty. Admin-gated; this is where your internal tooling begins."
+      />
     </DashboardShell>
   )
 }

--- a/web/next/src/app/(marketing)/page.tsx
+++ b/web/next/src/app/(marketing)/page.tsx
@@ -1,6 +1,7 @@
 import { site } from "@packages/config/site"
 import {
   RiArrowRightLine,
+  RiArrowRightSLine,
   RiBookOpenLine,
   RiDatabase2Line,
   RiGitForkLine,
@@ -253,7 +254,7 @@ docker compose up --build`
             <p className="text-muted-foreground mx-auto mt-6 max-w-2xl text-lg text-balance sm:text-xl">
               {site.description}
             </p>
-            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <div className="mt-8 flex items-center justify-center gap-3">
               <Button
                 role="link"
                 size="lg"
@@ -271,7 +272,7 @@ docker compose up --build`
                 render={<Link href="/docs" />}
               >
                 Get Started
-                <RiArrowRightLine className="size-4 transition-transform group-hover:translate-x-0.5" />
+                <RiArrowRightSLine className="size-4 transition-transform group-hover:translate-x-0.5" />
               </Button>
             </div>
             <div className="mt-10 flex justify-center">
@@ -557,7 +558,7 @@ docker compose up --build`
               and documentation both humans and agents can trust. It does not choose your payments
               or email vendor; the parts that make your product yours stay yours.
             </p>
-            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <div className="mt-8 flex items-center justify-center gap-3">
               <Button
                 role="link"
                 size="lg"
@@ -575,7 +576,7 @@ docker compose up --build`
                 render={<Link href="/docs" />}
               >
                 Get Started
-                <RiArrowRightLine className="size-4 transition-transform group-hover:translate-x-0.5" />
+                <RiArrowRightSLine className="size-4 transition-transform group-hover:translate-x-0.5" />
               </Button>
             </div>
             <p className="text-muted-foreground mt-6 text-sm">

--- a/web/next/src/app/(protected)/dashboard/page.tsx
+++ b/web/next/src/app/(protected)/dashboard/page.tsx
@@ -4,7 +4,10 @@ import { DashboardShell } from "@/components/dashboard/shell"
 export default function Page() {
   return (
     <DashboardShell>
-      <DashboardHeader title="Dashboard" description="Welcome back." />
+      <DashboardHeader
+        title="Dashboard"
+        description="Intentionally empty. Auth, orgs, and the API are wired; this page is where your product begins."
+      />
     </DashboardShell>
   )
 }

--- a/web/next/src/components/sidebar/shell.tsx
+++ b/web/next/src/components/sidebar/shell.tsx
@@ -17,7 +17,7 @@ import {
 // Shared collapsible sidebar shell used by the dashboard and console layouts. Owns the sidebar chrome (provider, header brand, footer, rail) and the persisted open state; callers supply the badge, nav, and footer.
 export async function SidebarShell({
   badge,
-  homeHref = "/",
+  homeHref = "/dashboard",
   header,
   nav,
   footer,

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -27,7 +27,7 @@ function getInitials(name: string) {
   return name.slice(0, 2).toUpperCase()
 }
 
-// Shared sidebar user dropdown (avatar, identity, landing link, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
+// Shared sidebar user dropdown (avatar, identity, home link, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
 export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard" | "console" }) {
   const router = useRouter()
   const [signingOut, setSigningOut] = useState(false)
@@ -51,6 +51,12 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
   return (
     <SidebarMenuItem>
       <SidebarDropdownMenu trigger={identity} header={identity} align="end" mobileSide="top">
+        {/* The sidebar brand stays inside the app, so this is the one way back to the landing page. */}
+        <DropdownMenuItem render={<Link href="/" className="cursor-pointer" />}>
+          <RiHome4Line />
+          Home
+          <RiArrowRightSLine className="text-muted-foreground ml-auto size-4" />
+        </DropdownMenuItem>
         {crossLink && (
           <DropdownMenuItem render={<Link href={crossLink.href} className="cursor-pointer" />}>
             {crossLink.icon}
@@ -58,11 +64,6 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
             <RiArrowRightSLine className="text-muted-foreground ml-auto size-4" />
           </DropdownMenuItem>
         )}
-        {/* The sidebar brand stays inside the app, so this is the one way back to the landing page. */}
-        <DropdownMenuItem render={<Link href="/" className="cursor-pointer" />}>
-          <RiHome4Line />
-          Landing
-        </DropdownMenuItem>
         <DropdownMenuSeparator />
         {env.NEXT_PUBLIC_USERJOT_URL && (
           <DropdownMenuItem

--- a/web/next/src/components/sidebar/user-menu.tsx
+++ b/web/next/src/components/sidebar/user-menu.tsx
@@ -4,6 +4,7 @@ import { env } from "@packages/env/web-next"
 import {
   RiArrowRightSLine,
   RiDashboardLine,
+  RiHome4Line,
   RiLogoutBoxLine,
   RiMessage2Line,
   RiTerminalBoxLine,
@@ -26,7 +27,7 @@ function getInitials(name: string) {
   return name.slice(0, 2).toUpperCase()
 }
 
-// Shared sidebar user dropdown (avatar, identity, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
+// Shared sidebar user dropdown (avatar, identity, landing link, feedback, sign out). Used by every sidebar footer so the menu and `getInitials` live in one place.
 export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard" | "console" }) {
   const router = useRouter()
   const [signingOut, setSigningOut] = useState(false)
@@ -51,15 +52,18 @@ export function SidebarUserMenu({ user, area }: { user: User; area?: "dashboard"
     <SidebarMenuItem>
       <SidebarDropdownMenu trigger={identity} header={identity} align="end" mobileSide="top">
         {crossLink && (
-          <>
-            <DropdownMenuItem render={<Link href={crossLink.href} className="cursor-pointer" />}>
-              {crossLink.icon}
-              {crossLink.label}
-              <RiArrowRightSLine className="text-muted-foreground ml-auto size-4" />
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-          </>
+          <DropdownMenuItem render={<Link href={crossLink.href} className="cursor-pointer" />}>
+            {crossLink.icon}
+            {crossLink.label}
+            <RiArrowRightSLine className="text-muted-foreground ml-auto size-4" />
+          </DropdownMenuItem>
         )}
+        {/* The sidebar brand stays inside the app, so this is the one way back to the landing page. */}
+        <DropdownMenuItem render={<Link href="/" className="cursor-pointer" />}>
+          <RiHome4Line />
+          Landing
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         {env.NEXT_PUBLIC_USERJOT_URL && (
           <DropdownMenuItem
             render={


### PR DESCRIPTION
## Summary

Keeps signed-in users inside the app and makes the starter's empty shells explain themselves.

- **Sidebar brand stays in-app**: `SidebarShell`'s `homeHref` now defaults to `/dashboard` instead of `/`, so clicking the brand no longer drops users back on the landing page. Console still passes `/console`.
- **Home link in the user menu**: the shared `SidebarUserMenu` gains a "Home" item (first, with a chevron) linking to `/`, now the one way back to the landing page from the app. Shows in both dashboard and console for all users.
- **Shell headers explain the handoff**: `/dashboard` and `/console` replace "Welcome back." with copy that says the page is intentionally empty and what is already wired.
- **Landing CTA fixes**: the hero and bottom-CTA button rows stay on one line on mobile (dropped the `flex-col sm:flex-row` stacking), and "Get Started" uses a chevron (`RiArrowRightSLine`) instead of the stemmed arrow.
- **Pipeline fix**: `@web/next` `check-types` runs `fumadocs-mdx` first, so `bun clean && bun i && ... && bun run check-types` no longer fails on the generated `collections/*` module before a build has run.
- Docs (`manage/dashboard.mdx`) updated to match.

## Screenshots

| Before | After |
| --- | --- |
| ![before dashboard](https://litter.catbox.moe/729fuj.png) | ![after dashboard](https://litter.catbox.moe/er9vcf.png) |

Dashboard: brand previously linked to `/`; menu had no way back to the landing page once the brand stops leaving the app. After: "Intentionally empty..." copy, Home + Console rows with chevrons.

| Before | After |
| --- | --- |
| ![before mobile hero](https://litter.catbox.moe/6vchhx.png) | ![after mobile hero](https://litter.catbox.moe/z9l5dq.png) |

Landing at 390px: CTAs stacked with a stemmed arrow before; one row with a chevron after (also holds at 320px with no horizontal overflow).

## Testing

- Verified end-to-end in the browser as `LocalAgent`: brand href is `/dashboard`, Home navigates to `/`, console brand still goes to `/console`, both menus render Home/cross-link/Feedback/Log out.
- Landing checked at 390px, 320px (no horizontal overflow, single-line CTAs), and 1440px.
- `bun clean && bun i && bun run lint && bun run format && bun run check-types && bun run build` passes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer home link in the user menu for quicker navigation back to the main page.
  * Updated the marketing page buttons with a refreshed arrow icon and improved alignment.

* **Bug Fixes**
  * The brand link in the sidebar now consistently opens the dashboard when no destination is set.
  * Improved sidebar menu behavior and layout for smoother navigation.

* **Documentation**
  * Updated dashboard and sidebar docs to reflect the latest empty-state and navigation wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->