### PR TITLE
refactor(node): require the node protocol prefix and add the runtime-apis skill

### DIFF
--- a/.agents/skills/runtime-apis/SKILL.md
+++ b/.agents/skills/runtime-apis/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: runtime-apis
+description: Prefer Bun-native APIs, else Node built-ins with the node: prefix. Use when importing a Node built-in (fs, path, child_process, crypto, os, util), reading or writing files, spawning a process, or choosing between a Bun and a Node API.
+---
+
+# Runtime APIs
+
+Two rules, in order:
+
+1. **Bun-first.** When the file runs under Bun and a native equivalent exists, use it: `Bun.file`, `Bun.write`, `Bun.spawn`/`Bun.spawnSync`, `Bun.Glob`, `Bun.YAML`, `Bun.serve`.
+2. **Else the `node:` prefix.** Reach for a Node built-in with the protocol prefix: `import { join } from "node:path"`, `require("node:fs")`. Never the bare form: write `node:path`, not a bare `path` specifier.
+
+The prefix is mandatory even in Bun-only code: it marks the import as a built-in rather than an npm package, so resolution is identical under every runtime.
+
+## Not everything runs under Bun
+
+`Bun.*` exists only on the Bun runtime. These areas run on **Node**, so `node:` is load-bearing and `Bun.*` is a crash, not a style choice:
+
+| Area | Runtime | Rule |
+| --- | --- | --- |
+| `packages/cli/**` | Node | `node:` only. Published to npm, launched via `npx` (bin shebang `#!/usr/bin/env node`); `Bun.*` breaks every npx user. |
+| `web/next/**` | Node | `node:` only. Next.js on Vercel. |
+| `packages/env/**` | Node + Bun | `node:` only. Imported by both web (Node) and api (Bun); stays portable. |
+| `.github/workflows/*` (`actions/github-script`) | Node | `require("node:...")`. |
+
+Bun-first applies to Bun-only files: `.github/scripts/*.ts` (`bun x.ts`). The CLI test files run under `bun test` but mirror the CLI's `node:` style on purpose.
+
+## Bun equivalents
+
+| Need | Bun (preferred) | Node fallback |
+| --- | --- | --- |
+| read file text | `await Bun.file(p).text()` | `node:fs` readFileSync |
+| read file bytes | `await Bun.file(p).arrayBuffer()` | `node:fs` readFileSync |
+| write file | `await Bun.write(p, data)` | `node:fs` writeFileSync |
+| file exists | `await Bun.file(p).exists()` | `node:fs` existsSync |
+| spawn a process | `Bun.spawn` / `Bun.spawnSync` | `node:child_process` |
+| glob | `new Bun.Glob(pattern)` | (none) |
+| parse YAML | `Bun.YAML.parse` | (none) |
+| serve HTTP/WS | `Bun.serve` | `@hono/node-server` (Vercel only) |
+
+## Built-ins with no Bun equivalent (always `node:`)
+
+`node:path`, `node:os`, `node:util`, `node:crypto`, `node:readline/promises`, and the directory/sync parts of `node:fs` (`existsSync` in sync code, `mkdirSync`, `mkdtempSync`, `readdirSync`, `rmSync`). Bun ships no `Bun.path`/`Bun.os`, so `node:` is the idiomatic API for these even in pure-Bun files.
+
+## Audit
+
+No bare (unprefixed) built-in specifier may exist anywhere. This prints nothing when clean:
+
+```bash
+rg -n "from ['\"](assert|buffer|child_process|crypto|events|fs|http|https|net|os|path|process|querystring|readline|stream|string_decoder|tls|tty|url|util|zlib)(/[a-z]+)?['\"]|require\(['\"](child_process|crypto|fs|os|path|util)['\"]\)" -g '!**/dist/**' -g '!.claude/worktrees/**' --hidden
+```
+
+The full per-file inventory lives in [`index.md`](index.md): every file, its runtime, and the `node:` modules it imports. Regenerate it when the surface changes:
+
+```bash
+rg -n "node:[a-z/_]+" -g '!**/dist/**' -g '!.claude/worktrees/**' --hidden
+```

--- a/.agents/skills/runtime-apis/SKILL.md
+++ b/.agents/skills/runtime-apis/SKILL.md
@@ -46,8 +46,11 @@ Bun-first applies to Bun-only files: `.github/scripts/*.ts` (`bun x.ts`). The CL
 
 No bare (unprefixed) built-in specifier may exist anywhere. This prints nothing when clean:
 
