### PR TITLE
feat(api): serve WebSockets on Vercel via the Node adapter

### DIFF
--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -87,12 +87,12 @@ Client components reading REST data use TanStack Query (see `components/common/a
 
 ## WebSocket routes
 
-For a live server-to-client stream instead of polling, upgrade a `GET` with `upgradeWebSocket` from `hono/bun` and add the shared `websocket` handler to the Bun server export next to `fetch` (`api/hono/src/index.ts`). `/api/health/ws` is the reference: a snapshot on connect, then a heartbeat every 5s.
+For a live server-to-client stream instead of polling, upgrade a `GET` with `upgradeWebSocket` (`api/hono/src/index.ts`). The socket owner differs by host: on Bun (local, Docker) it's `hono/bun` with the shared `websocket` handler next to `fetch` in the `Bun.serve()` export; on Vercel it's the Node adapter (`@hono/node-server` + `ws`) exporting the http server, since Vercel Functions can't run `Bun.serve()`. The starter picks the adapter at boot from `process.env.VERCEL`, so a new WS route just registers under the selected `upgradeWebSocket`. `/api/health/ws` is the reference: a snapshot on connect, then a heartbeat every 5s.
 
 - The typed client reaches it with `apiClient.health.ws.$ws()`, a standard `WebSocket` pointed at the API base (`http` becomes `ws`).
 - Frames are not RPC-typed: `ws.send()` takes a raw string and `$ws()` returns a plain `WebSocket`. Parse defensively and read only the fields you need; don't hand-maintain a shared payload type RPC can't derive.
 - Keep a `describeRoute` so the upgrade lists in Scalar as a `101`, and describe the frame shape in the route `description`, since OpenAPI can't schema-type WS frames and there is no `{ data }`/`{ error }` envelope.
 - The handshake skips `cors()` (browsers don't apply CORS to WebSockets) and `$ws()` sends no credentials, so gate a sensitive route on the `Origin` header or a token inside the handler, not the allowlist. `/api/health/ws` serves public data, so it doesn't.
-- `bun --hot` picks up edits to an existing `index.ts` route, but restart the stack if `hono/bun` isn't yet wired into the Bun export.
+- `bun --hot` picks up edits to an existing `index.ts` route, but restart the stack if the `upgradeWebSocket` isn't yet wired into the exported server.
 
-Reference client: `components/marketing/api-status.tsx`. REST `/api/health` is the always-honest baseline, polled whenever no frame is live; the socket overlays a live pulse and reconnects with capped backoff, so a serverless deploy or transient blip degrades to the REST-polled state instead of a broken badge.
+Reference client: `components/marketing/api-status.tsx`. REST `/api/health` is the always-honest baseline, polled whenever no frame is live; the socket overlays a live pulse and reconnects with capped backoff, so a cold start or transient blip (Vercel caps a connection at a few minutes) degrades to the REST-polled state instead of a broken badge.

--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -87,7 +87,7 @@ Client components reading REST data use TanStack Query (see `components/common/a
 
 ## WebSocket routes
 
-For a live server-to-client stream instead of polling, upgrade a `GET` with `upgradeWebSocket` (`api/hono/src/index.ts`). The socket owner differs by host: on Bun (local, Docker) it's `hono/bun` with the shared `websocket` handler next to `fetch` in the `Bun.serve()` export; on Vercel it's the Node adapter (`@hono/node-server` + `ws`) exporting the http server, since Vercel Functions can't run `Bun.serve()`. The starter picks the adapter at boot from `process.env.VERCEL`, so a new WS route just registers under the selected `upgradeWebSocket`. `/api/health/ws` is the reference: a snapshot on connect, then a heartbeat every 5s.
+For a live server-to-client stream instead of polling, upgrade a `GET` with `upgradeWebSocket` (`api/hono/src/index.ts`). The socket owner differs by host: on Bun (local, Docker) it's `hono/bun` with the shared `websocket` handler next to `fetch` in the `Bun.serve()` export; on Vercel it's the Node adapter (`@hono/node-server` + `ws`) exporting the http server, since Vercel Functions can't run `Bun.serve()`. That host branching (adapter + server export) lives in `@/lib/server`, picked at boot from `process.env.VERCEL`, so a new WS route just imports `upgradeWebSocket` from there and registers. `/api/health/ws` is the reference: a snapshot on connect, then a heartbeat every 5s.
 
 - The typed client reaches it with `apiClient.health.ws.$ws()`, a standard `WebSocket` pointed at the API base (`http` becomes `ws`).
 - Frames are not RPC-typed: `ws.send()` takes a raw string and `$ws()` returns a plain `WebSocket`. Parse defensively and read only the fields you need; don't hand-maintain a shared payload type RPC can't derive.

--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -91,6 +91,7 @@ For a live server-to-client stream instead of polling, upgrade a `GET` with `upg
 
 - The typed client reaches it with `apiClient.health.ws.$ws()`, a standard `WebSocket` pointed at the API base (`http` becomes `ws`).
 - Frames are not RPC-typed: `ws.send()` takes a raw string and `$ws()` returns a plain `WebSocket`. Parse defensively and read only the fields you need; don't hand-maintain a shared payload type RPC can't derive.
+- `@/lib/server` casts the Node adapter's `upgradeWebSocket` to the Bun type, so on the server side the handler's `ws` (WSContext) is typed as Bun's regardless of host. That is sound for `send`/`close`, but a route reaching into host-specific context (e.g. `ws.raw`) type-checks green yet can diverge at runtime on Vercel. Stick to the common surface (`send`, `close`) or branch per host.
 - Keep a `describeRoute` so the upgrade lists in Scalar as a `101`, and describe the frame shape in the route `description`, since OpenAPI can't schema-type WS frames and there is no `{ data }`/`{ error }` envelope.
 - The handshake skips `cors()` (browsers don't apply CORS to WebSockets) and `$ws()` sends no credentials, so gate a sensitive route on the `Origin` header or a token inside the handler, not the allowlist. `/api/health/ws` serves public data, so it doesn't.
 - `bun --hot` picks up edits to an existing `index.ts` route, but restart the stack if the `upgradeWebSocket` isn't yet wired into the exported server.

--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@arcjet/ip": "catalog:",
+    "@hono/node-server": "catalog:",
     "@hono/standard-validator": "catalog:",
     "@packages/auth": "workspace:*",
     "@packages/config": "workspace:*",
@@ -28,11 +29,13 @@
     "hono": "catalog:",
     "hono-openapi": "catalog:",
     "hono-rate-limiter": "catalog:",
+    "ws": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
+    "@types/ws": "catalog:",
     "concurrently": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -137,7 +137,7 @@ socket.addEventListener("message", (event) => {
           ws.send(snapshot())
           heartbeat = setInterval(() => ws.send(snapshot()), 5000)
         },
-        // Bun's WS adapter surfaces every disconnect as close (it has no error event), so this covers all cleanup.
+        // onClose fires on every disconnect on both adapters (Bun has no error event; ws always emits close after error), so this covers all cleanup.
         onClose() {
           if (heartbeat) clearInterval(heartbeat)
         },
@@ -182,7 +182,7 @@ socket.addEventListener("message", (event) => {
 export type AppType = typeof routes
 export type { ErrorCode } from "@/lib/error"
 
-// On Vercel, export the Node http.Server so the platform drives the WebSocket upgrade; Vercel owns the port (falls back to HONO_PORT when forced locally). Elsewhere, export the Bun.serve() shape so Bun owns fetch + the socket.
+// On Vercel, export the Node http.Server so the platform drives all traffic including the WebSocket upgrade; it binds PORT when Vercel sets it, else HONO_PORT (e.g. forced locally). Elsewhere, export the Bun.serve() shape so Bun owns fetch + the socket.
 export default onVercel
   ? serve({
       fetch: app.fetch,

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -1,13 +1,15 @@
+import { serve, upgradeWebSocket as nodeUpgradeWebSocket } from "@hono/node-server"
 import { site } from "@packages/config/site"
 import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
-import { upgradeWebSocket, websocket } from "hono/bun"
+import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { logger } from "hono/logger"
+import { WebSocketServer } from "ws"
 import { z } from "zod"
 
 import { errorHandler, globalErrorResponses, jsonError } from "@/lib/error"
@@ -15,6 +17,13 @@ import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
+
+// Vercel Functions can't run Bun.serve(), so on Vercel we serve WebSockets through the Node adapter (@hono/node-server + ws); everywhere else (local, Docker/self-host) Bun.serve() owns the socket via hono/bun.
+const onVercel = Boolean(process.env.VERCEL)
+// Both adapters accept the same handler factory; the cast collapses their otherwise non-unionable signatures to one callable type.
+const upgradeWebSocket = onVercel
+  ? (nodeUpgradeWebSocket as typeof bunUpgradeWebSocket)
+  : bunUpgradeWebSocket
 
 const app = new Hono()
 
@@ -95,7 +104,7 @@ const { data, error } = await unwrap(apiClient.health.$get())`,
     describeRoute({
       tags: ["System"],
       description:
-        "Live system health over a WebSocket (Bun). On connect the server sends a snapshot, then a heartbeat every 5s. Each frame is JSON: { message, version, environment, timestamp }.",
+        "Live system health over a WebSocket. On connect the server sends a snapshot, then a heartbeat every 5s. Each frame is JSON: { message, version, environment, timestamp }.",
       ...({
         "x-codeSamples": [
           {
@@ -173,8 +182,15 @@ socket.addEventListener("message", (event) => {
 export type AppType = typeof routes
 export type { ErrorCode } from "@/lib/error"
 
-export default {
-  port: env.HONO_PORT,
-  fetch: app.fetch,
-  websocket,
-}
+// On Vercel, export the Node http.Server so the platform drives the WebSocket upgrade; Vercel owns the port (falls back to HONO_PORT when forced locally). Elsewhere, export the Bun.serve() shape so Bun owns fetch + the socket.
+export default onVercel
+  ? serve({
+      fetch: app.fetch,
+      port: Number(process.env.PORT) || env.HONO_PORT,
+      websocket: { server: new WebSocketServer({ noServer: true }) },
+    })
+  : {
+      port: env.HONO_PORT,
+      fetch: app.fetch,
+      websocket,
+    }

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -1,29 +1,20 @@
-import { serve, upgradeWebSocket as nodeUpgradeWebSocket } from "@hono/node-server"
 import { site } from "@packages/config/site"
 import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
 import { Hono } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
-import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
 import { logger } from "hono/logger"
-import { WebSocketServer } from "ws"
 import { z } from "zod"
 
 import { errorHandler, globalErrorResponses, jsonError } from "@/lib/error"
+import { createServer, upgradeWebSocket } from "@/lib/server"
 import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
-
-// Vercel Functions can't run Bun.serve(), so on Vercel we serve WebSockets through the Node adapter (@hono/node-server + ws); everywhere else (local, Docker/self-host) Bun.serve() owns the socket via hono/bun.
-const onVercel = Boolean(process.env.VERCEL)
-// Both adapters accept the same handler factory; the cast collapses their otherwise non-unionable signatures to one callable type.
-const upgradeWebSocket = onVercel
-  ? (nodeUpgradeWebSocket as typeof bunUpgradeWebSocket)
-  : bunUpgradeWebSocket
 
 const app = new Hono()
 
@@ -182,15 +173,5 @@ socket.addEventListener("message", (event) => {
 export type AppType = typeof routes
 export type { ErrorCode } from "@/lib/error"
 
-// On Vercel, export the Node http.Server so the platform drives all traffic including the WebSocket upgrade; it binds PORT when Vercel sets it, else HONO_PORT (e.g. forced locally). Elsewhere, export the Bun.serve() shape so Bun owns fetch + the socket.
-export default onVercel
-  ? serve({
-      fetch: app.fetch,
-      port: Number(process.env.PORT) || env.HONO_PORT,
-      websocket: { server: new WebSocketServer({ noServer: true }) },
-    })
-  : {
-      port: env.HONO_PORT,
-      fetch: app.fetch,
-      websocket,
-    }
+// Bun.serve() shape locally and self-hosted, Node http.Server on Vercel; see @/lib/server.
+export default createServer(app)

--- a/api/hono/src/lib/server.ts
+++ b/api/hono/src/lib/server.ts
@@ -17,7 +17,7 @@ export const createServer = (app: Hono) =>
   onVercel
     ? serve({
         fetch: app.fetch,
-        port: Number(process.env.PORT) || env.HONO_PORT,
+        port: process.env.PORT ? Number(process.env.PORT) : env.HONO_PORT,
         websocket: { server: new WebSocketServer({ noServer: true }) },
       })
     : {

--- a/api/hono/src/lib/server.ts
+++ b/api/hono/src/lib/server.ts
@@ -5,7 +5,7 @@ import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
 import { WebSocketServer } from "ws"
 
 // Vercel Functions can't run Bun.serve(), so on Vercel we serve WebSockets through the Node adapter (@hono/node-server + ws); everywhere else (local, Docker/self-host) Bun.serve() owns the socket via hono/bun.
-const onVercel = Boolean(process.env.VERCEL)
+const onVercel = process.env.VERCEL === "1"
 
 // Both adapters accept the same handler factory; the cast collapses their otherwise non-unionable signatures to one callable type. Registered on a route in index.ts.
 export const upgradeWebSocket = onVercel

--- a/api/hono/src/lib/server.ts
+++ b/api/hono/src/lib/server.ts
@@ -1,0 +1,27 @@
+import { serve, upgradeWebSocket as nodeUpgradeWebSocket } from "@hono/node-server"
+import { env } from "@packages/env/api-hono"
+import type { Hono } from "hono"
+import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
+import { WebSocketServer } from "ws"
+
+// Vercel Functions can't run Bun.serve(), so on Vercel we serve WebSockets through the Node adapter (@hono/node-server + ws); everywhere else (local, Docker/self-host) Bun.serve() owns the socket via hono/bun.
+const onVercel = Boolean(process.env.VERCEL)
+
+// Both adapters accept the same handler factory; the cast collapses their otherwise non-unionable signatures to one callable type. Registered on a route in index.ts.
+export const upgradeWebSocket = onVercel
+  ? (nodeUpgradeWebSocket as typeof bunUpgradeWebSocket)
+  : bunUpgradeWebSocket
+
+// On Vercel, return the Node http.Server so the platform drives all traffic including the WebSocket upgrade; it binds PORT when Vercel sets it, else HONO_PORT (e.g. forced locally). Elsewhere, return the Bun.serve() shape so Bun owns fetch + the socket.
+export const createServer = (app: Hono) =>
+  onVercel
+    ? serve({
+        fetch: app.fetch,
+        port: Number(process.env.PORT) || env.HONO_PORT,
+        websocket: { server: new WebSocketServer({ noServer: true }) },
+      })
+    : {
+        port: env.HONO_PORT,
+        fetch: app.fetch,
+        websocket,
+      }

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@arcjet/ip": "catalog:",
+        "@hono/node-server": "catalog:",
         "@hono/standard-validator": "catalog:",
         "@packages/auth": "workspace:*",
         "@packages/config": "workspace:*",
@@ -40,11 +41,13 @@
         "hono": "catalog:",
         "hono-openapi": "catalog:",
         "hono-rate-limiter": "catalog:",
+        "ws": "catalog:",
         "zod": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
+        "@types/ws": "catalog:",
         "concurrently": "catalog:",
         "tsdown": "catalog:",
         "typescript": "catalog:",
@@ -68,7 +71,7 @@
     },
     "packages/cli": {
       "name": "zerostarter",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "bin": {
         "zerostarter": "dist/bin/index.mjs",
       },
@@ -196,6 +199,7 @@
     "@base-ui/react": "^1.6.0",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
+    "@hono/node-server": "^2.0.8",
     "@hono/standard-validator": "^0.2.3",
     "@octokit/rest": "^22.0.1",
     "@remixicon/react": "^4.9.0",
@@ -219,6 +223,7 @@
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/ws": "^8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "@viz-js/viz": "^3.28.0",
     "babel-plugin-react-compiler": "^1.0.0",
@@ -269,6 +274,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^7.0.2",
     "vaul": "^1.1.2",
+    "ws": "^8.21.0",
     "zod": "^4.4.3",
   },
   "packages": {
@@ -478,7 +484,7 @@
 
     "@fumadocs/tailwind": ["@fumadocs/tailwind@0.1.0", "", { "peerDependencies": { "tailwindcss": "^4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-nF/DCAwOR21HZ4AkjIOv3Iqwyqywzb6pdyeMcoa+aZzirXj5ntvNZbe3jJ0v3ehhtrRfYYeXBezvjn8ZmV+fuQ=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+    "@hono/node-server": ["@hono/node-server@2.0.8", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GuCWzLxwg218fy1JaHculFsdcuY12hxit83V+algozTPnwhNjLrRL/Alg9OYjLZLoUZ1rw/S4CdTMsnkSKCmFA=="],
 
     "@hono/standard-validator": ["@hono/standard-validator@0.2.3", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "hono": ">=3.9.0" } }, "sha512-bp9vHu6Va6SfMHC3D4ZLBbT/woi+AZ9CRdTXQu3kLJuLh2W/Gb9UO4hijS+BQAGFXi4EGpXdetxpzwTAawSVeg=="],
 
@@ -991,6 +997,8 @@
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260707.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg=="],
 
@@ -2256,6 +2264,8 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -2301,6 +2311,8 @@
     "@esbuild-kit/esm-loader/get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "@mdx-js/mdx/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@modelcontextprotocol/sdk/hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@base-ui/react": "^1.6.0",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
+    "@hono/node-server": "^2.0.8",
     "@hono/standard-validator": "^0.2.3",
     "@octokit/rest": "^22.0.1",
     "@remixicon/react": "^4.9.0",
@@ -92,6 +93,7 @@
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/ws": "^8.18.1",
     "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "@viz-js/viz": "^3.28.0",
     "babel-plugin-react-compiler": "^1.0.0",
@@ -142,6 +144,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^7.0.2",
     "vaul": "^1.1.2",
+    "ws": "^8.21.0",
     "zod": "^4.4.3"
   }
 }

--- a/web/next/content/docs/deployment/vercel.mdx
+++ b/web/next/content/docs/deployment/vercel.mdx
@@ -85,7 +85,7 @@ Env vars are set per project and don't propagate between them, and the two proje
 
 ## WebSockets
 
-The api serves WebSockets on Vercel through [Vercel's native support](https://vercel.com/docs/functions/websockets), which needs [Fluid compute](https://vercel.com/docs/fluid-compute) (on by default for projects created after April 23, 2025). `hono/bun` can't drive the upgrade because Vercel Functions don't run `Bun.serve()`, so the api switches to the Node adapter (`@hono/node-server` + `ws`) when `process.env.VERCEL` is set; on Bun (local and Docker) it keeps the `Bun.serve()` path. The live `/api/health/ws` example (see [Type-safe API](/docs/getting-started/type-safe-api#live-data-over-websockets)) works on both. A single connection is pinned to one function instance and capped at a few minutes, so keep any shared socket state external (for example Redis) and let clients reconnect.
+The api serves WebSockets on Vercel through [Vercel's native support](https://vercel.com/docs/functions/websockets), which needs [Fluid compute](https://vercel.com/docs/fluid-compute) (on by default for projects created on or after April 23, 2025). `hono/bun` can't drive the upgrade because Vercel Functions don't run `Bun.serve()`, so the api switches to the Node adapter (`@hono/node-server` + `ws`) when `process.env.VERCEL` is set; on Bun (local and Docker) it keeps the `Bun.serve()` path. The live `/api/health/ws` example (see [Type-safe API](/docs/getting-started/type-safe-api#live-data-over-websockets)) works on both. A single connection is pinned to one function instance and closes when the function reaches its max duration (a few minutes by default), so keep any shared socket state external (for example Redis) and let clients reconnect.
 
 ## Next
 

--- a/web/next/content/docs/deployment/vercel.mdx
+++ b/web/next/content/docs/deployment/vercel.mdx
@@ -83,6 +83,10 @@ Env vars are set per project and don't propagate between them, and the two proje
 
 </Callout>
 
+## WebSockets
+
+The api serves WebSockets on Vercel through [Vercel's native support](https://vercel.com/docs/functions/websockets), which needs [Fluid compute](https://vercel.com/docs/fluid-compute) (on by default for projects created after April 23, 2025). `hono/bun` can't drive the upgrade because Vercel Functions don't run `Bun.serve()`, so the api switches to the Node adapter (`@hono/node-server` + `ws`) when `process.env.VERCEL` is set; on Bun (local and Docker) it keeps the `Bun.serve()` path. The live `/api/health/ws` example (see [Type-safe API](/docs/getting-started/type-safe-api#live-data-over-websockets)) works on both. A single connection is pinned to one function instance and capped at a few minutes, so keep any shared socket state external (for example Redis) and let clients reconnect.
+
 ## Next
 
 - [Deploy with Docker](/docs/deployment/docker): the same stack in containers, where you run migrations yourself.

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -87,7 +87,7 @@ import type { Hono } from "hono"
 import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
 import { WebSocketServer } from "ws"
 
-const onVercel = Boolean(process.env.VERCEL)
+const onVercel = process.env.VERCEL === "1"
 
 export const upgradeWebSocket = onVercel
   ? (nodeUpgradeWebSocket as typeof bunUpgradeWebSocket)

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -130,7 +130,7 @@ socket.addEventListener("message", (event) => {
 })
 ```
 
-Treat the socket as progressive enhancement over a REST baseline. The reference component (`components/marketing/api-status.tsx`) polls REST `/api/health` whenever no frame is live and overlays a live pulse while the socket streams, reconnecting with capped backoff. So the badge always reflects real status before the socket connects or if it drops (Vercel caps a single connection at a few minutes), and only the pulse is socket-only.
+Treat the socket as progressive enhancement over a REST baseline. The reference component (`components/marketing/api-status.tsx`) polls REST `/api/health` whenever no frame is live and overlays a live pulse while the socket streams, reconnecting with capped backoff. So the badge always reflects real status before the socket connects or if it drops (Vercel closes a connection when the function reaches its max duration, a few minutes by default), and only the pulse is socket-only.
 
 <Callout type="info" title="Frames are not RPC-typed">
 

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -82,6 +82,8 @@ The route is a `GET` upgraded with `upgradeWebSocket`, but the socket owner diff
 ```ts
 // api/hono/src/lib/server.ts
 import { serve, upgradeWebSocket as nodeUpgradeWebSocket } from "@hono/node-server"
+import { env } from "@packages/env/api-hono"
+import type { Hono } from "hono"
 import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
 import { WebSocketServer } from "ws"
 
@@ -95,7 +97,7 @@ export const createServer = (app: Hono) =>
   onVercel
     ? serve({
         fetch: app.fetch,
-        port: Number(process.env.PORT) || env.HONO_PORT,
+        port: process.env.PORT ? Number(process.env.PORT) : env.HONO_PORT,
         websocket: { server: new WebSocketServer({ noServer: true }) },
       })
     : { port: env.HONO_PORT, fetch: app.fetch, websocket }

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -77,18 +77,33 @@ Every route decorated with `describeRoute` shows up in an interactive [Scalar](h
 
 Hono serves [WebSockets](https://hono.dev/docs/helpers/websocket) and the same typed client reaches them. The health endpoint ships a live example at `/api/health/ws` that pushes a status snapshot on connect and a heartbeat every few seconds.
 
-The route is a `GET` upgraded with `upgradeWebSocket`, but the socket owner differs by host. Bun (local, Docker/self-host) runs `Bun.serve()`, so the socket comes from `hono/bun`. Vercel Functions can't run `Bun.serve()`, so on Vercel the upgrade goes through the Node adapter (`@hono/node-server` + `ws`), which Vercel [drives natively](https://vercel.com/docs/functions/websockets). The starter picks the adapter at boot from `process.env.VERCEL` and exports the matching server:
+The route is a `GET` upgraded with `upgradeWebSocket`, but the socket owner differs by host. Bun (local, Docker/self-host) runs `Bun.serve()`, so the socket comes from `hono/bun`. Vercel Functions can't run `Bun.serve()`, so on Vercel the upgrade goes through the Node adapter (`@hono/node-server` + `ws`), which Vercel [drives natively](https://vercel.com/docs/functions/websockets). `lib/server.ts` picks the adapter at boot from `process.env.VERCEL` and builds the matching server export, keeping `index.ts` to route registration:
 
 ```ts
-// api/hono/src/index.ts
+// api/hono/src/lib/server.ts
 import { serve, upgradeWebSocket as nodeUpgradeWebSocket } from "@hono/node-server"
 import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
 import { WebSocketServer } from "ws"
 
 const onVercel = Boolean(process.env.VERCEL)
-const upgradeWebSocket = onVercel
+
+export const upgradeWebSocket = onVercel
   ? (nodeUpgradeWebSocket as typeof bunUpgradeWebSocket)
   : bunUpgradeWebSocket
+
+export const createServer = (app: Hono) =>
+  onVercel
+    ? serve({
+        fetch: app.fetch,
+        port: Number(process.env.PORT) || env.HONO_PORT,
+        websocket: { server: new WebSocketServer({ noServer: true }) },
+      })
+    : { port: env.HONO_PORT, fetch: app.fetch, websocket }
+```
+
+```ts
+// api/hono/src/index.ts
+import { createServer, upgradeWebSocket } from "@/lib/server"
 
 const routes = app.basePath("/api").get(
   "/health/ws",
@@ -99,13 +114,7 @@ const routes = app.basePath("/api").get(
   })),
 )
 
-export default onVercel
-  ? serve({
-      fetch: app.fetch,
-      port: Number(process.env.PORT) || env.HONO_PORT,
-      websocket: { server: new WebSocketServer({ noServer: true }) },
-    })
-  : { port: env.HONO_PORT, fetch: app.fetch, websocket }
+export default createServer(app)
 ```
 
 On the client, the RPC object exposes `$ws()` on the route, so the connection URL stays derived from the same configured API base (`http` becomes `ws`):

--- a/web/next/content/docs/getting-started/type-safe-api.mdx
+++ b/web/next/content/docs/getting-started/type-safe-api.mdx
@@ -75,13 +75,20 @@ Every route decorated with `describeRoute` shows up in an interactive [Scalar](h
 
 ## Live data over WebSockets
 
-Hono serves [WebSockets](https://hono.dev/docs/helpers/websocket) on Bun, and the same typed client reaches them. The health endpoint ships a live example at `/api/health/ws` that pushes a status snapshot on connect and a heartbeat every few seconds.
+Hono serves [WebSockets](https://hono.dev/docs/helpers/websocket) and the same typed client reaches them. The health endpoint ships a live example at `/api/health/ws` that pushes a status snapshot on connect and a heartbeat every few seconds.
 
-A WebSocket route is a `GET` upgraded with `upgradeWebSocket` from `hono/bun`. The shared `websocket` handler is added to the Bun server export next to `fetch`:
+The route is a `GET` upgraded with `upgradeWebSocket`, but the socket owner differs by host. Bun (local, Docker/self-host) runs `Bun.serve()`, so the socket comes from `hono/bun`. Vercel Functions can't run `Bun.serve()`, so on Vercel the upgrade goes through the Node adapter (`@hono/node-server` + `ws`), which Vercel [drives natively](https://vercel.com/docs/functions/websockets). The starter picks the adapter at boot from `process.env.VERCEL` and exports the matching server:
 
 ```ts
 // api/hono/src/index.ts
-import { upgradeWebSocket, websocket } from "hono/bun"
+import { serve, upgradeWebSocket as nodeUpgradeWebSocket } from "@hono/node-server"
+import { upgradeWebSocket as bunUpgradeWebSocket, websocket } from "hono/bun"
+import { WebSocketServer } from "ws"
+
+const onVercel = Boolean(process.env.VERCEL)
+const upgradeWebSocket = onVercel
+  ? (nodeUpgradeWebSocket as typeof bunUpgradeWebSocket)
+  : bunUpgradeWebSocket
 
 const routes = app.basePath("/api").get(
   "/health/ws",
@@ -92,7 +99,13 @@ const routes = app.basePath("/api").get(
   })),
 )
 
-export default { port: env.HONO_PORT, fetch: app.fetch, websocket }
+export default onVercel
+  ? serve({
+      fetch: app.fetch,
+      port: Number(process.env.PORT) || env.HONO_PORT,
+      websocket: { server: new WebSocketServer({ noServer: true }) },
+    })
+  : { port: env.HONO_PORT, fetch: app.fetch, websocket }
 ```
 
 On the client, the RPC object exposes `$ws()` on the route, so the connection URL stays derived from the same configured API base (`http` becomes `ws`):
@@ -106,7 +119,7 @@ socket.addEventListener("message", (event) => {
 })
 ```
 
-Treat the socket as progressive enhancement over a REST baseline. The reference component (`components/marketing/api-status.tsx`) polls REST `/api/health` whenever no frame is live and overlays a live pulse while the socket streams, reconnecting with capped backoff. So the badge always reflects real status, a serverless deploy that can't hold a socket simply shows the REST-polled state, and only the pulse is socket-only.
+Treat the socket as progressive enhancement over a REST baseline. The reference component (`components/marketing/api-status.tsx`) polls REST `/api/health` whenever no frame is live and overlays a live pulse while the socket streams, reconnecting with capped backoff. So the badge always reflects real status before the socket connects or if it drops (Vercel caps a single connection at a few minutes), and only the pulse is socket-only.
 
 <Callout type="info" title="Frames are not RPC-typed">
 


### PR DESCRIPTION
## Why

`api/hono` imports `upgradeWebSocket`/`websocket` from `hono/bun`, which is coupled to `Bun.serve()`. Vercel Functions don't run `Bun.serve()` (even under the Bun runtime), so `/api/health/ws` never upgraded on Vercel and silently fell back to REST polling. Vercel shipped [native WebSocket support](https://vercel.com/docs/functions/websockets) (public beta, 2026-06-22) whose documented Hono path is the Node adapter (`@hono/node-server` + `ws`), exporting the http server so the platform drives the upgrade.

## What

Pick the WS adapter at boot from `process.env.VERCEL`:

- **Bun (local, Docker/self-host)** keeps the existing `Bun.serve()` path via `hono/bun`, byte-for-byte the current behavior, zero regression.
- **Vercel** uses `@hono/node-server`'s `serve({ fetch, websocket: { server: new WebSocketServer({ noServer: true }) } })` and exports the http server, matching Vercel's official Hono example.

The `/api/health/ws` handler body is unchanged. Adds `@hono/node-server`, `ws`, `@types/ws` to the catalog + `api/hono`. Docs (`type-safe-api`, `deployment/vercel`) and the `api-endpoint` skill updated.

## Verification

- `check-types`, `oxlint`, `oxfmt`, both bundles (`build` + `build:vercel`), and the full pre-commit build (incl. strict docs build + `next build`) all pass.
- **Bun.serve() branch** (default): WS streams snapshot + heartbeat. No regression.
- **Vercel branch, forced under Bun** (`VERCEL=1 bun src/index.ts`): `@hono/node-server` + `ws` boots and streams snapshot + heartbeat identically.
- **Browser e2e**: the marketing home `ApiStatus` badge shows the live WS pulse (`animate-pulse` on the dot = frame from the socket, not REST).
- **Vercel preview (confirmed)**: the platform upgrades the WebSocket under the kept **Bun runtime** (`bunVersion` in `api/hono/vercel.json`), streaming the live pulse. No Node-runtime switch needed: the Node adapter runs on Vercel's Bun runtime via its `node:http`/`ws` compat, and `serve()`'s self-`listen()` is tolerated (Vercel's own docs example self-listens too).

![api-status live pulse via node adapter](https://litter.catbox.moe/ua3aas.png)

## Notes (previously open, now resolved)

- **Runtime**: kept the **Bun runtime** in `api/hono/vercel.json`; the preview confirmed Vercel drives the upgrade into the exported server under it, so no switch to the Node runtime was required.
- **Port**: the Vercel branch passes `port: Number(process.env.PORT) || env.HONO_PORT` so a forced local run still binds 4000; on Vercel the value is inert (the platform drives the upgrade regardless), matching how Vercel's example lets `serve()` default the port.
- A follow-up doc commit aligns two wording details with Vercel's page: Fluid compute is "on or after" April 23 2025, and a connection closes when the function reaches its max duration rather than a fixed "few minutes".

## Incidental (not part of the feature)

`bun install` reconciled a stale `packages/cli` version in `bun.lock` (`0.0.24` -> `0.0.25`) to match `packages/cli/package.json`, which is already `0.0.25` on `canary`. Pre-existing lockfile drift on `canary`, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
