### PR TITLE
feat(env): scoped SKIP_ENV_VALIDATION_SERVER and _CLIENT flags

### DIFF
--- a/packages/env/src/api-hono.ts
+++ b/packages/env/src/api-hono.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
+import { skipServerValidation } from "@/lib/skip"
 
 export const env = createEnv({
   server: {
@@ -25,5 +26,5 @@ export const env = createEnv({
     HONO_TRUSTED_ORIGINS: process.env.HONO_TRUSTED_ORIGINS,
   },
   emptyStringAsUndefined: true,
-  skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
+  skipValidation: skipServerValidation,
 })

--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
+import { skipServerValidation } from "@/lib/skip"
 
 export const env = createEnv({
   server: {
@@ -29,5 +30,5 @@ export const env = createEnv({
     HONO_TRUSTED_ORIGINS: process.env.HONO_TRUSTED_ORIGINS,
   },
   emptyStringAsUndefined: true,
-  skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
+  skipValidation: skipServerValidation,
 })

--- a/packages/env/src/db.ts
+++ b/packages/env/src/db.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
+import { skipServerValidation } from "@/lib/skip"
 
 export const env = createEnv({
   server: {
@@ -16,5 +17,5 @@ export const env = createEnv({
       : process.env.POSTGRES_URL,
   },
   emptyStringAsUndefined: true,
-  skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
+  skipValidation: skipServerValidation,
 })

--- a/packages/env/src/lib/skip.ts
+++ b/packages/env/src/lib/skip.ts
@@ -1,0 +1,5 @@
+// Env-validation skip flags. `SKIP_ENV_VALIDATION` is the base "skip everything" escape hatch (the Next.js/t3-env/Docker convention); the scoped `_SERVER` / `_CLIENT` variants skip just one side. Base implies both.
+const skipAll = process.env.SKIP_ENV_VALIDATION === "true"
+
+export const skipClientValidation = skipAll || process.env.SKIP_ENV_VALIDATION_CLIENT === "true"
+export const skipServerValidation = skipAll || process.env.SKIP_ENV_VALIDATION_SERVER === "true"

--- a/packages/env/src/web-next.ts
+++ b/packages/env/src/web-next.ts
@@ -5,16 +5,18 @@ import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
 import { skipClientValidation, skipServerValidation } from "@/lib/skip"
 
-// Split into two createEnv calls so the server and client sections can be skipped independently (t3-env's skipValidation is one boolean per call). The client env extends the server env, so the exported `env` still carries both.
+// Split into two createEnv calls so the server and client sections can be skipped independently (t3-env's skipValidation is one boolean per call). The client env extends the server env, so the exported `env` carries both when validating.
+const serverRuntimeEnv = {
+  NODE_ENV: process.env.NODE_ENV,
+  INTERNAL_API_URL: process.env.INTERNAL_API_URL,
+}
+
 const serverEnv = createEnv({
   server: {
     NODE_ENV,
     INTERNAL_API_URL: z.url().optional(),
   },
-  runtimeEnv: {
-    NODE_ENV: process.env.NODE_ENV,
-    INTERNAL_API_URL: process.env.INTERNAL_API_URL,
-  },
+  runtimeEnv: serverRuntimeEnv,
   emptyStringAsUndefined: true,
   skipValidation: skipServerValidation,
 })
@@ -31,6 +33,8 @@ export const env = createEnv({
     NEXT_PUBLIC_USERJOT_URL: z.url().optional(),
   },
   runtimeEnv: {
+    // Server vars are repeated here so they survive t3-env's skip short-circuit: when the client section is skipped, createEnv returns this runtimeEnv verbatim and does not merge `extends`.
+    ...serverRuntimeEnv,
     NEXT_PUBLIC_API_URL:
       process.env.NEXT_PUBLIC_API_URL ??
       (skipClientValidation ? "https://polyfill.url" : undefined),

--- a/packages/env/src/web-next.ts
+++ b/packages/env/src/web-next.ts
@@ -3,12 +3,24 @@ import { z } from "zod"
 
 import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
+import { skipClientValidation, skipServerValidation } from "@/lib/skip"
 
-export const env = createEnv({
+// Split into two createEnv calls so the server and client sections can be skipped independently (t3-env's skipValidation is one boolean per call). The client env extends the server env, so the exported `env` still carries both.
+const serverEnv = createEnv({
   server: {
     NODE_ENV,
     INTERNAL_API_URL: z.url().optional(),
   },
+  runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    INTERNAL_API_URL: process.env.INTERNAL_API_URL,
+  },
+  emptyStringAsUndefined: true,
+  skipValidation: skipServerValidation,
+})
+
+export const env = createEnv({
+  extends: [serverEnv],
   clientPrefix: "NEXT_PUBLIC_",
   client: {
     NEXT_PUBLIC_APP_URL: z.url(),
@@ -19,19 +31,17 @@ export const env = createEnv({
     NEXT_PUBLIC_USERJOT_URL: z.url().optional(),
   },
   runtimeEnv: {
-    NODE_ENV: process.env.NODE_ENV,
-    INTERNAL_API_URL: process.env.INTERNAL_API_URL,
     NEXT_PUBLIC_API_URL:
       process.env.NEXT_PUBLIC_API_URL ??
-      (process.env.SKIP_ENV_VALIDATION === "true" ? "https://polyfill.url" : undefined),
+      (skipClientValidation ? "https://polyfill.url" : undefined),
     NEXT_PUBLIC_APP_URL:
       process.env.NEXT_PUBLIC_APP_URL ??
-      (process.env.SKIP_ENV_VALIDATION === "true" ? "https://polyfill.url" : undefined),
+      (skipClientValidation ? "https://polyfill.url" : undefined),
     NEXT_PUBLIC_NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN,
     NEXT_PUBLIC_USERJOT_URL: process.env.NEXT_PUBLIC_USERJOT_URL,
   },
   emptyStringAsUndefined: true,
-  skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
+  skipValidation: skipClientValidation,
 })

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,8 @@
   "globalEnv": [
     // CI variables
     "SKIP_ENV_VALIDATION",
+    "SKIP_ENV_VALIDATION_CLIENT",
+    "SKIP_ENV_VALIDATION_SERVER",
     // Server variables
     "NODE_ENV",
     "BETTER_AUTH_SECRET",

--- a/web/next/content/docs/manage/environment.mdx
+++ b/web/next/content/docs/manage/environment.mdx
@@ -59,6 +59,13 @@ A variable declared in the schema but missing from the `runtimeEnv` map is silen
 
 `SKIP_ENV_VALIDATION=true` bypasses every check. This is how CI and Docker images build before real secrets exist (in `web-next`, missing public URLs fall back to `https://polyfill.url` so the build completes). Never set it for a running app: it turns off the guarantee that every variable is present and typed.
 
+Two scoped variants skip just one side, for builds that have one set of vars but not the other (e.g. a web build that must guarantee the inlined `NEXT_PUBLIC_*` client vars but has no server secrets):
+
+- `SKIP_ENV_VALIDATION_CLIENT=true` skips only the `client` section (the `NEXT_PUBLIC_*` vars).
+- `SKIP_ENV_VALIDATION_SERVER=true` skips only the `server` section.
+
+The base flag implies both, so a section is skipped when `SKIP_ENV_VALIDATION` **or** its scoped flag is set. The server-only packages (`api-hono`, `auth`, `db`) respond to the base and `_SERVER` flags; `_CLIENT` only affects `web-next`.
+
 ## Next
 
 - [Database](/docs/manage/database): where `POSTGRES_URL` is consumed.


### PR DESCRIPTION
Adds scoped env-validation skip flags so a build can bypass just the server or just the client section, alongside the existing all-or-nothing `SKIP_ENV_VALIDATION`.

## Why

`SKIP_ENV_VALIDATION=true` skips *everything* — the Docker/CI escape hatch. But some builds legitimately have one set of vars and not the other (e.g. a web build that must still guarantee the inlined `NEXT_PUBLIC_*` client vars but has no server secrets). This adds a scalpel without removing the hammer.

## Flags & precedence

| Flag set | server section | client section |
| --- | --- | --- |
| (none) | validated | validated |
| `SKIP_ENV_VALIDATION` | skipped | skipped |
| `SKIP_ENV_VALIDATION_SERVER` | skipped | validated |
| `SKIP_ENV_VALIDATION_CLIENT` | validated | skipped |

Base implies both: a section is skipped when `SKIP_ENV_VALIDATION` **or** its scoped flag is set. The naming is a suffix family (`SKIP_ENV_VALIDATION`, `..._CLIENT`, `..._SERVER`) so the flags group and sort together.

## Implementation

- New `packages/env/src/lib/skip.ts` computes `skipClientValidation` / `skipServerValidation` from the three vars (base OR scoped).
- Server-only packages (`api-hono`, `auth`, `db`) map `skipValidation` to `skipServerValidation` (`_CLIENT` never applies — they have no client section).
- `web-next` is split into two `createEnv` calls — a `serverEnv` (skipped by `skipServerValidation`) and a client env that `extends: [serverEnv]` (skipped by `skipClientValidation`). `extends` is native to `@t3-oss/env-core` 0.13, so the exported `env` still carries both sets. The `NEXT_PUBLIC_*` polyfill now keys off `skipClientValidation`.
- `turbo.json` `globalEnv` gains the two flags so cache keys track them.
- Docs (`manage/environment.mdx`) document the flags and precedence.

## Testing

- Proved the full truth table above by loading the composed `web-next` env under each flag combination (client-skip polyfills the missing `NEXT_PUBLIC_*` and leaves server enforced; server-skip lets an invalid `INTERNAL_API_URL` through while still enforcing the client vars; base skips both).
- `bunx turbo run build` (7/7) and `check-types` (12/12, CI-style with the skip flag) pass in a fresh worktree.
- Confirmed `SKIP_ENV_VALIDATION_SERVER=true` alone unblocks the server-package builds without a `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
