### PR TITLE
feat(web): use shadcn/typeset for docs and blog typography

### DIFF
--- a/web/next/src/app/globals.css
+++ b/web/next/src/app/globals.css
@@ -3,6 +3,7 @@
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 @import "shadcn/tailwind.css";
+@import "./typeset.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/web/next/src/app/globals.css
+++ b/web/next/src/app/globals.css
@@ -147,3 +147,18 @@
     @apply mt-0;
   }
 }
+
+/* shadcn/typeset preset for docs + blog. Tune here or regenerate on https://ui.shadcn.com/typeset. */
+.typeset-docs {
+  --typeset-font-body: var(--font-sans);
+  --typeset-font-heading: var(--font-heading);
+  --typeset-font-mono: var(--font-mono);
+  --typeset-size: 15px;
+  --typeset-leading: 1.75;
+  --typeset-flow: 1.25em;
+}
+
+/* Fumadocs wraps every heading in an anchor link; typeset underlines links, so keep heading anchors looking like headings (matches shadcn's plain-markdown look). */
+.typeset :where(:is(h1, h2, h3, h4, h5, h6) a) {
+  text-decoration: none;
+}

--- a/web/next/src/app/typeset.css
+++ b/web/next/src/app/typeset.css
@@ -1,0 +1,166 @@
+/*
+ * typeset.css - a starter shadcn/typeset preset (https://ui.shadcn.com/docs/typeset).
+ * Regenerate on the builder (https://ui.shadcn.com/typeset) to lock in your final
+ * fonts and rhythm; this hand-authored version follows the same size/leading/flow model
+ * and references the app's own font + color tokens so it fits the theme.
+ */
+
+.typeset {
+  --typeset-font-body: inherit;
+  --typeset-font-heading: var(--font-heading);
+  --typeset-font-mono: var(--font-mono);
+  --typeset-size: 1rem;
+  --typeset-leading: 1.7;
+  --typeset-flow: 1.25em;
+
+  font-family: var(--typeset-font-body);
+  font-size: var(--typeset-size);
+  line-height: var(--typeset-leading);
+  color: var(--foreground);
+  text-wrap: pretty;
+}
+
+/* Flow: one rhythm unit between consecutive blocks; first block flush to the top. */
+.typeset > * + * {
+  margin-top: var(--typeset-flow);
+}
+.typeset > :first-child {
+  margin-top: 0;
+}
+
+/* Headings share the heading font and a tighter leading; h2/h3 open with extra air. */
+.typeset :is(h1, h2, h3, h4, h5, h6) {
+  font-family: var(--typeset-font-heading);
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  text-wrap: balance;
+  scroll-margin-top: 5rem;
+}
+.typeset h1 {
+  font-size: 2em;
+}
+.typeset h2 {
+  font-size: 1.5em;
+  margin-top: calc(var(--typeset-flow) * 1.6);
+}
+.typeset h3 {
+  font-size: 1.25em;
+  margin-top: calc(var(--typeset-flow) * 1.35);
+}
+.typeset h4 {
+  font-size: 1.1em;
+}
+.typeset :is(h5, h6) {
+  font-size: 1em;
+}
+/* Heading anchor links (fumadocs auto-adds them) inherit the heading, not the link style. */
+.typeset :is(h1, h2, h3, h4, h5, h6) a {
+  color: inherit;
+  font-weight: inherit;
+  text-decoration: none;
+}
+
+/* Links: semantic primary, subtle underline. */
+.typeset a {
+  color: var(--primary);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+.typeset a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/* Lists. */
+.typeset :is(ul, ol) {
+  padding-left: 1.5em;
+}
+.typeset ul {
+  list-style: disc;
+}
+.typeset ol {
+  list-style: decimal;
+}
+.typeset li + li,
+.typeset li > :is(ul, ol) {
+  margin-top: 0.375em;
+}
+.typeset li::marker {
+  color: var(--muted-foreground);
+}
+
+/* Inline code and code blocks. */
+.typeset :not(pre) > code {
+  font-family: var(--typeset-font-mono);
+  font-size: 0.875em;
+  background: var(--muted);
+  padding: 0.15em 0.4em;
+  border-radius: 0.35em;
+}
+.typeset pre {
+  font-family: var(--typeset-font-mono);
+  font-size: 0.875em;
+  overflow-x: auto;
+  border-radius: 0.5em;
+  padding: 1em;
+  background: var(--muted);
+}
+.typeset pre code {
+  background: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* Blockquotes. */
+.typeset blockquote {
+  border-left: 2px solid var(--border);
+  padding-left: 1em;
+  color: var(--muted-foreground);
+  font-style: italic;
+}
+
+/* Tables (wrap in .typeset-scroll for narrow viewports). */
+.typeset-scroll {
+  overflow-x: auto;
+}
+.typeset table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9em;
+}
+.typeset :is(th, td) {
+  border: 1px solid var(--border);
+  padding: 0.5em 0.75em;
+  text-align: left;
+}
+.typeset th {
+  font-weight: 600;
+  background: var(--muted);
+}
+
+/* Rules and media. */
+.typeset hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin-block: calc(var(--typeset-flow) * 1.5);
+}
+.typeset :is(img, video) {
+  border-radius: 0.5em;
+  max-width: 100%;
+  height: auto;
+}
+
+/* Opt-out: elements that bring their own styling (MDX components, callouts, code blocks). */
+.typeset :is(.not-typeset, [data-not-typeset]),
+.typeset :is(.not-typeset, [data-not-typeset]) * {
+  all: revert;
+}
+
+/* Preset: docs. Tune size/leading/flow here (or regenerate on the builder). */
+.typeset-docs {
+  --typeset-size: 1rem;
+  --typeset-leading: 1.7;
+  --typeset-flow: 1.25em;
+}

