### PR TITLE
refactor(env): validate server env at runtime, not at build time

### DIFF
--- a/api/hono/tsdown.config.ts
+++ b/api/hono/tsdown.config.ts
@@ -1,10 +1,5 @@
 import { definePackageConfig } from "@packages/config/tsdown"
-import { getSafeEnv } from "@packages/env"
-import { env } from "@packages/env/api-hono"
 
 export default definePackageConfig({
-  name: "@api/hono",
-  env,
-  getSafeEnv,
   deps: { alwaysBundle: [/^@packages\//], neverBundle: ["bun"] },
 })

--- a/packages/auth/tsdown.config.ts
+++ b/packages/auth/tsdown.config.ts
@@ -2,5 +2,5 @@ import { definePackageConfig } from "@packages/config/tsdown"
 import { getSafeEnv } from "@packages/env"
 import { env } from "@packages/env/auth"
 
-// `env` and `getSafeEnv` are passed only to keep these imports in the tsconfig program (auth's tsconfig includes this file). Better-auth's inferred `auth` type references a zod internal, and the zod re-exported through `@packages/env` is what keeps that reference nameable so tsgo can emit the dts. `env` is lazy, so importing it here does not validate at build time.
+// Unused at build, but kept: this file is in auth's tsconfig program, and the zod re-exported through @packages/env keeps better-auth's zod-referencing `auth` type nameable so tsgo can emit its dts. `env` is lazy, so importing it does not validate.
 export default definePackageConfig({ env, getSafeEnv })

--- a/packages/auth/tsdown.config.ts
+++ b/packages/auth/tsdown.config.ts
@@ -2,4 +2,5 @@ import { definePackageConfig } from "@packages/config/tsdown"
 import { getSafeEnv } from "@packages/env"
 import { env } from "@packages/env/auth"
 
-export default definePackageConfig({ name: "@packages/auth", env, getSafeEnv })
+// `env` and `getSafeEnv` are passed only to keep these imports in the tsconfig program (auth's tsconfig includes this file). Better-auth's inferred `auth` type references a zod internal, and the zod re-exported through `@packages/env` is what keeps that reference nameable so tsgo can emit the dts. `env` is lazy, so importing it here does not validate at build time.
+export default definePackageConfig({ env, getSafeEnv })

--- a/packages/config/tsdown.ts
+++ b/packages/config/tsdown.ts
@@ -5,7 +5,7 @@ type BundleDeps = {
   alwaysBundle?: (string | RegExp)[]
 }
 
-// Shared tsdown config for the backend packages: emits tsgo dts and minifies. It never reads env, so building a package does not validate env; each env file is validated at runtime by the package that owns it. The optional `env` is accepted only so a caller can keep its env import in the package's tsconfig program (auth's dts generation needs the zod reference that import transitively provides) without it counting as unused; it is never read here.
+// Shared tsdown config: never reads env, so building a package never validates it. env/getSafeEnv are accepted but intentionally unused, for callers that keep a required @packages/env import (see packages/auth/tsdown.config.ts).
 export function definePackageConfig(
   options: { env?: unknown; getSafeEnv?: unknown; deps?: BundleDeps } = {},
 ) {

--- a/packages/config/tsdown.ts
+++ b/packages/config/tsdown.ts
@@ -5,25 +5,17 @@ type BundleDeps = {
   alwaysBundle?: (string | RegExp)[]
 }
 
-// Shared tsdown config for the backend packages: validates env in build:prepare via the caller's getSafeEnv (passed in so this package stays env-agnostic, avoiding a config<->env cycle), emits tsgo dts, and minifies. Callers supply only their name, env, and any bundle overrides.
-export function definePackageConfig(options: {
-  name: string
-  env: Record<string, unknown>
-  getSafeEnv: (env: Record<string, unknown>, name?: string) => unknown
-  deps?: BundleDeps
-}) {
-  const { name, env, getSafeEnv, deps } = options
+// Shared tsdown config for the backend packages: emits tsgo dts and minifies. It never reads env, so building a package does not validate env; each env file is validated at runtime by the package that owns it. The optional `env` is accepted only so a caller can keep its env import in the package's tsconfig program (auth's dts generation needs the zod reference that import transitively provides) without it counting as unused; it is never read here.
+export function definePackageConfig(
+  options: { env?: unknown; getSafeEnv?: unknown; deps?: BundleDeps } = {},
+) {
+  const { deps } = options
 
   return [
     defineConfig({
       ...(deps ? { deps } : {}),
       dts: { tsgo: true },
       entry: ["src/index.ts"],
-      hooks: {
-        "build:prepare": () => {
-          getSafeEnv(env, name)
-        },
-      },
       minify: true,
     }),
   ]

--- a/packages/db/tsdown.config.ts
+++ b/packages/db/tsdown.config.ts
@@ -1,10 +1,5 @@
 import { definePackageConfig } from "@packages/config/tsdown"
-import { getSafeEnv } from "@packages/env"
-import { env } from "@packages/env/db"
 
 export default definePackageConfig({
-  name: "@packages/db",
-  env,
-  getSafeEnv,
   deps: { neverBundle: ["bun"] },
 })

--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -3,31 +3,35 @@ import { z } from "zod"
 
 import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
+import { lazyEnv } from "@/lib/lazy"
 
-export const env = createEnv({
-  server: {
-    NODE_ENV,
-    BETTER_AUTH_SECRET: z.string().min(1),
-    GITHUB_CLIENT_ID: z.string().min(1).optional(),
-    GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
-    GOOGLE_CLIENT_ID: z.string().min(1).optional(),
-    GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
-    HONO_APP_URL: z.url(),
-    HONO_TRUSTED_ORIGINS: z
-      .string()
-      .transform((s) => s.split(",").map((v) => v.trim().replace(/\/$/, "")))
-      .pipe(z.array(z.url())),
-  },
-  runtimeEnv: {
-    NODE_ENV: process.env.NODE_ENV,
-    BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
-    GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
-    GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
-    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
-    HONO_APP_URL: process.env.HONO_APP_URL,
-    HONO_TRUSTED_ORIGINS: process.env.HONO_TRUSTED_ORIGINS,
-  },
-  emptyStringAsUndefined: true,
-  skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
-})
+// Lazy so that importing this module (e.g. in auth's tsdown.config.ts) does not validate at build time; the auth server validates it on first access at runtime.
+export const env = lazyEnv(() =>
+  createEnv({
+    server: {
+      NODE_ENV,
+      BETTER_AUTH_SECRET: z.string().min(1),
+      GITHUB_CLIENT_ID: z.string().min(1).optional(),
+      GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
+      GOOGLE_CLIENT_ID: z.string().min(1).optional(),
+      GOOGLE_CLIENT_SECRET: z.string().min(1).optional(),
+      HONO_APP_URL: z.url(),
+      HONO_TRUSTED_ORIGINS: z
+        .string()
+        .transform((s) => s.split(",").map((v) => v.trim().replace(/\/$/, "")))
+        .pipe(z.array(z.url())),
+    },
+    runtimeEnv: {
+      NODE_ENV: process.env.NODE_ENV,
+      BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+      GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
+      GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
+      GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+      GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
+      HONO_APP_URL: process.env.HONO_APP_URL,
+      HONO_TRUSTED_ORIGINS: process.env.HONO_TRUSTED_ORIGINS,
+    },
+    emptyStringAsUndefined: true,
+    skipValidation: process.env.SKIP_ENV_VALIDATION === "true",
+  }),
+)

--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -5,7 +5,6 @@ import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
 import { lazyEnv } from "@/lib/lazy"
 
-// Lazy so that importing this module (e.g. in auth's tsdown.config.ts) does not validate at build time; the auth server validates it on first access at runtime.
 export const env = lazyEnv(() =>
   createEnv({
     server: {

--- a/packages/env/src/lib/lazy.ts
+++ b/packages/env/src/lib/lazy.ts
@@ -1,4 +1,4 @@
-// Wraps a createEnv factory so validation runs on first property access, not at import. A build tool (tsdown) that only imports a lazy env never triggers validation, so building a package does not require that package's runtime variables; the owning code validates them when it actually reads the env.
+// Defers createEnv (and its validation) to first property access, so importing a lazy env never validates; the owner validates on first read at runtime.
 export function lazyEnv<T extends object>(create: () => T): T {
   let cached: T | undefined
   const resolve = () => (cached ??= create())

--- a/packages/env/src/lib/lazy.ts
+++ b/packages/env/src/lib/lazy.ts
@@ -1,0 +1,17 @@
+// Wraps a createEnv factory so validation runs on first property access, not at import. A build tool (tsdown) that only imports a lazy env never triggers validation, so building a package does not require that package's runtime variables; the owning code validates them when it actually reads the env.
+export function lazyEnv<T extends object>(create: () => T): T {
+  let cached: T | undefined
+  const resolve = () => (cached ??= create())
+
+  return new Proxy({} as T, {
+    get: (_, key, receiver) => Reflect.get(resolve(), key, receiver),
+    has: (_, key) => Reflect.has(resolve(), key),
+    ownKeys: () => Reflect.ownKeys(resolve()),
+    getOwnPropertyDescriptor: (_, key) => {
+      const descriptor = Reflect.getOwnPropertyDescriptor(resolve(), key)
+      // The proxy target is an empty object, so a real key must be reported configurable to satisfy the invariant.
+      if (descriptor) descriptor.configurable = true
+      return descriptor
+    },
+  })
+}


### PR DESCRIPTION
Makes env a **runtime** concern instead of a build-time one, so building a package never requires another package's variables. Concretely: a Next.js frontend build no longer demands `POSTGRES_URL` (or `BETTER_AUTH_SECRET`, etc.) — each env file is validated at runtime by the package that owns it.

## The problem

The web build is `turbo build --filter=@web/next`, which builds the whole dependency graph including `@packages/db`, `@packages/auth`, `@api/hono`. Each of those `tsdown.config.ts` did `import { env } from "@packages/env/<pkg>"`, and t3-env's `createEnv` validates eagerly at import — so merely *loading the build config* validated that package's server env. Building the frontend therefore required every server secret, none of which it uses. (This is what caused the recent web deploy failure after those "unused" vars were removed from Vercel.)

## The fix

- `definePackageConfig` (`packages/config/tsdown.ts`) no longer reads env — no `build:prepare` validation hook. Building a package validates nothing.
- `db` and `api-hono` drop env from their tsdown configs entirely.
- `@packages/env/auth` is now **lazy** (`lazyEnv` in `packages/env/src/lib/lazy.ts`): `createEnv` runs on first property access, not at import. The auth server validates on first access at runtime; the build never does.
- Each env still validates at runtime (verified: accessing `db`/`auth` env with a required var missing throws; `next build` still validates the `NEXT_PUBLIC_*` client vars for inlining).

## Why not just annotate the type (the "clean" alternative)

`@packages/auth`'s `betterAuth(...)` export has an inferred type that references a zod-v4 internal (`$strip`), which isn't dts-portable. Annotating it (`auth: Auth` / `as unknown as Auth`) makes dts build but **widens the type and breaks the app** — `activeOrganizationId` (org plugin) and `role` (admin plugin) disappear from the inferred `Session`/`User`, which `(protected)/layout.tsx` and `console.ts` depend on. There is no self-contained annotation that keeps the plugin types. So auth's tsdown config keeps a `@packages/env` import purely to hold a zod reference in its tsconfig program (it `include: ["**/*.ts"]`) so tsgo can emit the dts — documented inline. The env is lazy, so this import doesn't validate at build.

## Verification

- `bunx turbo build check-types` — **14/14 pass with all server env UNSET and no `SKIP_ENV_VALIDATION`** (only the client vars a web build needs). This is the goal.
- Runtime validation preserved: `env.POSTGRES_URL` / `env.BETTER_AUTH_SECRET` throw on access when unset, return the value when set.
- `oxlint` + `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
