### PR TITLE
refactor(scripts): generalize ensure-branches to a declared branch list

### DIFF
--- a/.github/scripts/ensure-remote-branches.ts
+++ b/.github/scripts/ensure-remote-branches.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from "node:child_process"
 
-// Pre-push guard for fresh forks, GitHub remotes only (other remotes are left alone). The user's first `git push origin canary` creates canary, which GitHub makes the default branch; on the next push the hook seeds main (a different ref, so it never collides with the canary push) so auto-canary-into-main opens the release PR. No gh or repo-admin is needed: the default branch falls out of push order. A per-remote git-config marker makes it a no-op once done; shared via lefthook.yml so it runs here and in every fork.
+// Pre-push guard for fresh forks, GitHub remotes only (other remotes are left alone). The user's first `git push origin canary` creates canary, which GitHub makes the default branch; on the next push the hook seeds the release branches (main by default, from RELEASE_BRANCHES) as separate refs, so they never collide with the canary push, so auto-canary-into-main opens the release PR. No gh or repo-admin is needed: the default branch falls out of push order. A per-branch, per-remote git-config marker makes it a no-op once done; shared via lefthook.yml so it runs here and in every fork.
 
-// Per-remote, local-only marker; the remote is sanitized and prefixed so the key is always a valid git-config name.
-export const markerKey = (remote: string): string => {
+// Per-branch, per-remote local-only marker; the remote is sanitized and prefixed so the key is always a valid git-config name.
+export const markerKey = (branch: string, remote: string): string => {
   const safe = remote.replace(/[^A-Za-z0-9-]/g, "-")
-  return `zerostarter.mainSeeded.${/^[A-Za-z]/.test(safe) ? safe : `r-${safe}`}`
+  return `zerostarter.seeded.${branch}.${/^[A-Za-z]/.test(safe) ? safe : `r-${safe}`}`
 }
 
 const git = (args: string[]): string =>
@@ -23,17 +23,17 @@ export const repoSlug = (remoteUrl: string): string => {
   return m ? `${m[1]}/${m[2]}` : ""
 }
 
-const done = (remote: string): boolean => {
+const done = (branch: string, remote: string): boolean => {
   try {
-    return git(["config", "--local", "--get", markerKey(remote)]) === "true"
+    return git(["config", "--local", "--get", markerKey(branch, remote)]) === "true"
   } catch {
     return false
   }
 }
 
-const markDone = (remote: string): void => {
+const markDone = (branch: string, remote: string): void => {
   try {
-    git(["config", "--local", markerKey(remote), "true"])
+    git(["config", "--local", markerKey(branch, remote), "true"])
   } catch {
     // best-effort: a missing marker only costs an extra ls-remote on the next push
   }
@@ -82,45 +82,53 @@ const printPermsInstructions = (remote: string): void => {
   console.error("  4. Click Save")
 }
 
+// The long-lived branches this hook seeds on a fresh GitHub remote once canary exists. Default is just main, which drives the canary -> main release PR; a fork can add more (e.g. "staging", "production").
+const RELEASE_BRANCHES = ["main"]
+
 const ensureRemoteBranches = (remote: string): void => {
-  if (done(remote)) return
-  if (!hasLocalBranch("main")) return
   if (!repoSlug(remoteUrl(remote))) return // not a GitHub remote: the release flow does not apply, so do not interfere
+
+  // Declared branches that exist locally and are not yet marked seeded for this remote.
+  const pending = RELEASE_BRANCHES.filter(
+    (branch) => hasLocalBranch(branch) && !done(branch, remote),
+  )
+  if (pending.length === 0) return
 
   const canaryOnRemote = remoteHasBranch(remote, "canary")
   if (canaryOnRemote === null) return // remote unreachable: never block the push, retry next time
 
   if (!canaryOnRemote) {
-    // This push creates canary, which GitHub makes the default branch. main is seeded on the next push.
+    // This push creates canary, which GitHub makes the default branch. The release branches are seeded on the next push.
     console.error(
-      "zerostarter: publishing canary; it becomes your default branch. Push again to seed main and open the release PR.",
+      "zerostarter: publishing canary; it becomes your default branch. Push again to seed the release branches and open the release PR.",
     )
     printPermsInstructions(remote)
-    return // not done; main is seeded on the next push
+    return // not done; the release branches are seeded on the next push
   }
 
-  const mainOnRemote = remoteHasBranch(remote, "main")
-  if (mainOnRemote === null) return
-  if (mainOnRemote) {
-    markDone(remote) // both branches exist; nothing left to do
-    return
-  }
-
-  // canary exists, main does not: seed main (a different ref, so no collision with the canary push) so the release PR can open.
-  console.error(
-    `zerostarter: seeding main on ${remote} so the canary -> main release PR can open ...`,
-  )
-  try {
-    execFileSync("git", ["push", "--no-verify", remote, "main"], {
-      stdio: ["ignore", "inherit", "inherit"],
-    })
-  } catch {
+  // canary exists: seed each pending branch (a different ref, so no collision with the canary push) so the release PR can open.
+  for (const branch of pending) {
+    const onRemote = remoteHasBranch(remote, branch)
+    if (onRemote === null) return // remote went unreachable mid-loop: retry next push
+    if (onRemote) {
+      markDone(branch, remote) // already on the remote; nothing to push
+      continue
+    }
     console.error(
-      `zerostarter: could not push main automatically. Push it yourself: git push ${remote} main`,
+      `zerostarter: seeding ${branch} on ${remote} so the canary -> ${branch} release PR can open ...`,
     )
-    return // do not mark; let the canary push proceed so nothing is blocked
+    try {
+      execFileSync("git", ["push", "--no-verify", remote, branch], {
+        stdio: ["ignore", "inherit", "inherit"],
+      })
+    } catch {
+      console.error(
+        `zerostarter: could not push ${branch} automatically. Push it yourself: git push ${remote} ${branch}`,
+      )
+      return // do not mark; let the canary push proceed so nothing is blocked
+    }
+    markDone(branch, remote)
   }
-  markDone(remote)
 }
 
 if (import.meta.main) ensureRemoteBranches(process.argv[2] || "origin")

--- a/packages/cli/test/ensure-remote-branches.test.ts
+++ b/packages/cli/test/ensure-remote-branches.test.ts
@@ -24,17 +24,18 @@ test("settingsUrl returns empty for a non-GitHub remote", () => {
   expect(settingsUrl("https://gitlab.com/acme/widgets.git")).toBe("")
 })
 
-test("markerKey is scoped per remote so seeding one does not mark another", () => {
-  expect(markerKey("origin")).toBe("zerostarter.mainSeeded.origin")
-  expect(markerKey("upstream")).toBe("zerostarter.mainSeeded.upstream")
+test("markerKey is scoped per branch and remote so seeding one does not mark another", () => {
+  expect(markerKey("main", "origin")).toBe("zerostarter.seeded.main.origin")
+  expect(markerKey("main", "upstream")).toBe("zerostarter.seeded.main.upstream")
+  expect(markerKey("staging", "origin")).toBe("zerostarter.seeded.staging.origin")
 })
 
 test("markerKey sanitizes a remote name into a valid git-config key", () => {
-  expect(markerKey("feature/fork")).toBe("zerostarter.mainSeeded.feature-fork")
+  expect(markerKey("main", "feature/fork")).toBe("zerostarter.seeded.main.feature-fork")
 })
 
 test("markerKey prefixes a digit-leading remote so the key stays a valid git-config name", () => {
-  expect(markerKey("2fork")).toBe("zerostarter.mainSeeded.r-2fork")
+  expect(markerKey("main", "2fork")).toBe("zerostarter.seeded.main.r-2fork")
 })
 
 test("repoSlug detects GitHub remotes (SSH and HTTPS) and is empty otherwise", () => {

--- a/web/next/content/docs/manage/code-quality.mdx
+++ b/web/next/content/docs/manage/code-quality.mdx
@@ -72,7 +72,7 @@ pre-push:
 
 **commit-msg**: [Commitlint](https://commitlint.js.org) checks the message against Conventional Commits (below).
 
-**pre-push**: `bun audit --audit-level high` runs, but only from `canary` (`only: ref: canary`), so a vulnerable dependency is caught before the branch leaves your machine without blocking your offline commits. `ensure-remote-branches.ts` seeds the `main` branch that drives the release PR (see [Releases](/docs/manage/release)).
+**pre-push**: `bun audit --audit-level high` runs, but only from `canary` (`only: ref: canary`), so a vulnerable dependency is caught before the branch leaves your machine without blocking your offline commits. `ensure-remote-branches.ts` seeds the release branches (default `main`) that drive the release PR (see [Releases](/docs/manage/release)).
 
 <Callout type="warn" title="The local build sees your real .env">
 

--- a/web/next/content/docs/manage/release.mdx
+++ b/web/next/content/docs/manage/release.mdx
@@ -24,7 +24,7 @@ Under **Settings → Actions → General → Workflow permissions** (the pre-pus
 
 ![GitHub Workflow permissions: Read and write permissions selected and Allow GitHub Actions to create and approve pull requests checked](/marketing/docs/release/workflow-permissions.png)
 
-On a brand-new empty repo, push `canary` first (`git push origin canary`) so GitHub makes it the default branch. The pre-push hook (`.github/scripts/ensure-remote-branches.ts`) then seeds `main` on your next push (a separate ref, so it never collides) and the release PR opens on its own. No `gh` and no repo-admin required.
+On a brand-new empty repo, push `canary` first (`git push origin canary`) so GitHub makes it the default branch. The pre-push hook (`.github/scripts/ensure-remote-branches.ts`) then seeds the release branches (`main` by default) on your next push (each a separate ref, so they never collide) and the release PR opens on its own. No `gh` and no repo-admin required.
 
 ## Land work on canary with squash-merge
 


### PR DESCRIPTION
Closes #581.

## What

Finishes #581: the `ensure-branches` hook was renamed (#631) but its internals stayed hardcoded to `main`. This makes it list-driven so a fork can seed additional long-lived branches without forking the script.

- `.github/scripts/ensure-remote-branches.ts`: introduce `const RELEASE_BRANCHES = ["main"]`. `ensureRemoteBranches` now loops the list, seeding each branch that exists locally and isn't on the remote yet, once `canary` exists. Marker is now **per-branch** (`markerKey(branch, remote)` -> `zerostarter.seeded.<branch>.<remote>`) so a push interrupted partway through resumes cleanly.
- `packages/cli/test/ensure-remote-branches.test.ts`: `markerKey` assertions updated to the `(branch, remote)` signature; added a per-branch scoping case.
- `web/next/content/docs/manage/code-quality.mdx`: one line ("seeds the `main` branch" -> "seeds the release branches (default `main`)").

## Behavior is unchanged for zerostarter

With `RELEASE_BRANCHES = ["main"]` it does exactly what it did before: seed `main` after `canary`. Every guarantee is preserved: GitHub-remotes-only, never blocks the push on an unreachable remote, idempotent, no `gh`/repo-admin.

## Marker migration (harmless)

The key changed from `zerostarter.mainSeeded.<remote>` to `zerostarter.seeded.main.<remote>`. On an already-seeded repo the old marker is orphaned, so the next push re-checks the remote, finds `main` already present, and writes the new marker without re-pushing. One extra `ls-remote`, no side effects.

## Verified

- `bun test packages/cli/test/ensure-remote-branches.test.ts` -> 8 pass
- `check-types:scripts` (tsgo), oxlint, oxfmt, full pre-commit build: all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release branches can now be seeded automatically after the initial `canary` push.
  * Multiple configured release branches are supported, with `main` used by default.
  * Release branch setup is tracked independently for each remote and branch.

* **Bug Fixes**
  * Improved handling of unreachable remotes and failed seed pushes without blocking the push process.

* **Documentation**
  * Clarified release branch seeding and automatic release pull request behavior for new repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->