--- a/web/next/src/app/typeset.css
+++ b/web/next/src/app/typeset.css
@@ -1,166 +1,452 @@
 /*
- * typeset.css - a starter shadcn/typeset preset (https://ui.shadcn.com/docs/typeset).
- * Regenerate on the builder (https://ui.shadcn.com/typeset) to lock in your final
- * fonts and rhythm; this hand-authored version follows the same size/leading/flow model
- * and references the app's own font + color tokens so it fits the theme.
+ * shadcn/typeset
+ * https://ui.shadcn.com/docs/typeset.
  */
 
-.typeset {
-  --typeset-font-body: inherit;
-  --typeset-font-heading: var(--font-heading);
-  --typeset-font-mono: var(--font-mono);
-  --typeset-size: 1rem;
-  --typeset-leading: 1.7;
-  --typeset-flow: 1.25em;
-
-  font-family: var(--typeset-font-body);
-  font-size: var(--typeset-size);
-  line-height: var(--typeset-leading);
-  color: var(--foreground);
-  text-wrap: pretty;
+@layer components {
+  .typeset {
+    --typeset-font-body: inherit;
+    --typeset-font-heading: var(--font-heading);
+    --typeset-font-mono: var(--font-mono);
+    --typeset-size: 1em;
+    --typeset-leading: 1.75;
+    --typeset-flow: 1.25em;
+  }
 }
 
-/* Flow: one rhythm unit between consecutive blocks; first block flush to the top. */
-.typeset > * + * {
-  margin-top: var(--typeset-flow);
-}
-.typeset > :first-child {
-  margin-top: 0;
-}
+@layer components {
+  .typeset {
+    font-family: var(--typeset-font-body);
+    font-size: calc(var(--typeset-size) * 1.125);
+    line-height: var(--typeset-leading);
+    color: var(--color-foreground, currentColor);
+    overflow-wrap: break-word;
+    margin-trim: block-start;
 
-/* Headings share the heading font and a tighter leading; h2/h3 open with extra air. */
-.typeset :is(h1, h2, h3, h4, h5, h6) {
-  font-family: var(--typeset-font-heading);
-  font-weight: 600;
-  line-height: 1.25;
-  letter-spacing: -0.01em;
-  text-wrap: balance;
-  scroll-margin-top: 5rem;
-}
-.typeset h1 {
-  font-size: 2em;
-}
-.typeset h2 {
-  font-size: 1.5em;
-  margin-top: calc(var(--typeset-flow) * 1.6);
-}
-.typeset h3 {
-  font-size: 1.25em;
-  margin-top: calc(var(--typeset-flow) * 1.35);
-}
-.typeset h4 {
-  font-size: 1.1em;
-}
-.typeset :is(h5, h6) {
-  font-size: 1em;
-}
-/* Heading anchor links (fumadocs auto-adds them) inherit the heading, not the link style. */
-.typeset :is(h1, h2, h3, h4, h5, h6) a {
-  color: inherit;
-  font-weight: inherit;
-  text-decoration: none;
-}
+    @media (min-width: 48rem), print {
+      font-size: var(--typeset-size);
+    }
 
-/* Links: semantic primary, subtle underline. */
-.typeset a {
-  color: var(--primary);
-  font-weight: 500;
-  text-decoration: underline;
-  text-decoration-thickness: 1px;
-  text-underline-offset: 2px;
-}
-.typeset a:hover {
-  text-decoration-thickness: 2px;
-}
+    --typeset-muted: var(
+      --color-muted-foreground,
+      color-mix(in oklab, currentColor 60%, transparent)
+    );
+    --typeset-rule: var(--color-border, color-mix(in oklab, currentColor 20%, transparent));
+  }
 
-/* Lists. */
-.typeset :is(ul, ol) {
-  padding-left: 1.5em;
-}
-.typeset ul {
-  list-style: disc;
-}
-.typeset ol {
-  list-style: decimal;
-}
-.typeset li + li,
-.typeset li > :is(ul, ol) {
-  margin-top: 0.375em;
-}
-.typeset li::marker {
-  color: var(--muted-foreground);
-}
+  .typeset *:not(:where(.not-typeset, [data-not-typeset], .not-typeset *, [data-not-typeset] *)) {
+    /* Paragraphs. */
+    &:where(p) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
 
-/* Inline code and code blocks. */
-.typeset :not(pre) > code {
-  font-family: var(--typeset-font-mono);
-  font-size: 0.875em;
-  background: var(--muted);
-  padding: 0.15em 0.4em;
-  border-radius: 0.35em;
-}
-.typeset pre {
-  font-family: var(--typeset-font-mono);
-  font-size: 0.875em;
-  overflow-x: auto;
-  border-radius: 0.5em;
-  padding: 1em;
-  background: var(--muted);
-}
-.typeset pre code {
-  background: none;
-  padding: 0;
-  font-size: inherit;
-}
+    /* Headings. */
+    &:where(h1, h2, h3, h4, h5, h6) {
+      color: var(--color-foreground, currentColor);
+      font-family: var(--typeset-font-heading);
+      font-weight: 600;
+      margin-block-end: 0;
+    }
+    &:where(h1) {
+      font-size: 1.75em;
+      line-height: 1.3;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h2) {
+      font-size: 1.25em;
+      line-height: 1.4;
+      margin-block-start: calc(var(--typeset-flow) * 1.4);
+    }
+    &:where(h3) {
+      font-size: 1.125em;
+      line-height: 1.45;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h4) {
+      font-size: 1em;
+      line-height: 1.5;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(h5) {
+      font-size: 0.875em;
+      line-height: 1.5;
+      font-weight: 500;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+    }
+    &:where(h6) {
+      font-size: 0.8125em;
+      line-height: 1.5;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--typeset-muted);
+      margin-block-start: calc(var(--typeset-flow) / 0.8125);
+    }
+    /* Anchors. */
+    &:where([id]) {
+      scroll-margin-block-start: var(--typeset-flow);
+    }
 
-/* Blockquotes. */
-.typeset blockquote {
-  border-left: 2px solid var(--border);
-  padding-left: 1em;
-  color: var(--muted-foreground);
-  font-style: italic;
-}
+    /* Headings own the space below them. */
+    &:where(h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *) {
+      margin-block-start: 1em;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(code)) {
+      font-size: 0.9em;
+    }
 
-/* Tables (wrap in .typeset-scroll for narrow viewports). */
-.typeset-scroll {
-  overflow-x: auto;
-}
-.typeset table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9em;
-}
-.typeset :is(th, td) {
-  border: 1px solid var(--border);
-  padding: 0.5em 0.75em;
-  text-align: left;
-}
-.typeset th {
-  font-weight: 600;
-  background: var(--muted);
-}
+    /* Links. */
+    &:where(a) {
+      color: inherit;
+      font-weight: 500;
+      text-decoration-line: underline;
+      text-decoration-color: color-mix(in oklab, currentColor 30%, transparent);
+    }
+    &:where(a:hover) {
+      text-decoration-color: currentColor;
+    }
+    &:where(a:focus-visible) {
+      outline: 2px solid var(--color-ring, currentColor);
+      outline-offset: 2px;
+      border-radius: 0.125em;
+    }
+    &:where(:is(h1, h2, h3, h4, h5, h6) :is(a)) {
+      font-weight: inherit;
+    }
 
-/* Rules and media. */
-.typeset hr {
-  border: none;
-  border-top: 1px solid var(--border);
-  margin-block: calc(var(--typeset-flow) * 1.5);
-}
-.typeset :is(img, video) {
-  border-radius: 0.5em;
-  max-width: 100%;
-  height: auto;
-}
+    /* Inline semantics. */
+    &:where(strong, b) {
+      font-weight: 600;
+    }
+    &:where(:is(h1, h2, h3, h4) :is(strong, b)) {
+      font-weight: 600;
+    }
+    &:where(mark) {
+      background-color: color-mix(in oklab, oklch(0.86 0.17 95) 40%, transparent);
+      color: inherit;
+      padding: 0.05em 0.15em;
+      border-radius: 0.2em;
+    }
+    &:where(abbr[title]) {
+      text-decoration-line: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 0.2em;
+      cursor: help;
+    }
+    &:where(del, s) {
+      color: var(--typeset-muted);
+      text-decoration-line: line-through;
+    }
+    &:where(sup, sub) {
+      font-size: 0.75em;
+      line-height: 0;
+      position: relative;
+      vertical-align: baseline;
+    }
+    &:where(sup) {
+      top: -0.5em;
+    }
+    &:where(sub) {
+      bottom: -0.25em;
+    }
+    &:where(sup a) {
+      text-decoration-line: none;
+      font-weight: 500;
+    }
 
-/* Opt-out: elements that bring their own styling (MDX components, callouts, code blocks). */
-.typeset :is(.not-typeset, [data-not-typeset]),
-.typeset :is(.not-typeset, [data-not-typeset]) * {
-  all: revert;
-}
+    /* Lists. */
+    &:where(ul) {
+      list-style-type: disc;
+    }
+    &:where(ol) {
+      list-style-type: decimal;
+    }
+    &:where(ul ul) {
+      list-style-type: circle;
+    }
+    &:where(ul ul ul) {
+      list-style-type: square;
+    }
+    &:where(ol[type="a" i]) {
+      list-style-type: lower-alpha;
+    }
+    &:where(ol[type="i" i]) {
+      list-style-type: lower-roman;
+    }
+    &:where(ol[type="A" s]) {
+      list-style-type: upper-alpha;
+    }
+    &:where(ol[type="I" s]) {
+      list-style-type: upper-roman;
+    }
+    &:where(ul, ol) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      padding-inline-start: 1.5em;
+    }
+    &:where(li) {
+      margin-block-start: 0.5em;
+      padding-inline-start: 0.4em;
+    }
+    &:where(li > p, li > ul, li > ol) {
+      margin-block-start: 0.5em;
+    }
+    &:where(ul > li)::marker {
+      color: var(--typeset-muted);
+    }
+    &:where(ol > li)::marker {
+      color: var(--typeset-muted);
+    }
 
-/* Preset: docs. Tune size/leading/flow here (or regenerate on the builder). */
-.typeset-docs {
-  --typeset-size: 1rem;
-  --typeset-leading: 1.7;
-  --typeset-flow: 1.25em;
+    /* GFM task lists. */
+    &:where(ul.contains-task-list) {
+      list-style-type: none;
+      padding-inline-start: 0.25em;
+    }
+    &:where(li.task-list-item > input[type="checkbox"]) {
+      margin-inline-end: 0.5em;
+      vertical-align: -0.1em;
+      accent-color: var(--color-primary, currentColor);
+    }
+
+    /* Disclosures. */
+    &:where(details) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(summary) {
+      cursor: pointer;
+      font-weight: 500;
+    }
+    &:where(summary)::marker {
+      color: var(--typeset-muted);
+    }
+
+    /* Keyboard keys. */
+    &:where(kbd) {
+      font-family: inherit;
+      font-size: 0.85em;
+      font-weight: 500;
+      border: 1px solid var(--typeset-rule);
+      border-block-end-width: 2px;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.0625em 0.35em;
+    }
+
+    /* Definition lists. */
+    &:where(dl) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(dt) {
+      font-weight: 500;
+      margin-block-start: 1em;
+    }
+    &:where(dt + dt) {
+      margin-block-start: 0.25em;
+    }
+    &:where(dd) {
+      margin-block-start: 0.25em;
+      margin-inline-start: 0;
+      padding-inline-start: 1em;
+      color: var(--typeset-muted);
+    }
+
+    /* Inline code. */
+    &:where(:not(pre) > code) {
+      background-color: var(--color-muted, color-mix(in oklab, currentColor 8%, transparent));
+      font-family: var(--typeset-font-mono);
+      font-size: 0.85em;
+      border-radius: min(calc(var(--radius, 0.5em) * 0.6), 0.35em);
+      padding: 0.125em 0.3em;
+    }
+
+    /* Code blocks. */
+    &:where(pre) {
+      background-color: var(--color-muted, color-mix(in oklab, currentColor 8%, transparent));
+      font-family: var(--typeset-font-mono);
+      font-size: 0.875em;
+      line-height: 1.5;
+      tab-size: 2;
+      direction: ltr;
+      border-radius: var(--radius, 0.5em);
+      padding: 0.75em 1em;
+      overflow-x: auto;
+      margin-block-start: calc(var(--typeset-flow) / 0.875);
+      margin-block-end: 0;
+    }
+    &:where(pre code) {
+      background-color: transparent;
+      font-family: inherit;
+      font-size: inherit;
+      padding: 0;
+      border-radius: 0;
+    }
+
+    /* Blockquote. */
+    &:where(blockquote) {
+      border-inline-start: 2px solid var(--typeset-rule);
+      padding-inline-start: 1em;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+
+    /* Dividers. */
+    &:where(hr) {
+      border: 0;
+      border-block-start: 1px solid var(--typeset-rule);
+      margin-block-start: calc(var(--typeset-flow) * 2.4);
+      margin-block-end: 0;
+    }
+    &:where(hr + h1, hr + h2, hr + h3, hr + h4) {
+      margin-block-start: var(--typeset-flow);
+    }
+
+    /* GFM footnotes. */
+    &:where(.footnotes, [data-footnotes]) {
+      margin-block-start: calc(var(--typeset-flow) * 2);
+      border-block-start: 1px solid var(--typeset-rule);
+      padding-block-start: var(--typeset-flow);
+      font-size: 0.875em;
+      color: var(--typeset-muted);
+    }
+
+    /* Math. */
+    &:where(math[display="block"]) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-block: 0.25em;
+    }
+
+    /* Media. */
+    &:where(img, video) {
+      border-radius: var(--radius, 0.5em);
+      max-width: 100%;
+      height: auto;
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+    &:where(p img) {
+      margin-block-start: 0;
+    }
+    &:where(figure) {
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+      margin-inline: 0;
+    }
+    &:where(figcaption, caption) {
+      color: var(--typeset-muted);
+      font-size: 0.875em;
+      text-align: center;
+      margin-block-start: calc(0.75em / 0.875);
+    }
+    &:where(caption) {
+      caption-side: bottom;
+    }
+
+    /* Tables. Separators sit on cells, not tr:last-child: append-safe.
+       Bare tables stay real tables (keep their semantics) and wrap to fit. */
+    &:where(table) {
+      max-width: 100%;
+      font-size: 1em;
+      line-height: 1.5;
+      font-variant-numeric: tabular-nums;
+      border-collapse: separate;
+      border-spacing: 0;
+      border-block-end: 1px solid var(--typeset-rule);
+      margin-block-start: var(--typeset-flow);
+      margin-block-end: 0;
+    }
+
+    /* Horizontal scroll for any wide block. Wrap it and the wrapper owns the
+       flow margin. Tables shrink to fit, so widen the table to make it scroll
+       instead of compress. */
+    &:where(.typeset-scroll) {
+      overflow-x: auto;
+      margin-block-start: var(--typeset-flow);
+    }
+    &:where(.typeset-scroll > *) {
+      margin-block-start: 0;
+    }
+    &:where(.typeset-scroll table) {
+      width: max-content;
+      max-width: none;
+    }
+    &:where(thead th) {
+      font-weight: 500;
+      text-align: start;
+      white-space: nowrap;
+      padding: 0.65em 1em;
+    }
+    &:where(:is(tbody, tfoot) :is(td, th)) {
+      padding: 0.75em 1em;
+      text-align: start;
+      vertical-align: top;
+      border-block-start: 1px solid var(--typeset-rule);
+    }
+    &:where(tbody th, tfoot th) {
+      font-weight: 500;
+    }
+    &:where(th:first-child, td:first-child) {
+      padding-inline-start: 0;
+    }
+    &:where(th[align="center"], td[align="center"]) {
+      text-align: center;
+    }
+    &:where(th[align="right"], td[align="right"]) {
+      text-align: end;
+    }
+
+    /* Blocks inside list items keep the list's tighter rhythm. */
+    &:where(li > blockquote, li > table, li > figure) {
+      margin-block-start: 0.5em;
+    }
+    &:where(li > pre) {
+      margin-block-start: calc(0.5em / 0.875);
+    }
+
+    @media print {
+      &:where(pre, table, blockquote, figure) {
+        break-inside: avoid;
+      }
+      &:where(h1, h2, h3, h4) {
+        break-after: avoid;
+      }
+    }
+
+    /* Forced colors strips the code background, so give it a border. */
+    @media (forced-colors: active) {
+      &:where(:not(pre) > code) {
+        border: 1px solid;
+      }
+    }
+  }
+
+  /* First child adds no space above. Last so it wins ties. */
+  .typeset
+    > :where(:first-child):not(
+      :where(.not-typeset, [data-not-typeset], .not-typeset *, [data-not-typeset] *)
+    ),
+  .typeset
+    > :where(:first-child)
+    > :where(:first-child):not(
+      :where(.not-typeset, [data-not-typeset], .not-typeset *, [data-not-typeset] *)
+    ),
+  .typeset
+    :where(
+      li > :first-child,
+      blockquote > :first-child,
+      td > :first-child,
+      th > :first-child,
+      dd > :first-child,
+      figure > :first-child,
+      figure > picture > img
+    ):not(:where(.not-typeset, [data-not-typeset], .not-typeset *, [data-not-typeset] *)) {
+    margin-block-start: 0;
+  }
 }

--- a/web/next/src/lib/fumadocs.tsx
+++ b/web/next/src/lib/fumadocs.tsx
@@ -1,5 +1,5 @@
 import { site } from "@packages/config/site"
-import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page"
+import { DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page"
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared"
 import { createRelativeLink } from "fumadocs-ui/mdx"
 import type { Metadata } from "next"
@@ -81,13 +81,13 @@ export function renderPageContent(data: AnyPageData) {
         {page.data.title} {isDocsPage && <CopyAsMarkdown url={page.url} />}
       </DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
-      <DocsBody>
+      <div className="typeset typeset-docs flex-1">
         <MDX
           components={getMDXComponents({
             a: createPageRelativeLink(data),
           })}
         />
-      </DocsBody>
+      </div>
       {blogArticleDates && (
         <div className="not-prose text-muted-foreground mt-4 flex flex-wrap justify-end gap-x-3 gap-y-1 text-right text-sm">
           <time dateTime={blogArticleDates.publishedAt}>


### PR DESCRIPTION
## What

Swap fumadocs' `<DocsBody>` for shadcn's [`typeset`](https://ui.shadcn.com/docs/typeset) on the docs **and** blog (both render through `lib/fumadocs.tsx`), per Fuma's suggestion.

- `lib/fumadocs.tsx`: `<DocsBody>` → `<div className="typeset typeset-docs flex-1">`.
- `web/next/src/app/typeset.css`: **shadcn's actual `typeset.css`, verbatim from the [builder](https://ui.shadcn.com/typeset)** — not a hand-rolled approximation. Imported after Tailwind in `globals.css`.
- `globals.css`: the `.typeset-docs` preset wired to the repo's fonts (`--font-sans` / `--font-heading` / `--font-mono`, 15px). Tune here or regenerate the whole file on the builder.

## Two integration details (both handled)

1. **Code blocks stay fumadocs'.** shadcn's typeset does style `pre` / `figure` / `code`, but entirely via `:where()` (zero specificity), so fumadocs' own code-block component (real classes + shiki inline styles) wins and renders itself. Code blocks and callouts are untouched — no double-styling.
2. **Headings aren't underlined.** typeset underlines links and fumadocs wraps every heading in an anchor, so a one-line tune in `globals.css` keeps heading anchors looking like headings (matches shadcn's plain-markdown look). `typeset.css` itself stays pristine.

## ui-verify

`bun run check-types` + `oxlint` clean; browser-verified — both themes, no mobile overflow.

| State | View |
| --- | --- |
| **Before** — fumadocs `DocsBody` | ![before](https://litter.catbox.moe/6xld4g.png) |
| **After** — `typeset` prose (Introduction) | ![after-intro](https://litter.catbox.moe/r45bm5.png) |
| **After** — code block + headings (dark) | ![after-code](https://litter.catbox.moe/dx6sxt.png) |
| **After** — code block + headings (light) | ![after-light](https://litter.catbox.moe/6yy2iw.png) |
| **After** — mobile | ![after-mobile](https://litter.catbox.moe/07jaoj.png) |

typeset owns the prose (headings, paragraphs, lists, inline-code chips, links); fumadocs still owns code blocks + callouts. Renders close to `DocsBody`.

## Decision for you

This ships shadcn's real typeset with the repo fonts. To change the type scale / rhythm, tune `.typeset-docs` in `globals.css` (or regenerate `typeset.css` on the builder). Clean 3-file revert if you'd rather stay on `DocsBody`.
