### PR TITLE
feat(web): add inscope to hire page npm projects

### DIFF
--- a/web/next/src/app/(marketing)/hire/page.tsx
+++ b/web/next/src/app/(marketing)/hire/page.tsx
@@ -112,6 +112,12 @@ const sections: {
         description: "The easiest way to write Karabiner-Elements configuration files, ever!",
       },
       {
+        href: "https://github.com/nrjdalal/inscope",
+        title: "inscope",
+        description:
+          "Per-workspace identity for Claude Code: each directory auto-resolves its own login, MCP servers, GitHub account, and skills.",
+      },
+      {
         href: "https://github.com/nrjdalal/pglaunch",
         title: "pglaunch",
         description:


### PR DESCRIPTION
## What

Adds **inscope** to the `npm` section of the hire page (`web/next/src/app/(marketing)/hire/page.tsx`).

- Placed **4th** in the npm list (GitPick → Smart Registry → Karabiner Human Config → **inscope** → pglaunch), keeping the established flagships up top.
- Links to `github.com/nrjdalal/inscope`, with a one-liner matching the section's voice.
- Résumé page intentionally left unchanged (its "selected projects" stays a star-ranked "strongest" set).

## Verification

- `bun run check-types` passes.
- Verified in a real browser at `/hire`; renders in the correct slot with consistent styling and the external-link arrow.

![hire page npm section with inscope](https://litter.catbox.moe/1in9w9.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added "inscope" project entry to the hire section—a workspace identity management solution for Claude Code with per-directory configuration for login, MCP servers, GitHub integration, and skills resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->