### PR TITLE
feat: stream system health over a WebSocket (live status demo)

### DIFF
--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -83,7 +83,7 @@ import { apiClient, unwrap } from "@/lib/api/client"
 const { data, error } = await unwrap(apiClient.<name>.$post({ json: { ... } }))   // fully typed
 ```
 
-Client components polling REST data use TanStack Query (see `components/access.tsx`).
+Client components reading REST data use TanStack Query (see `components/access.tsx`).
 
 ## WebSocket routes
 
@@ -92,6 +92,7 @@ For a live server-to-client stream instead of polling, upgrade a `GET` with `upg
 - The typed client reaches it with `apiClient.health.ws.$ws()`, which returns a standard `WebSocket` pointed at the configured API base (`http` becomes `ws`).
 - Frame payloads are not RPC-typed: `ws.send()` takes a raw string and `$ws()` returns a plain `WebSocket`, so parse defensively on the client and read only the fields you need. Don't hand-maintain a shared payload type RPC can't derive.
 - Keep a `describeRoute` so the upgrade lists in the Scalar reference as a `101`, but OpenAPI can't schema-type WS frames and there is no `{ data }` / `{ error }` envelope: describe the frame shape in the route's `description`.
+- Unlike REST, the handshake is not gated by `cors()` (browsers don't apply CORS to WebSockets) and `$ws()` does not send the client's credentials, so for a sensitive or authed route check the `Origin` header (or a token) in the handler rather than relying on the allowlist. `/api/health/ws` serves public data, so it doesn't.
 - `bun --hot` picks up edits to the existing `index.ts` route, but restart the stack if `hono/bun` isn't yet wired into the Bun export.
 
-See `components/marketing/api-status.tsx` for the reference client: it uses the socket for a live pulse, retries a transient drop a few times, then falls back to polling REST `/api/health` when the socket can't connect or deliver a frame (serverless, buffered upgrade).
+See `components/marketing/api-status.tsx` for the reference client: REST `/api/health` is the always-honest baseline (polled whenever no frame is live), and the socket overlays a live pulse, reconnecting with capped backoff so a serverless deploy or a transient blip degrades to the REST-polled state instead of a broken badge.

--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -83,4 +83,15 @@ import { apiClient, unwrap } from "@/lib/api/client"
 const { data, error } = await unwrap(apiClient.<name>.$post({ json: { ... } }))   // fully typed
 ```
 
-Client components needing live data use TanStack Query (see `components/marketing/api-status.tsx`).
+Client components polling REST data use TanStack Query (see `components/access.tsx`).
+
+## WebSocket routes
+
+For a live server-to-client stream instead of polling, upgrade a `GET` with `upgradeWebSocket` from `hono/bun` and add the shared `websocket` handler to the Bun server export next to `fetch` (`api/hono/src/index.ts`). `/api/health/ws` is the reference: it pushes a snapshot on connect and a heartbeat every 5s.
+
+- The typed client reaches it with `apiClient.health.ws.$ws()`, which returns a standard `WebSocket` pointed at the configured API base (`http` becomes `ws`).
+- Frame payloads are not RPC-typed, so export a shared type (the API exports `HealthEvent` from `@api/hono`) and parse against it on the client.
+- WebSocket routes skip `describeRoute`, the `{ data }` / `{ error }` envelope, and the OpenAPI reference (which only describes HTTP).
+- `bun --hot` picks up edits to the existing `index.ts` route, but restart the stack if `hono/bun` isn't yet wired into the Bun export.
+
+See `components/marketing/api-status.tsx` for the client with reconnect.

--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -94,4 +94,4 @@ For a live server-to-client stream instead of polling, upgrade a `GET` with `upg
 - Keep a `describeRoute` so the upgrade lists in the Scalar reference as a `101`, but OpenAPI can't schema-type WS frames and there is no `{ data }` / `{ error }` envelope: describe the frame shape in the route's `description`.
 - `bun --hot` picks up edits to the existing `index.ts` route, but restart the stack if `hono/bun` isn't yet wired into the Bun export.
 
-See `components/marketing/api-status.tsx` for the reference client: it uses the socket for a live pulse and falls back to polling REST `/api/health` when the socket can't connect or deliver a frame (serverless, buffered upgrade).
+See `components/marketing/api-status.tsx` for the reference client: it uses the socket for a live pulse, retries a transient drop a few times, then falls back to polling REST `/api/health` when the socket can't connect or deliver a frame (serverless, buffered upgrade).

--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -90,8 +90,8 @@ Client components polling REST data use TanStack Query (see `components/access.t
 For a live server-to-client stream instead of polling, upgrade a `GET` with `upgradeWebSocket` from `hono/bun` and add the shared `websocket` handler to the Bun server export next to `fetch` (`api/hono/src/index.ts`). `/api/health/ws` is the reference: it pushes a snapshot on connect and a heartbeat every 5s.
 
 - The typed client reaches it with `apiClient.health.ws.$ws()`, which returns a standard `WebSocket` pointed at the configured API base (`http` becomes `ws`).
-- Frame payloads are not RPC-typed, so export a shared type (the API exports `HealthEvent` from `@api/hono`) and parse against it on the client.
-- WebSocket routes skip `describeRoute`, the `{ data }` / `{ error }` envelope, and the OpenAPI reference (which only describes HTTP).
+- Frame payloads are not RPC-typed: `ws.send()` takes a raw string and `$ws()` returns a plain `WebSocket`, so parse defensively on the client and read only the fields you need. Don't hand-maintain a shared payload type RPC can't derive.
+- Keep a `describeRoute` so the upgrade lists in the Scalar reference as a `101`, but OpenAPI can't schema-type WS frames and there is no `{ data }` / `{ error }` envelope: describe the frame shape in the route's `description`.
 - `bun --hot` picks up edits to the existing `index.ts` route, but restart the stack if `hono/bun` isn't yet wired into the Bun export.
 
 See `components/marketing/api-status.tsx` for the client with reconnect.

--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -94,4 +94,4 @@ For a live server-to-client stream instead of polling, upgrade a `GET` with `upg
 - Keep a `describeRoute` so the upgrade lists in the Scalar reference as a `101`, but OpenAPI can't schema-type WS frames and there is no `{ data }` / `{ error }` envelope: describe the frame shape in the route's `description`.
 - `bun --hot` picks up edits to the existing `index.ts` route, but restart the stack if `hono/bun` isn't yet wired into the Bun export.
 
-See `components/marketing/api-status.tsx` for the client with reconnect.
+See `components/marketing/api-status.tsx` for the reference client: it uses the socket for a live pulse and falls back to polling REST `/api/health` when the socket can't connect or deliver a frame (serverless, buffered upgrade).

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -16,14 +16,6 @@ import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
 
-// Live payload pushed over /api/health/ws: the REST health data plus an ISO timestamp per heartbeat.
-export type HealthEvent = {
-  message: string
-  version: string
-  environment: typeof env.NODE_ENV
-  timestamp: string
-}
-
 const app = new Hono()
 
 app.use(
@@ -100,18 +92,41 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
   )
   .get(
     "/health/ws",
+    describeRoute({
+      tags: ["System"],
+      description:
+        "Live system health over a WebSocket (Bun). On connect the server sends a snapshot, then a heartbeat every 5s. Each frame is JSON: { message, version, environment, timestamp }.",
+      ...({
+        "x-codeSamples": [
+          {
+            lang: "typescript",
+            label: "hono/client",
+            source: `import { apiClient } from "@/lib/api/client"
+
+const socket = apiClient.health.ws.$ws()
+socket.addEventListener("message", (event) => {
+  const health = JSON.parse(event.data)
+})`,
+          },
+        ],
+      } as object),
+      responses: {
+        101: { description: "Switching Protocols: the WebSocket handshake succeeded." },
+      },
+    }),
     upgradeWebSocket(() => {
       let heartbeat: ReturnType<typeof setInterval> | null = null
-      const snapshot = (): HealthEvent => ({
-        message: "ok",
-        version: BUILD_VERSION,
-        environment: env.NODE_ENV,
-        timestamp: new Date().toISOString(),
-      })
+      const snapshot = () =>
+        JSON.stringify({
+          message: "ok",
+          version: BUILD_VERSION,
+          environment: env.NODE_ENV,
+          timestamp: new Date().toISOString(),
+        })
       return {
         onOpen(_event, ws) {
-          ws.send(JSON.stringify(snapshot()))
-          heartbeat = setInterval(() => ws.send(JSON.stringify(snapshot())), 5000)
+          ws.send(snapshot())
+          heartbeat = setInterval(() => ws.send(snapshot()), 5000)
         },
         onClose() {
           if (heartbeat) clearInterval(heartbeat)

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -4,6 +4,7 @@ import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
+import { upgradeWebSocket, websocket } from "hono/bun"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { logger } from "hono/logger"
@@ -14,6 +15,14 @@ import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
+
+// Live payload pushed over /api/health/ws: the REST health data plus an ISO timestamp per heartbeat.
+export type HealthEvent = {
+  message: string
+  version: string
+  environment: typeof env.NODE_ENV
+  timestamp: string
+}
 
 const app = new Hono()
 
@@ -89,6 +98,27 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
       return c.json({ data })
     },
   )
+  .get(
+    "/health/ws",
+    upgradeWebSocket(() => {
+      let heartbeat: ReturnType<typeof setInterval> | null = null
+      const snapshot = (): HealthEvent => ({
+        message: "ok",
+        version: BUILD_VERSION,
+        environment: env.NODE_ENV,
+        timestamp: new Date().toISOString(),
+      })
+      return {
+        onOpen(_event, ws) {
+          ws.send(JSON.stringify(snapshot()))
+          heartbeat = setInterval(() => ws.send(JSON.stringify(snapshot())), 5000)
+        },
+        onClose() {
+          if (heartbeat) clearInterval(heartbeat)
+        },
+      }
+    }),
+  )
   .route("/agents", agentsRouter)
   .route("/auth", authRouter)
   .route("/v1", v1Router)
@@ -130,4 +160,5 @@ export type { ErrorCode } from "@/lib/error"
 export default {
   port: env.HONO_PORT,
   fetch: app.fetch,
+  websocket,
 }

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -116,10 +116,6 @@ socket.addEventListener("message", (event) => {
     }),
     upgradeWebSocket(() => {
       let heartbeat: ReturnType<typeof setInterval> | null = null
-      const stop = () => {
-        if (heartbeat) clearInterval(heartbeat)
-        heartbeat = null
-      }
       const snapshot = () =>
         JSON.stringify({
           message: "ok",
@@ -132,11 +128,9 @@ socket.addEventListener("message", (event) => {
           ws.send(snapshot())
           heartbeat = setInterval(() => ws.send(snapshot()), 5000)
         },
+        // Bun's WS adapter surfaces every disconnect as close (it has no error event), so this covers all cleanup.
         onClose() {
-          stop()
-        },
-        onError() {
-          stop()
+          if (heartbeat) clearInterval(heartbeat)
         },
       }
     }),

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -116,6 +116,10 @@ socket.addEventListener("message", (event) => {
     }),
     upgradeWebSocket(() => {
       let heartbeat: ReturnType<typeof setInterval> | null = null
+      const stop = () => {
+        if (heartbeat) clearInterval(heartbeat)
+        heartbeat = null
+      }
       const snapshot = () =>
         JSON.stringify({
           message: "ok",
@@ -129,7 +133,10 @@ socket.addEventListener("message", (event) => {
           heartbeat = setInterval(() => ws.send(snapshot()), 5000)
         },
         onClose() {
-          if (heartbeat) clearInterval(heartbeat)
+          stop()
+        },
+        onError() {
+          stop()
         },
       }
     }),

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -91,7 +91,7 @@ const routes = app.basePath("/api").get(
   "/health/ws",
   upgradeWebSocket(() => ({
     onOpen(_event, ws) {
-      ws.send(JSON.stringify(snapshot()))
+      ws.send(JSON.stringify({ message: "ok", version, environment, timestamp }))
     },
   })),
 )

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -110,7 +110,7 @@ socket.addEventListener("message", (event) => {
 })
 ```
 
-Treat the socket as progressive enhancement. A serverless deploy can't hold a long-lived connection, so the reference component (`components/marketing/api-status.tsx`) uses the WebSocket for its live pulse but falls back to polling REST `/api/health` when the socket can't connect or deliver a frame. The badge always reflects real status; only the pulse is socket-only.
+Treat the socket as progressive enhancement. A serverless deploy can't hold a long-lived connection, so the reference component (`components/marketing/api-status.tsx`) uses the WebSocket for its live pulse, retries a transient drop a few times, and falls back to polling REST `/api/health` when the socket can't connect or deliver a frame. The badge always reflects real status; only the pulse is socket-only.
 
 <Callout type="info" title="Frames are not RPC-typed">
 

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -102,18 +102,17 @@ export default { port: env.HONO_PORT, fetch: app.fetch, websocket }
 On the client, the RPC object exposes `$ws()` on the route, so the connection URL stays derived from the same configured API base (`http` becomes `ws`):
 
 ```ts
-import type { HealthEvent } from "@api/hono"
 import { apiClient } from "@/lib/api/client"
 
 const socket = apiClient.health.ws.$ws()
 socket.addEventListener("message", (event) => {
-  const health = JSON.parse(event.data) as HealthEvent
+  const health = JSON.parse(event.data)
 })
 ```
 
 <Callout type="info" title="Frames are not RPC-typed">
 
-`$ws()` types the route path, not the messages on the wire. Share the payload type explicitly: the API exports `HealthEvent` from `@api/hono`, so both ends agree on the shape. WebSocket routes carry no `{ data }` envelope and stay out of the OpenAPI reference, which only describes HTTP. `components/marketing/api-status.tsx` is the reference client, with reconnect.
+`$ws()` types the route _path_, not the messages on the wire: `ws.send()` takes a raw string and the client hands back a standard `WebSocket`, so frame data arrives untyped. Parse defensively and read only what you need (`api-status.tsx` checks `message`). A WebSocket carries no `{ data }` envelope either, and OpenAPI can't schema-type its frames, so the route is listed in the reference as a `101` upgrade with the shape described in prose, not as a typed response.
 
 </Callout>
 

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -77,6 +77,46 @@ The `api-endpoint` skill has the full recipe: the router template, the mandatory
 
 Every route decorated with `describeRoute` shows up in an interactive [Scalar](https://scalar.com) reference at `/api/docs`, with request and response schemas from the Zod validators and code samples that default to `hono/client`. The raw spec is at `/api/openapi.json`.
 
+## Live data over WebSockets
+
+Hono serves [WebSockets](https://hono.dev/docs/helpers/websocket) on Bun, and the same typed client reaches them. The health endpoint ships a live example at `/api/health/ws` that pushes a status snapshot on connect and a heartbeat every few seconds.
+
+A WebSocket route is a `GET` upgraded with `upgradeWebSocket` from `hono/bun`. The shared `websocket` handler is added to the Bun server export next to `fetch`:
+
+```ts
+// api/hono/src/index.ts
+import { upgradeWebSocket, websocket } from "hono/bun"
+
+const routes = app.basePath("/api").get(
+  "/health/ws",
+  upgradeWebSocket(() => ({
+    onOpen(_event, ws) {
+      ws.send(JSON.stringify(snapshot()))
+    },
+  })),
+)
+
+export default { port: env.HONO_PORT, fetch: app.fetch, websocket }
+```
+
+On the client, the RPC object exposes `$ws()` on the route, so the connection URL stays derived from the same configured API base (`http` becomes `ws`):
+
+```ts
+import type { HealthEvent } from "@api/hono"
+import { apiClient } from "@/lib/api/client"
+
+const socket = apiClient.health.ws.$ws()
+socket.addEventListener("message", (event) => {
+  const health = JSON.parse(event.data) as HealthEvent
+})
+```
+
+<Callout type="info" title="Frames are not RPC-typed">
+
+`$ws()` types the route path, not the messages on the wire. Share the payload type explicitly: the API exports `HealthEvent` from `@api/hono`, so both ends agree on the shape. WebSocket routes carry no `{ data }` envelope and stay out of the OpenAPI reference, which only describes HTTP. `components/marketing/api-status.tsx` is the reference client, with reconnect.
+
+</Callout>
+
 ## Next
 
 - [API Conventions](/docs/manage/api-conventions): the `{ data }` / `{ error }` envelope and error codes.

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -110,7 +110,7 @@ socket.addEventListener("message", (event) => {
 })
 ```
 
-Treat the socket as progressive enhancement. A serverless deploy can't hold a long-lived connection, so the reference component (`components/marketing/api-status.tsx`) uses the WebSocket for its live pulse, retries a transient drop a few times, and falls back to polling REST `/api/health` when the socket can't connect or deliver a frame. The badge always reflects real status; only the pulse is socket-only.
+Treat the socket as progressive enhancement over a REST baseline. The reference component (`components/marketing/api-status.tsx`) polls REST `/api/health` whenever no frame is live and overlays a live pulse while the socket streams, reconnecting with capped backoff. So the badge always reflects real status, a serverless deploy that can't hold a socket simply shows the REST-polled state, and only the pulse is socket-only.
 
 <Callout type="info" title="Frames are not RPC-typed">
 

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -110,6 +110,8 @@ socket.addEventListener("message", (event) => {
 })
 ```
 
+Treat the socket as progressive enhancement. A serverless deploy can't hold a long-lived connection, so the reference component (`components/marketing/api-status.tsx`) uses the WebSocket for its live pulse but falls back to polling REST `/api/health` when the socket can't connect or deliver a frame. The badge always reflects real status; only the pulse is socket-only.
+
 <Callout type="info" title="Frames are not RPC-typed">
 
 `$ws()` types the route _path_, not the messages on the wire: `ws.send()` takes a raw string and the client hands back a standard `WebSocket`, so frame data arrives untyped. Parse defensively and read only what you need (`api-status.tsx` checks `message`). A WebSocket carries no `{ data }` envelope either, and OpenAPI can't schema-type its frames, so the route is listed in the reference as a `101` upgrade with the shape described in prose, not as a typed response.

--- a/web/next/src/app/(marketing)/page.tsx
+++ b/web/next/src/app/(marketing)/page.tsx
@@ -274,11 +274,11 @@ docker compose up --build`
                 <RiArrowRightSLine className="size-4 transition-transform group-hover:translate-x-0.5" />
               </Button>
             </div>
+            <div className="mx-auto mt-10 max-w-2xl">
+              <CodeWindow label="Quickstart" html={initHtml} />
+            </div>
             <div className="mt-10 flex justify-center">
               <ApiStatus />
-            </div>
-            <div className="mx-auto mt-6 max-w-2xl">
-              <CodeWindow label="Quickstart" html={initHtml} />
             </div>
           </div>
         </div>

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -1,11 +1,11 @@
 "use client"
 
+import { useQuery } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
-import { apiClient } from "@/lib/api/client"
-
-type ConnectionState = "connecting" | "live" | "down"
+import { apiClient, unwrap } from "@/lib/api/client"
+import { cn } from "@/lib/utils"
 
 // Frames aren't RPC-typed (Hono types the route, not the payload), so read the one field we need defensively.
 function isOperational(raw: unknown): boolean {
@@ -19,38 +19,71 @@ function isOperational(raw: unknown): boolean {
 }
 
 export function ApiStatus() {
-  const [state, setState] = useState<ConnectionState>("connecting")
+  // The WebSocket is the live channel (pulsing dot). If it cannot connect or
+  // deliver a frame (serverless deploy, a proxy that buffers the upgrade), fall
+  // back to polling REST /api/health so the badge still reflects real status.
+  const [wsLive, setWsLive] = useState<boolean | null>(null)
+  const [useRest, setUseRest] = useState(false)
+
+  const rest = useQuery({
+    queryKey: ["api-health"],
+    queryFn: async () => {
+      const { data, error } = await unwrap(apiClient.health.$get())
+      if (error) throw new Error(error.message)
+      return data
+    },
+    enabled: useRest,
+    refetchInterval: 30000,
+  })
 
   useEffect(() => {
     let socket: WebSocket | null = null
-    let reconnect: ReturnType<typeof setTimeout> | null = null
+    let deadline: ReturnType<typeof setTimeout> | null = null
     let stopped = false
+    let fellBack = false
 
-    const connect = () => {
-      socket = apiClient.health.ws.$ws()
-      socket.addEventListener("message", (event) => {
-        setState(isOperational(event.data) ? "live" : "down")
-      })
-      socket.addEventListener("close", () => {
-        if (stopped) return
-        setState("down")
-        reconnect = setTimeout(connect, 3000)
-      })
-      socket.addEventListener("error", () => {
-        if (socket) socket.close()
-      })
+    const fallBack = () => {
+      if (stopped || fellBack) return
+      fellBack = true
+      if (deadline) clearTimeout(deadline)
+      if (socket) socket.close()
+      socket = null
+      setUseRest(true)
     }
 
-    connect()
+    socket = apiClient.health.ws.$ws()
+    socket.addEventListener("message", (event) => {
+      if (stopped || fellBack) return
+      if (deadline) {
+        clearTimeout(deadline)
+        deadline = null
+      }
+      setWsLive(isOperational(event.data))
+    })
+    socket.addEventListener("close", fallBack)
+    socket.addEventListener("error", fallBack)
+    // A socket can open yet never deliver a frame; don't hang in "connecting" forever.
+    deadline = setTimeout(fallBack, 4000)
 
     return () => {
       stopped = true
-      if (reconnect) clearTimeout(reconnect)
+      if (deadline) clearTimeout(deadline)
       if (socket) socket.close()
     }
   }, [])
 
-  if (state === "connecting") {
+  let status: "connecting" | "operational" | "down"
+  let live = false
+  if (useRest) {
+    status = rest.isError ? "down" : rest.data ? "operational" : "connecting"
+  } else if (wsLive === null) {
+    status = "connecting"
+  } else {
+    status = wsLive ? "operational" : "down"
+    live = wsLive
+  }
+
+  if (status === "connecting") {
     return (
       <Badge
         variant="outline"
@@ -64,7 +97,7 @@ export function ApiStatus() {
     )
   }
 
-  if (state === "down") {
+  if (status === "down") {
     return (
       <Badge
         variant="destructive"
@@ -85,7 +118,7 @@ export function ApiStatus() {
       aria-label="API status"
       className="border-success/20 bg-success/10 text-success animate-in fade-in h-8 gap-2 rounded-full border px-4 py-1.5 text-sm duration-2000"
     >
-      <span className="bg-success size-2 shrink-0 animate-pulse rounded-full" />
+      <span className={cn("bg-success size-2 shrink-0 rounded-full", live && "animate-pulse")} />
       <span className="min-w-48 text-center whitespace-nowrap">All systems are operational</span>
     </Badge>
   )

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -7,11 +7,9 @@ import { Badge } from "@/components/ui/badge"
 import { apiClient, unwrap } from "@/lib/api/client"
 import { cn } from "@/lib/utils"
 
-const FRAME_DEADLINE_MS = 4000
-// Rolling watchdog for a half-open socket; must exceed the server's 5s heartbeat so a real gap trips it.
 const HEARTBEAT_TIMEOUT_MS = 12000
-const RETRY_DELAY_MS = 3000
-const RETRY_LIMIT = 3
+const RECONNECT_BASE_MS = 3000
+const RECONNECT_MAX_MS = 30000
 
 // Frames aren't RPC-typed (Hono types the route, not the payload), so read the one field we need defensively.
 function isOperational(raw: unknown): boolean {
@@ -25,10 +23,8 @@ function isOperational(raw: unknown): boolean {
 }
 
 export function ApiStatus() {
-  // wsHealth is the last health seen on the socket; wsConnected is whether a frame is currently streaming (the pulse); useRest is the fallback poll when the socket can't hold.
-  const [wsHealth, setWsHealth] = useState<boolean | null>(null)
-  const [wsConnected, setWsConnected] = useState(false)
-  const [useRest, setUseRest] = useState(false)
+  // REST is the always-honest baseline (polled whenever no frame is live); the socket only overlays a live pulse and faster updates. wsFrame is the latest frame's health, or null when nothing is currently streaming.
+  const [wsFrame, setWsFrame] = useState<boolean | null>(null)
 
   const rest = useQuery({
     queryKey: ["api-health"],
@@ -37,66 +33,54 @@ export function ApiStatus() {
       if (error) throw new Error(error.message)
       return data
     },
-    enabled: useRest,
+    enabled: wsFrame === null,
     refetchInterval: 30000,
   })
 
   useEffect(() => {
     let socket: WebSocket | null = null
-    let deadline: ReturnType<typeof setTimeout> | null = null
-    let retry: ReturnType<typeof setTimeout> | null = null
-    let retries = 0
-    let wasLive = false
+    let watchdog: ReturnType<typeof setTimeout> | null = null
+    let reconnect: ReturnType<typeof setTimeout> | null = null
+    let backoff = 0
     let stopped = false
-
-    const clearTimers = () => {
-      if (deadline) clearTimeout(deadline)
-      if (retry) clearTimeout(retry)
-      deadline = null
-      retry = null
-    }
 
     const connect = () => {
       if (stopped) return
-      socket = apiClient.health.ws.$ws()
-      socket.addEventListener("message", (event) => {
-        if (stopped) return
-        wasLive = true
-        retries = 0
-        setUseRest(false)
-        setWsConnected(true)
-        setWsHealth(isOperational(event.data))
-        // Re-arm the watchdog each frame: a heartbeat gap on a half-open socket must trip onDrop.
-        if (deadline) clearTimeout(deadline)
-        deadline = setTimeout(onDrop, HEARTBEAT_TIMEOUT_MS)
-      })
-      socket.addEventListener("close", onDrop)
-      socket.addEventListener("error", onDrop)
-      // A socket can open yet never deliver a frame; treat 4s of silence as a drop.
-      deadline = setTimeout(onDrop, FRAME_DEADLINE_MS)
-    }
-
-    const onDrop = () => {
-      if (stopped || socket === null) return
-      socket.close()
-      socket = null
-      clearTimers()
-      // No live socket: drop the pulse but keep the last-known health showing until a retry or REST resolves it.
-      setWsConnected(false)
-      // Retry only a connection that had gone live (a transient blip); one that never delivered a frame commits to REST.
-      if (wasLive && retries < RETRY_LIMIT) {
-        retries += 1
-        retry = setTimeout(connect, RETRY_DELAY_MS)
-      } else {
-        setUseRest(true)
+      const ws = apiClient.health.ws.$ws()
+      socket = ws
+      // Ignore events from a socket that has already been superseded, so a late close can't tear down a newer one.
+      const current = () => !stopped && socket === ws
+      const drop = () => {
+        if (!current()) return
+        socket = null
+        setWsFrame(null)
+        if (watchdog) clearTimeout(watchdog)
+        watchdog = null
+        // Capped backoff: a blip reconnects fast, a dead endpoint (serverless) settles into a gentle re-probe while REST carries the badge.
+        reconnect = setTimeout(
+          connect,
+          Math.min(RECONNECT_BASE_MS * 2 ** backoff, RECONNECT_MAX_MS),
+        )
+        backoff += 1
       }
+      ws.addEventListener("message", (event) => {
+        if (!current()) return
+        backoff = 0
+        setWsFrame(isOperational(event.data))
+        // Half-open guard: if heartbeats stop while the socket stays open, treat the gap as a drop.
+        if (watchdog) clearTimeout(watchdog)
+        watchdog = setTimeout(drop, HEARTBEAT_TIMEOUT_MS)
+      })
+      ws.addEventListener("close", drop)
+      ws.addEventListener("error", drop)
     }
 
-    // Re-probe only when settled on REST (no live socket and no pending retry): reset the budget so a genuinely-reachable socket recovers, while bailing mid-burst keeps a flapping socket falling through to REST.
+    // A backgrounded tab often drops the socket; reconnect immediately (and reset backoff) when it returns.
     const onVisible = () => {
-      if (stopped || socket !== null || retry !== null || document.visibilityState !== "visible")
-        return
-      retries = 0
+      if (stopped || socket !== null || document.visibilityState !== "visible") return
+      if (reconnect) clearTimeout(reconnect)
+      reconnect = null
+      backoff = 0
       connect()
     }
 
@@ -105,7 +89,8 @@ export function ApiStatus() {
 
     return () => {
       stopped = true
-      clearTimers()
+      if (watchdog) clearTimeout(watchdog)
+      if (reconnect) clearTimeout(reconnect)
       if (socket) socket.close()
       document.removeEventListener("visibilitychange", onVisible)
     }
@@ -113,11 +98,13 @@ export function ApiStatus() {
 
   let status: "connecting" | "operational" | "down"
   let live = false
-  if (useRest) {
-    status = rest.isError ? "down" : rest.data ? "operational" : "connecting"
-  } else if (wsConnected && wsHealth !== null) {
-    status = wsHealth ? "operational" : "down"
-    live = wsHealth
+  if (wsFrame !== null) {
+    status = wsFrame ? "operational" : "down"
+    live = wsFrame
+  } else if (rest.isError) {
+    status = "down"
+  } else if (rest.data) {
+    status = "operational"
   } else {
     status = "connecting"
   }

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -25,11 +25,9 @@ function isOperational(raw: unknown): boolean {
 }
 
 export function ApiStatus() {
-  // The WebSocket is the live channel (pulsing dot). A socket that was live and
-  // blips gets a few quick retries; one that never connects (serverless deploy,
-  // a proxy that buffers the upgrade) falls straight to polling REST /api/health,
-  // so the badge always reflects real status and only the pulse is socket-only.
-  const [wsLive, setWsLive] = useState<boolean | null>(null)
+  // wsHealth is the last health seen on the socket; wsConnected is whether a frame is currently streaming (the pulse); useRest is the fallback poll when the socket can't hold.
+  const [wsHealth, setWsHealth] = useState<boolean | null>(null)
+  const [wsConnected, setWsConnected] = useState(false)
   const [useRest, setUseRest] = useState(false)
 
   const rest = useQuery({
@@ -66,7 +64,8 @@ export function ApiStatus() {
         wasLive = true
         retries = 0
         setUseRest(false)
-        setWsLive(isOperational(event.data))
+        setWsConnected(true)
+        setWsHealth(isOperational(event.data))
         // Re-arm the watchdog each frame: a heartbeat gap on a half-open socket must trip onDrop.
         if (deadline) clearTimeout(deadline)
         deadline = setTimeout(onDrop, HEARTBEAT_TIMEOUT_MS)
@@ -82,8 +81,9 @@ export function ApiStatus() {
       socket.close()
       socket = null
       clearTimers()
-      // Retry only a connection that had gone live (a transient blip); a socket
-      // that never delivered a frame commits to REST straight away.
+      // No live socket: drop the pulse but keep the last-known health showing until a retry or REST resolves it.
+      setWsConnected(false)
+      // Retry only a connection that had gone live (a transient blip); one that never delivered a frame commits to REST.
       if (wasLive && retries < RETRY_LIMIT) {
         retries += 1
         retry = setTimeout(connect, RETRY_DELAY_MS)
@@ -92,12 +92,10 @@ export function ApiStatus() {
       }
     }
 
-    // When the tab comes back to the foreground, give the socket another chance.
-    // Cancel any pending reconnect first so we never open a second overlapping socket.
+    // On refocus, retry the socket; cancel any pending reconnect first so we never open a second overlapping socket. A recovered frame resets the retry budget, so don't zero it here (that could starve the REST fallback).
     const onVisible = () => {
       if (stopped || socket !== null || document.visibilityState !== "visible") return
       clearTimers()
-      retries = 0
       connect()
     }
 
@@ -116,11 +114,11 @@ export function ApiStatus() {
   let live = false
   if (useRest) {
     status = rest.isError ? "down" : rest.data ? "operational" : "connecting"
-  } else if (wsLive === null) {
+  } else if (wsHealth === null) {
     status = "connecting"
   } else {
-    status = wsLive ? "operational" : "down"
-    live = wsLive
+    status = wsHealth ? "operational" : "down"
+    live = wsConnected
   }
 
   if (status === "connecting") {

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import type { HealthEvent } from "@api/hono"
 import { useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
@@ -8,12 +7,14 @@ import { apiClient } from "@/lib/api/client"
 
 type ConnectionState = "connecting" | "live" | "down"
 
-function parseHealthEvent(raw: unknown): HealthEvent | null {
-  if (typeof raw !== "string") return null
+// Frames aren't RPC-typed (Hono types the route, not the payload), so read the one field we need defensively.
+function isOperational(raw: unknown): boolean {
+  if (typeof raw !== "string") return false
   try {
-    return JSON.parse(raw) as HealthEvent
+    const frame = JSON.parse(raw) as { message?: unknown }
+    return frame.message === "ok"
   } catch {
-    return null
+    return false
   }
 }
 
@@ -28,8 +29,7 @@ export function ApiStatus() {
     const connect = () => {
       socket = apiClient.health.ws.$ws()
       socket.addEventListener("message", (event) => {
-        const health = parseHealthEvent(event.data)
-        setState(health && health.message === "ok" ? "live" : "down")
+        setState(isOperational(event.data) ? "live" : "down")
       })
       socket.addEventListener("close", () => {
         if (stopped) return

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -91,9 +91,11 @@ export function ApiStatus() {
       }
     }
 
-    // When the tab comes back to the foreground and we've settled on REST, give the socket another chance.
+    // When the tab comes back to the foreground, give the socket another chance.
+    // Cancel any pending reconnect first so we never open a second overlapping socket.
     const onVisible = () => {
       if (stopped || socket !== null || document.visibilityState !== "visible") return
+      clearTimers()
       retries = 0
       connect()
     }

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -52,6 +52,8 @@ export function ApiStatus() {
       const current = () => !stopped && socket === ws
       const drop = () => {
         if (!current()) return
+        // Close it ourselves: on the watchdog path the socket is still OPEN, and closing lets the server's onClose clear its heartbeat instead of streaming to a dead peer (a no-op once close/error already fired).
+        ws.close()
         socket = null
         setWsFrame(null)
         if (watchdog) clearTimeout(watchdog)

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -92,10 +92,11 @@ export function ApiStatus() {
       }
     }
 
-    // On refocus, retry the socket; cancel any pending reconnect first so we never open a second overlapping socket. A recovered frame resets the retry budget, so don't zero it here (that could starve the REST fallback).
+    // Re-probe only when settled on REST (no live socket and no pending retry): reset the budget so a genuinely-reachable socket recovers, while bailing mid-burst keeps a flapping socket falling through to REST.
     const onVisible = () => {
-      if (stopped || socket !== null || document.visibilityState !== "visible") return
-      clearTimers()
+      if (stopped || socket !== null || retry !== null || document.visibilityState !== "visible")
+        return
+      retries = 0
       connect()
     }
 
@@ -114,11 +115,11 @@ export function ApiStatus() {
   let live = false
   if (useRest) {
     status = rest.isError ? "down" : rest.data ? "operational" : "connecting"
-  } else if (wsHealth === null) {
-    status = "connecting"
-  } else {
+  } else if (wsConnected && wsHealth !== null) {
     status = wsHealth ? "operational" : "down"
-    live = wsConnected
+    live = wsHealth
+  } else {
+    status = "connecting"
   }
 
   if (status === "connecting") {

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -8,6 +8,8 @@ import { apiClient, unwrap } from "@/lib/api/client"
 import { cn } from "@/lib/utils"
 
 const FRAME_DEADLINE_MS = 4000
+// Rolling watchdog for a half-open socket; must exceed the server's 5s heartbeat so a real gap trips it.
+const HEARTBEAT_TIMEOUT_MS = 12000
 const RETRY_DELAY_MS = 3000
 const RETRY_LIMIT = 3
 
@@ -61,14 +63,13 @@ export function ApiStatus() {
       socket = apiClient.health.ws.$ws()
       socket.addEventListener("message", (event) => {
         if (stopped) return
-        if (deadline) {
-          clearTimeout(deadline)
-          deadline = null
-        }
         wasLive = true
         retries = 0
         setUseRest(false)
         setWsLive(isOperational(event.data))
+        // Re-arm the watchdog each frame: a heartbeat gap on a half-open socket must trip onDrop.
+        if (deadline) clearTimeout(deadline)
+        deadline = setTimeout(onDrop, HEARTBEAT_TIMEOUT_MS)
       })
       socket.addEventListener("close", onDrop)
       socket.addEventListener("error", onDrop)

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -7,6 +7,10 @@ import { Badge } from "@/components/ui/badge"
 import { apiClient, unwrap } from "@/lib/api/client"
 import { cn } from "@/lib/utils"
 
+const FRAME_DEADLINE_MS = 4000
+const RETRY_DELAY_MS = 3000
+const RETRY_LIMIT = 3
+
 // Frames aren't RPC-typed (Hono types the route, not the payload), so read the one field we need defensively.
 function isOperational(raw: unknown): boolean {
   if (typeof raw !== "string") return false
@@ -19,9 +23,10 @@ function isOperational(raw: unknown): boolean {
 }
 
 export function ApiStatus() {
-  // The WebSocket is the live channel (pulsing dot). If it cannot connect or
-  // deliver a frame (serverless deploy, a proxy that buffers the upgrade), fall
-  // back to polling REST /api/health so the badge still reflects real status.
+  // The WebSocket is the live channel (pulsing dot). A socket that was live and
+  // blips gets a few quick retries; one that never connects (serverless deploy,
+  // a proxy that buffers the upgrade) falls straight to polling REST /api/health,
+  // so the badge always reflects real status and only the pulse is socket-only.
   const [wsLive, setWsLive] = useState<boolean | null>(null)
   const [useRest, setUseRest] = useState(false)
 
@@ -39,36 +44,68 @@ export function ApiStatus() {
   useEffect(() => {
     let socket: WebSocket | null = null
     let deadline: ReturnType<typeof setTimeout> | null = null
+    let retry: ReturnType<typeof setTimeout> | null = null
+    let retries = 0
+    let wasLive = false
     let stopped = false
-    let fellBack = false
 
-    const fallBack = () => {
-      if (stopped || fellBack) return
-      fellBack = true
+    const clearTimers = () => {
       if (deadline) clearTimeout(deadline)
-      if (socket) socket.close()
-      socket = null
-      setUseRest(true)
+      if (retry) clearTimeout(retry)
+      deadline = null
+      retry = null
     }
 
-    socket = apiClient.health.ws.$ws()
-    socket.addEventListener("message", (event) => {
-      if (stopped || fellBack) return
-      if (deadline) {
-        clearTimeout(deadline)
-        deadline = null
+    const connect = () => {
+      if (stopped) return
+      socket = apiClient.health.ws.$ws()
+      socket.addEventListener("message", (event) => {
+        if (stopped) return
+        if (deadline) {
+          clearTimeout(deadline)
+          deadline = null
+        }
+        wasLive = true
+        retries = 0
+        setUseRest(false)
+        setWsLive(isOperational(event.data))
+      })
+      socket.addEventListener("close", onDrop)
+      socket.addEventListener("error", onDrop)
+      // A socket can open yet never deliver a frame; treat 4s of silence as a drop.
+      deadline = setTimeout(onDrop, FRAME_DEADLINE_MS)
+    }
+
+    const onDrop = () => {
+      if (stopped || socket === null) return
+      socket.close()
+      socket = null
+      clearTimers()
+      // Retry only a connection that had gone live (a transient blip); a socket
+      // that never delivered a frame commits to REST straight away.
+      if (wasLive && retries < RETRY_LIMIT) {
+        retries += 1
+        retry = setTimeout(connect, RETRY_DELAY_MS)
+      } else {
+        setUseRest(true)
       }
-      setWsLive(isOperational(event.data))
-    })
-    socket.addEventListener("close", fallBack)
-    socket.addEventListener("error", fallBack)
-    // A socket can open yet never deliver a frame; don't hang in "connecting" forever.
-    deadline = setTimeout(fallBack, 4000)
+    }
+
+    // When the tab comes back to the foreground and we've settled on REST, give the socket another chance.
+    const onVisible = () => {
+      if (stopped || socket !== null || document.visibilityState !== "visible") return
+      retries = 0
+      connect()
+    }
+
+    connect()
+    document.addEventListener("visibilitychange", onVisible)
 
     return () => {
       stopped = true
-      if (deadline) clearTimeout(deadline)
+      clearTimers()
       if (socket) socket.close()
+      document.removeEventListener("visibilitychange", onVisible)
     }
   }, [])
 

--- a/web/next/src/components/marketing/api-status.tsx
+++ b/web/next/src/components/marketing/api-status.tsx
@@ -1,22 +1,56 @@
 "use client"
 
-import { useQuery } from "@tanstack/react-query"
+import type { HealthEvent } from "@api/hono"
+import { useEffect, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
-import { apiClient, unwrap } from "@/lib/api/client"
+import { apiClient } from "@/lib/api/client"
+
+type ConnectionState = "connecting" | "live" | "down"
+
+function parseHealthEvent(raw: unknown): HealthEvent | null {
+  if (typeof raw !== "string") return null
+  try {
+    return JSON.parse(raw) as HealthEvent
+  } catch {
+    return null
+  }
+}
 
 export function ApiStatus() {
-  const { isLoading, isError } = useQuery({
-    queryKey: ["api-health"],
-    queryFn: async () => {
-      const { data, error } = await unwrap(apiClient.health.$get())
-      if (error) throw new Error(error.message)
-      return data
-    },
-    refetchInterval: 30000,
-  })
+  const [state, setState] = useState<ConnectionState>("connecting")
 
-  if (isLoading) {
+  useEffect(() => {
+    let socket: WebSocket | null = null
+    let reconnect: ReturnType<typeof setTimeout> | null = null
+    let stopped = false
+
+    const connect = () => {
+      socket = apiClient.health.ws.$ws()
+      socket.addEventListener("message", (event) => {
+        const health = parseHealthEvent(event.data)
+        setState(health && health.message === "ok" ? "live" : "down")
+      })
+      socket.addEventListener("close", () => {
+        if (stopped) return
+        setState("down")
+        reconnect = setTimeout(connect, 3000)
+      })
+      socket.addEventListener("error", () => {
+        if (socket) socket.close()
+      })
+    }
+
+    connect()
+
+    return () => {
+      stopped = true
+      if (reconnect) clearTimeout(reconnect)
+      if (socket) socket.close()
+    }
+  }, [])
+
+  if (state === "connecting") {
     return (
       <Badge
         variant="outline"
@@ -30,7 +64,7 @@ export function ApiStatus() {
     )
   }
 
-  if (isError) {
+  if (state === "down") {
     return (
       <Badge
         variant="destructive"
@@ -51,7 +85,7 @@ export function ApiStatus() {
       aria-label="API status"
       className="border-success/20 bg-success/10 text-success animate-in fade-in h-8 gap-2 rounded-full border px-4 py-1.5 text-sm duration-2000"
     >
-      <span className="bg-success size-2 shrink-0 rounded-full" />
+      <span className="bg-success size-2 shrink-0 animate-pulse rounded-full" />
       <span className="min-w-48 text-center whitespace-nowrap">All systems are operational</span>
     </Badge>
   )


### PR DESCRIPTION
## Summary

Introduces WebSocket support to the stack, using the health endpoint as the live demo. The landing page's "All systems are operational" badge shows a live pulse from a WebSocket, over a REST poll that keeps it honest.

## What changed

**Backend** (`api/hono/src/index.ts`)
- New `/api/health/ws` route: a `GET` upgraded with `upgradeWebSocket` from `hono/bun`. Pushes a health snapshot on connect, then a heartbeat every 5s; the interval is cleared in `onClose` (Bun's WS adapter surfaces every disconnect as `close`).
- The shared `websocket` handler is registered on the Bun server export next to `fetch`.
- Documented with `describeRoute`, so it lists in the Scalar reference at `/api/docs` as a `101` upgrade. OpenAPI can't schema-type WS frames, so the frame shape is described in prose.
- The REST `/api/health` endpoint is untouched.

**Frontend** (`components/marketing/api-status.tsx`)
- REST is the always-honest baseline: `apiClient.health.$get()` is polled (TanStack Query) whenever no frame is live, and the socket (`apiClient.health.ws.$ws()`) overlays a live pulse while it streams. The badge prefers a live frame and otherwise reflects REST.
- The socket reconnects with capped exponential backoff (reset on a frame and on tab refocus), a rolling 12s heartbeat watchdog catches a half-open connection, and a socket-identity guard stops a superseded socket's late events from disturbing a newer one. Frames aren't RPC-typed, so it parses defensively and reads `message`.
- Moved the status badge below the Quickstart window in the hero.

**Docs**
- "Live data over WebSockets" section in the type-safe API guide, and a "WebSocket routes" section in the `api-endpoint` skill (including a note that CORS doesn't gate a WS handshake).

## Verification

`check-types` (12/12), `oxlint`, `oxfmt --check`, and docs strict-validation all pass. Verified end-to-end in a real browser.

- WebSocket probe: snapshot on connect, heartbeat at 5s, clean close.
- `/api/openapi.json` lists `/api/health/ws` (GET -> `101`) under the **System** tag; `/api/docs` renders it.
- Live: green dot with `animate-pulse`.
- WS unavailable but API up (serverless-like): green **static** dot via the REST baseline, no pulse.
- Outage: killing the API flips the badge from green to `connecting`, then REST surfaces it as `down`; on restart the pulse recovers.

### Before / after (hero)

| Before (poll, badge above Quickstart) | After (WS live, badge below Quickstart) |
| --- | --- |
| ![before](https://litter.catbox.moe/m2e8oi.png) | ![after](https://litter.catbox.moe/qlzg21.png) |

## Deployment

WebSockets hold under Bun (local + Docker/self-hosted) but not on standard Vercel serverless functions. Since REST is the baseline, a serverless deploy simply shows a normal green (non-pulsing) badge; the live pulse appears wherever the socket holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