+The alternation `$B` is the full Node built-in list, so a new bare import cannot slip through; extend it only if Node ships a new module.
+
 ```bash
-rg -n "from ['\"](assert|buffer|child_process|crypto|events|fs|http|https|net|os|path|process|querystring|readline|stream|string_decoder|tls|tty|url|util|zlib)(/[a-z]+)?['\"]|require\(['\"](child_process|crypto|fs|os|path|util)['\"]\)" -g '!**/dist/**' -g '!.claude/worktrees/**' --hidden
+B='assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|diagnostics_channel|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|trace_events|tty|url|util|v8|vm|wasi|worker_threads|zlib'
+rg -n "from ['\"]($B)(/[a-z_]+)?['\"]|require\(['\"]($B)(/[a-z_]+)?['\"]\)" -g '!**/dist/**' -g '!.claude/worktrees/**' --hidden
 ```
 
 The full per-file inventory lives in [`index.md`](index.md): every file, its runtime, and the `node:` modules it imports. Regenerate it when the surface changes:

--- a/.agents/skills/runtime-apis/index.md
+++ b/.agents/skills/runtime-apis/index.md
@@ -1,0 +1,45 @@
+# Node API index
+
+Per-file inventory of every Node built-in used in the repo, for the [`runtime-apis`](SKILL.md) skill.
+Snapshot: 2026-07-11. Regenerate with the `rg "node:..."` command in `SKILL.md`.
+
+The `Runtime` column drives the rule: **Node** and **Both** files stay on `node:` (no `Bun.*`);
+**Bun** files may move a call to a `Bun.*` equivalent where one exists.
+
+| File | Runtime | `node:` modules (APIs used) |
+| --- | --- | --- |
+| `.github/scripts/compress-images.ts` | Bun | `node:path` (path) |
+| `.github/scripts/docs.ts` | Bun | `node:path` (path) |
+| `.github/scripts/ensure-remote-branches.ts` | Bun | `node:child_process` (execFileSync) |
+| `.github/scripts/shadcn-customize.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (readFileSync, writeFileSync) |
+| `.github/workflows/auto-labeler.yml` | Node | `node:fs`, `node:path` (via `require`, `actions/github-script`) |
+| `packages/cli/bin/commands/_args.ts` | Node | `node:util` (parseArgs, ParseArgsConfig) |
+| `packages/cli/bin/commands/_bun.ts` | Node | `node:os` (homedir); `node:path` (delimiter, join) |
+| `packages/cli/bin/commands/_prompt.ts` | Node | `node:readline/promises` (createInterface) |
+| `packages/cli/bin/commands/init.ts` | Node | `node:fs` (existsSync, readdirSync, readFileSync); `node:path` (basename, dirname, join, parse, resolve) |
+| `packages/cli/bin/commands/reinit.ts` | Node | `node:path` (basename, resolve) |
+| `packages/cli/bin/commands/sync.ts` | Node | `node:path` (join, resolve) |
+| `packages/cli/src/convert.ts` | Node | `node:path` (join) |
+| `packages/cli/src/db.ts` | Node | `node:crypto` (randomBytes); `node:path` (join) |
+| `packages/cli/src/git.ts` | Node | `node:path` (join) |
+| `packages/cli/src/io.ts` | Node | `node:fs` (existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync); `node:path` (dirname, join) |
+| `packages/cli/src/vendor/nano-spawn.ts` | Node | `node:child_process` (spawn, SpawnOptions); `node:fs/promises` (access); `node:path` (delimiter, resolve) |
+| `packages/cli/test/convert.test.ts` | Bun | `node:fs` (mkdtempSync, readFileSync, rmSync); `node:os` (tmpdir); `node:path` (join) |
+| `packages/cli/test/db.test.ts` | Bun | `node:fs` (mkdtempSync, readFileSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
+| `packages/cli/test/git.test.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
+| `packages/cli/test/io.test.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (mkdirSync, mkdtempSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
+| `packages/env/src/lib/utils.ts` | Both | `node:path` (path) |
+| `packages/env/tsdown.config.ts` | Build | `node:child_process` (execSync) |
+| `web/next/src/app/layout.tsx` | Node | `node:fs` (existsSync); `node:path` (join) |
+
+## Convertible to `Bun.*` (optional, Bun-only files)
+
+Only where the file runs **only** under Bun and the call has a `Bun.*` equivalent:
+
+| File | Node call | Bun equivalent |
+| --- | --- | --- |
+| `.github/scripts/ensure-remote-branches.ts` | `execFileSync` | `Bun.spawnSync` |
+| `.github/scripts/shadcn-customize.ts` | `execFileSync` | `Bun.spawnSync` |
+| `.github/scripts/shadcn-customize.ts` | `readFileSync` / `writeFileSync` | `Bun.file().text()` / `Bun.write` |
+
+`ensure-remote-branches.ts` is also shared into forks via `lefthook.yml`, where portable `node:child_process` is a feature, not a gap.

--- a/.github/scripts/compress-images.ts
+++ b/.github/scripts/compress-images.ts
@@ -1,4 +1,4 @@
-import path from "path"
+import path from "node:path"
 
 import { Glob } from "bun"
 import sharp from "sharp"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -45,8 +45,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const path = require('path');
+            const fs = require('node:fs');
+            const path = require('node:path');
             const { globbySync } = require('globby');
 
             const { number: prNumber } = context.payload.pull_request;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ This file provides guidance to AI coding agents when working with code in this r
 ## Instructions
 
 - ALWAYS: Use `@/` for imports, if applicable.
+- ALWAYS: Create git worktrees under `.claude/worktrees/` (repo-root relative), one directory per worktree. Never place them elsewhere (`/tmp`, home, or a sibling of the repo).
+- ALWAYS: Prefer a Bun-native API when the file runs under Bun and one exists (`Bun.file`, `Bun.write`, `Bun.spawn`); otherwise use a Node built-in with the `node:` protocol prefix (`import { join } from "node:path"`, `require("node:fs")`), never the bare specifier. Node-runtime code (the `packages/cli` npm binary, `web/next`, and shared `packages/env`) stays on `node:`. See the `runtime-apis` skill.
 - ALWAYS: Follow the `design` skill for UI, styling, and design decisions (it holds the canonical conventions). Update it in the same change when a convention changes.
 - ALWAYS: For any frontend or UI change, verify it in a real browser with agent-browser before opening or updating a PR; drive the actual page or flow, do not rely on type-check and lint alone. Run the end-to-end flow when the change spans it or when asked. Capture screenshots, upload them to litterbox (72h), and attach the URLs to the PR. See the `ui-verify` skill.
 - ALWAYS: Keep documentation in sync with every change. Whenever code, structure, conventions, or tooling change, update the matching docs in the same change (e.g. `web/next/content/docs/`, `README.md`, the `llms.txt`/`llms-full.txt` context routes, skill docs under `.agents/skills/` and `.claude/skills/`, and these agent guides `AGENTS.md`/`CLAUDE.md`). Docs must never drift.
@@ -44,5 +46,6 @@ Custom skills live in `.agents/skills` (symlinked to `.claude/skills` and `.gith
 | `fonts`         | Add or swap a self-hosted web font.                                                                |
 | `gh-commit`     | Make atomic, conventional commits.                                                                 |
 | `ignore-sync`   | Keep `.dockerignore` in step with `.gitignore`.                                                    |
