### PR TITLE
fix(web): don't flash Login in navbar before session resolves

### DIFF
--- a/web/next/src/components/access.tsx
+++ b/web/next/src/components/access.tsx
@@ -28,7 +28,7 @@ const formSchema = z.object({
   email: z.email({ error: "Please enter a valid email address." }),
 })
 
-export function Access() {
+export function Access({ labelClassName }: { labelClassName?: string }) {
   const pathname = usePathname()
   const [loader, setLoader] = useState<"email" | "github" | "google" | null>(null)
   const [open, setOpen] = useState(false)
@@ -85,7 +85,9 @@ export function Access() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger render={<Button className="w-24" variant="outline" />}>Login</DialogTrigger>
+      <DialogTrigger render={<Button className="w-24" variant="outline" />}>
+        <span className={labelClassName}>Login</span>
+      </DialogTrigger>
       <DialogContent className="max-w-md" initialFocus={false}>
         <DialogHeader className="sr-only">
           <DialogTitle className="text-center">Sign in/up</DialogTitle>

--- a/web/next/src/components/navbar/home.tsx
+++ b/web/next/src/components/navbar/home.tsx
@@ -69,7 +69,7 @@ function SocialLinks({ onClick }: { onClick?: () => void }) {
 
 export function Navbar() {
   const pathname = usePathname()
-  const { data: session } = authClient.useSession()
+  const { data: session, isPending } = authClient.useSession()
 
   const [toDashboard, setToDashboard] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
@@ -132,7 +132,15 @@ export function Navbar() {
             <SocialLinks />
           </div>
 
-          {session?.user ? (
+          {/* Shell paints immediately; only the label fades in once auth resolves, so the box never pops and a logged-in user never sees a flash of Login. */}
+          {isPending ? (
+            <Button
+              className="pointer-events-none w-24"
+              variant="outline"
+              aria-hidden
+              tabIndex={-1}
+            />
+          ) : session?.user ? (
             <Button
               role="link"
               className="w-24"
@@ -140,10 +148,14 @@ export function Navbar() {
               onClick={() => setToDashboard(true)}
               render={<Link href="/dashboard" />}
             >
-              {toDashboard ? <Spinner /> : "Dashboard"}
+              {toDashboard ? (
+                <Spinner />
+              ) : (
+                <span className="animate-in fade-in duration-1000">Dashboard</span>
+              )}
             </Button>
           ) : (
-            <Access />
+            <Access labelClassName="animate-in fade-in duration-1000" />
           )}
 
           <div className="lg:-mr-2.5">


### PR DESCRIPTION
## Problem

The navbar auth button read only `data: session` from `useSession()`. During the initial session fetch, `session` is `null`, so the ternary fell through to the **Login** branch. A logged-in user saw a fully clickable **Login** button until the session resolved, and could open the sign-in dialog despite being signed in.

## Fix

Gate the button on `isPending` (mirroring the `ApiStatus` connecting → fade-in pattern), giving three states:

1. **Auth unknown (`isPending`)** — render the outlined `w-24` shell **empty and non-interactive** (`pointer-events-none`, `aria-hidden`, `tabIndex={-1}`). No label, so the wrong word never shows.
2. **Logged in** — the shell becomes the **Dashboard** link; only the label text fades in (`animate-in fade-in duration-1000`).
3. **Logged out** — the shell becomes the **Login** trigger; only the label text fades in.

The outlined box is identical across all three states, so it never pops or shifts. Because the fade starts only after auth resolves, the label uses a 1s (not 2s) fade so it settles quickly.

`Access` gained a `labelClassName` prop so the navbar can fade just the "Login" text, leaving its shell painted from the start.

## Behavior change

- **Before:** logged-in users briefly saw (and could click) **Login**.
- **After:** a neutral empty outlined box shows only while auth is unknown (a short window on full page load), then the correct label fades in. Never the wrong label, never clickable before it's known.

## Verification

Type-check clean; build + lint passed on commit. Verified in a real browser (agent-browser) on dev (`:3000` / API `:4000`):

- Logged out → shell renders **Login** (`<span class="animate-in fade-in duration-1000">Login</span>`), shell button carries no fade class.
- Signed in as `LocalAgent` → homepage navbar renders **Dashboard** link, no Login flash.

| Logged out | Logged in |
| --- | --- |
| ![logged out](https://litter.catbox.moe/7yx9pe.png) | ![logged in](https://litter.catbox.moe/dbxgzo.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the top navigation auth state so the “Dashboard”/“Login” area no longer flickers while sign-in status is loading.
  * Added a neutral loading placeholder in place of the auth button until the session is resolved.
  * Updated the login trigger styling to support a customizable label appearance where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->