### PR TITLE
docs(web): mark the /og file-tracing include as load-bearing on Vercel

### DIFF
--- a/web/next/next.config.ts
+++ b/web/next/next.config.ts
@@ -35,6 +35,7 @@ const nextConfig: NextConfig = {
   output: "standalone",
   ...(libc && {
     outputFileTracingExcludes: { "*": libcExcludes[libc] },
+    // Kept for Vercel: /og is traced into its own function and needs the takumi core binary here; removing it 500s /og at runtime (redundant only in Docker standalone).
     outputFileTracingIncludes: {
       "/og": [`node_modules/@takumi-rs/core-linux-*-${{ glibc: "gnu", musl: "musl" }[libc]}/**`],
     },


### PR DESCRIPTION
## What

One-line comment in `web/next/next.config.ts` documenting that the `/og` `outputFileTracingIncludes` must not be removed. No behavior change.

```diff
   ...(libc && {
     outputFileTracingExcludes: { "*": libcExcludes[libc] },
+    // Kept for Vercel: /og is traced into its own function and needs the takumi core binary here; removing it 500s /og at runtime (redundant only in Docker standalone).
     outputFileTracingIncludes: {
       "/og": [`node_modules/@takumi-rs/core-linux-*-${{ glibc: "gnu", musl: "musl" }[libc]}/**`],
     },
   }),
```

## Why

The include *looks* removable. In a Docker `output: standalone` build it genuinely is: nft already traces the correct-libc `@takumi-rs/core`, and I confirmed all 32 OG images come out byte-identical without it on real glibc + musl builds.

But removing it **500s `/og` on Vercel**. Vercel traces each route into its own serverless function; the dynamic `/og` function needs the takumi core binary, and the include is what puts it there. Docker standalone ships all of `node_modules`, which hides the dependency. The comment stops the next reader (or agent) from "cleaning up" the include and breaking production `/og`.

## What was considered and dropped

- **Remove the include** to save ~4 MB dup: rejected, it 500s `/og` on Vercel.
- **Drop `takumi-js` from `serverExternalPackages`** (per @kanewang_): rejected. It bundles fine, but bundling it *grows* the compiled server bundle ~252 KB (`serverExternalPackages` is the keep-it-out-of-the-bundle knob), so it is a wash. Left external.
- **The libc excludes** (~20 MB, ~80% sharp libvips): already in production, unchanged. They are the real win, needed because bun installs both libc variants on one host so nft copies both.

Net: the config was already well-tuned; this PR just documents the one non-obvious load-bearing line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)