+| `runtime-apis`  | Prefer Bun-native APIs; fall back to Node built-ins with the `node:` prefix.                       |
 | `shadcn-sync`   | Run and reconcile the shadcn component sync.                                                       |
 | `ui-verify`     | Verify a frontend or UI change in a real browser and attach screenshots to the PR.                 |

--- a/web/next/content/docs/resources/ai-skills.mdx
+++ b/web/next/content/docs/resources/ai-skills.mdx
@@ -17,13 +17,13 @@ name: api-endpoint
 description: Add a typed Hono API endpoint following repo conventions... Use when adding or modifying API routes in api/hono.
 ```
 
-An agent reads those descriptions, matches the task in front of it against the "Use when…" trigger, loads the one skill that fits, and follows the procedure verbatim. Only the descriptions are scanned up front, so all fourteen skills cost almost nothing in context until one is needed; the full procedure loads only on a match.
+An agent reads those descriptions, matches the task in front of it against the "Use when…" trigger, loads the one skill that fits, and follows the procedure verbatim. Only the descriptions are scanned up front, so the whole catalog costs almost nothing in context until one is needed; the full procedure loads only on a match.
 
 When you don't know where to start, the `codebase-map` skill orients first; it maps where each kind of change lives and how types ripple across the stack. It is the one skill worth reading before you have a specific task.
 
 ## The catalog
 
-Fourteen skills, arranged as the arc of a real task, **Navigate** to find your way, **Build** the feature, **Operate** the running app, **Maintain** the scaffolding, **Ship** the change:
+The skills, arranged as the arc of a real task, **Navigate** to find your way, **Build** the feature, **Operate** the running app, **Maintain** the scaffolding, **Ship** the change:
 
 | Stage    | Skill           | What it does                                                                                                                  |
 | -------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
@@ -43,7 +43,7 @@ Fourteen skills, arranged as the arc of a real task, **Navigate** to find your w
 | Ship     | `doc-sync`      | Sync docs and skills so a change never ships drift: the surface map, a grep sweep, and the strict docs build.                 |
 | Ship     | `gh-commit`     | Atomic commits in conventional-commit format.                                                                                 |
 
-Only `agent-browser` is vendored. It comes from [`vercel-labs/agent-browser`](https://github.com/vercel-labs/agent-browser), pinned in `skills-lock.json` for integrity. Its committed `SKILL.md` is a discovery stub; the agent loads the live workflow from the CLI with `agent-browser skills get core`. Install it with `npm i -g agent-browser && agent-browser install`. The other thirteen are written for this repo.
+Only `agent-browser` is vendored. It comes from [`vercel-labs/agent-browser`](https://github.com/vercel-labs/agent-browser), pinned in `skills-lock.json` for integrity. Its committed `SKILL.md` is a discovery stub; the agent loads the live workflow from the CLI with `agent-browser skills get core`. Install it with `npm i -g agent-browser && agent-browser install`. Every other skill is written for this repo.
 
 ## Writing your own
 

--- a/web/next/content/docs/resources/ai-skills.mdx
+++ b/web/next/content/docs/resources/ai-skills.mdx
@@ -32,6 +32,7 @@ Fourteen skills, arranged as the arc of a real task, **Navigate** to find your w
 | Build    | `db-migration`  | Change the Drizzle schema and apply it: `db:generate`, then `db:migrate`.                                                     |
 | Build    | `dev`           | Start, restart, and verify the dev stack; fixes the `bun --hot` trap where new files return `NOT_FOUND`.                      |
 | Build    | `design`        | The canonical UI conventions: spacing, color, cursor, typography, tokens. Follow it for any component work.                   |
+| Build    | `runtime-apis`  | Prefer Bun-native APIs; fall back to Node built-ins with the required `node:` prefix.                                         |
 | Operate  | `agent-browser` | Drive the running app like a user: navigate, click, and snapshot the accessibility tree.                                      |
 | Operate  | `docker-test`   | Build and smoke-test the Docker images with `docker compose`.                                                                 |
 | Operate  | `audit`         | Run the dependency security audit and maintain `AUDIT.md`; unblocks the pre-push audit hook.                                  |


### PR DESCRIPTION
## What

Verifying the "everything is on Bun APIs" claim surfaced that the repo is deliberately mixed: two areas run on the **Node** runtime, so their `node:` imports are load-bearing, not migration debt. This PR makes the real convention explicit and enforceable, and fixes the few bare (unprefixed) specifiers.

## The rule

1. **Bun-first** where the file runs under Bun and a native API exists (`Bun.file`, `Bun.write`, `Bun.spawn`, ...).
2. Otherwise a Node built-in with the **`node:` protocol prefix**, never the bare specifier.

Node-runtime code stays on `node:` and cannot use `Bun.*`:

- `packages/cli/**` is published to npm and launched via `npx` (bin shebang `#!/usr/bin/env node`); `Bun.*` would crash every npx user.
- `web/next/**` runs as Next.js on Vercel.
- `packages/env/**` is imported by both Node (web) and Bun (api), so it stays portable.

## Changes

- **Prefix fixes** (the only bare specifiers in the repo):
  - `.github/scripts/compress-images.ts`: `"path"` -> `"node:path"`.
  - `.github/workflows/auto-labeler.yml`: `require('fs'|'path')` -> `require('node:fs'|'node:path')`.
- **New `runtime-apis` skill** (`.agents/skills/runtime-apis/`): the Bun-first / `node:`-prefix rule, the runtime map, a Bun-equivalents table, an audit command, and a full per-file `index.md` inventory of every `node:` module in the repo.
- **AGENTS.md**: two new ALWAYS rules (create worktrees under `.claude/worktrees/`; Bun-first else the `node:` prefix) and the skill added to the skills table.
- **ai-skills.mdx**: the skill added to the docs skill table.

## Not changed (on purpose)

The CLI, `web/next`, and `packages/env` keep their `node:` imports; converting them to `Bun.*` would crash npx users and the Vercel build. The narrow set that could move to `Bun.*` (Bun-only scripts) is listed in the skill's `index.md`.

## Verification

- The skill's audit command prints nothing: no bare builtin specifiers remain anywhere.
- Pre-commit build + lint (oxfmt) + commitlint passed on both commits.

No runtime/UI surface changes (tooling, workflow, and docs only), so no browser verification applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new `runtime-apis` skill to the AI skills catalog.
  * Documented guidance for preferring Bun-native APIs and using explicit Node built-in module prefixes when needed.
  * Clarified worktree creation requirements for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->