### PR TITLE
ci(release): patch-by-default releases with a manual pin, CLI tracks release; cut 0.1.0

### DIFF
--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -23,6 +23,7 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 - [A better landing page](landing-page.md) - #26.
 - [Bun-native file APIs in .github/scripts](bun-native-scripts.md) - #423.
 - [Org-creation name and other restrictions](org-creation-restrictions.md) - #349.
+- [Standardize and pin the release-workflow tooling](workflow-tooling-consistency.md) - deferred from #683 (JSON tool standardized on `json`; pinning + read-helper unification left).
 
 ### Architecture deepenings (2026-07-12 review, deep-module lens)
 

--- a/.github/notes/plans/workflow-tooling-consistency.md
+++ b/.github/notes/plans/workflow-tooling-consistency.md
@@ -1,0 +1,9 @@
+# Standardize and pin the release-workflow tooling
+
+- Status: backlog
+- Links: PR #683 (JSON tool standardized on `json`)
+
+The release workflows (`auto-release.yml`, `cli-release.yml`) shell out to several bunx tools. JSON edits are now standardized on `bunx json -I` across both (fx dropped: smaller, zero-dep, native in-place, already the incumbent; the runtime gap is negligible at release cadence). Two consistency threads remain, deferred:
+
+- **Pin the bunx tools.** `bunx changelogen`, `bunx oxfmt`, `bunx json`, `bunx semver` are all unpinned (`@latest`). Pin them to explicit versions for supply-chain safety and reproducible releases (see the pin-package-versions convention).
+- **Unify JSON reads.** Field reads are split between `bun -e 'JSON.parse(...)'` (auto-release) and `bunx json -f -a` (cli-release). Both work; pick one for consistency. Bun-native is faster and dependency-free for reads, so leaning that way, with `bunx json -I` kept for the in-place edits.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -44,7 +44,7 @@ jobs:
           BOUNDARY=$(git rev-parse HEAD)
           LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
           LAST_VERSION="${LAST_TAG#v}"
-          # version target: a hand-set package.json version (ahead of the last tag) ships as-is; otherwise every release bumps the minor. captured before changelogen, which only computes a patch.
+          # version target: a hand-set package.json version (ahead of the last tag) ships as-is; otherwise changelogen's patch bump stands. captured before changelogen overwrites it.
           MANUAL_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
           if [ -n "$LAST_TAG" ]; then
             # only changelog commits (or nothing) since the anchor: skip, but backfill the
@@ -69,17 +69,13 @@ jobs:
           else
             bunx changelogen --bump --no-commit || true
           fi
-          # retarget changelogen's patch to the intended version: a hand-set number (ahead of the last tag) as-is, otherwise a minor bump. a pinned number resumes minor-bumping on the next release.
-          AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
+          # honor a hand-set version: when package.json is ahead of the last tag, retarget changelogen's computed patch to that number; otherwise the patch bump stands.
           if [ -n "$LAST_TAG" ] && [ "$MANUAL_VERSION" != "$LAST_VERSION" ]; then
-            TARGET_VERSION="$MANUAL_VERSION"
-          else
-            BASE_VERSION="${LAST_VERSION:-${MANUAL_VERSION:-0.0.0}}"
-            TARGET_VERSION=$(bun -e "const p='$BASE_VERSION'.split('.'); console.log(p[0]+'.'+(Number(p[1])+1)+'.0')")
-          fi
-          if [ -n "$TARGET_VERSION" ] && [ "$TARGET_VERSION" != "$AUTO_VERSION" ]; then
-            sed -i "s|\"version\": \"$AUTO_VERSION\"|\"version\": \"$TARGET_VERSION\"|" package.json
-            sed -i "s|v${AUTO_VERSION}|v${TARGET_VERSION}|g" CHANGELOG.md
+            AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
+            if [ "$MANUAL_VERSION" != "$AUTO_VERSION" ]; then
+              sed -i "s|\"version\": \"$AUTO_VERSION\"|\"version\": \"$MANUAL_VERSION\"|" package.json
+              sed -i "s|v${AUTO_VERSION}|v${MANUAL_VERSION}|g" CHANGELOG.md
+            fi
           fi
           bunx oxfmt --write CHANGELOG.md
           # refresh the build-graph snapshot for this release from a fresh CI build

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -44,7 +44,7 @@ jobs:
           BOUNDARY=$(git rev-parse HEAD)
           LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
           LAST_VERSION="${LAST_TAG#v}"
-          # a hand-set package.json version (ahead of the last release tag) ships as-is; otherwise changelogen auto-increments. lets a maintainer pin a milestone like 0.1.0, then auto-bumping resumes from it.
+          # version target: a hand-set package.json version (ahead of the last tag) ships as-is; otherwise every release bumps the minor. captured before changelogen, which only computes a patch.
           MANUAL_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
           if [ -n "$LAST_TAG" ]; then
             # only changelog commits (or nothing) since the anchor: skip, but backfill the
@@ -69,13 +69,17 @@ jobs:
           else
             bunx changelogen --bump --no-commit || true
           fi
-          # honor a hand-set version: retarget changelogen's computed bump to the maintainer's number, then auto-bumping resumes from it next release
-          if [ -n "$LAST_TAG" ] && [ -n "$MANUAL_VERSION" ] && [ "$MANUAL_VERSION" != "$LAST_VERSION" ]; then
-            AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
-            if [ "$MANUAL_VERSION" != "$AUTO_VERSION" ]; then
-              sed -i "s|\"version\": \"$AUTO_VERSION\"|\"version\": \"$MANUAL_VERSION\"|" package.json
-              sed -i "s|v${AUTO_VERSION}|v${MANUAL_VERSION}|g" CHANGELOG.md
-            fi
+          # retarget changelogen's patch to the intended version: a hand-set number (ahead of the last tag) as-is, otherwise a minor bump. a pinned number resumes minor-bumping on the next release.
+          AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
+          if [ -n "$LAST_TAG" ] && [ "$MANUAL_VERSION" != "$LAST_VERSION" ]; then
+            TARGET_VERSION="$MANUAL_VERSION"
+          else
+            BASE_VERSION="${LAST_VERSION:-${MANUAL_VERSION:-0.0.0}}"
+            TARGET_VERSION=$(bun -e "const p='$BASE_VERSION'.split('.'); console.log(p[0]+'.'+(Number(p[1])+1)+'.0')")
+          fi
+          if [ -n "$TARGET_VERSION" ] && [ "$TARGET_VERSION" != "$AUTO_VERSION" ]; then
+            sed -i "s|\"version\": \"$AUTO_VERSION\"|\"version\": \"$TARGET_VERSION\"|" package.json
+            sed -i "s|v${AUTO_VERSION}|v${TARGET_VERSION}|g" CHANGELOG.md
           fi
           bunx oxfmt --write CHANGELOG.md
           # refresh the build-graph snapshot for this release from a fresh CI build

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -43,6 +43,9 @@ jobs:
           # the boundary this changelog covers; tagged below so the next run starts exactly here
           BOUNDARY=$(git rev-parse HEAD)
           LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
+          LAST_VERSION="${LAST_TAG#v}"
+          # a hand-set package.json version (ahead of the last release tag) ships as-is; otherwise changelogen auto-increments. lets a maintainer pin a milestone like 0.1.0, then auto-bumping resumes from it.
+          MANUAL_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
           if [ -n "$LAST_TAG" ]; then
             # only changelog commits (or nothing) since the anchor: skip, but backfill the
             # release if a previous run pushed the commit+tag and failed before publishing
@@ -65,6 +68,14 @@ jobs:
             fi
           else
             bunx changelogen --bump --no-commit || true
+          fi
+          # honor a hand-set version: retarget changelogen's computed bump to the maintainer's number, then auto-bumping resumes from it next release
+          if [ -n "$LAST_TAG" ] && [ -n "$MANUAL_VERSION" ] && [ "$MANUAL_VERSION" != "$LAST_VERSION" ]; then
+            AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
+            if [ "$MANUAL_VERSION" != "$AUTO_VERSION" ]; then
+              sed -i "s|\"version\": \"$AUTO_VERSION\"|\"version\": \"$MANUAL_VERSION\"|" package.json
+              sed -i "s|v${AUTO_VERSION}|v${MANUAL_VERSION}|g" CHANGELOG.md
+            fi
           fi
           bunx oxfmt --write CHANGELOG.md
           # refresh the build-graph snapshot for this release from a fresh CI build

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -77,7 +77,7 @@ jobs:
             fi
             AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
             if [ "$MANUAL_VERSION" != "$AUTO_VERSION" ]; then
-              V="$MANUAL_VERSION" bunx fx package.json 'x => ({ ...x, version: process.env.V })' > package.json.tmp && mv package.json.tmp package.json
+              bunx json -I -f package.json -e "this.version=\"$MANUAL_VERSION\""
               AUTO_ESC=$(printf '%s' "$AUTO_VERSION" | sed 's/[.]/\\./g')
               sed -i "s|v${AUTO_ESC}|v${MANUAL_VERSION}|g" CHANGELOG.md
             fi

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -69,12 +69,17 @@ jobs:
           else
             bunx changelogen --bump --no-commit || true
           fi
-          # honor a hand-set version: when package.json is ahead of the last tag, retarget changelogen's computed patch to that number; otherwise the patch bump stands.
+          # honor a hand-set version: ship it exactly when package.json is ahead of the last tag; otherwise changelogen's patch bump stands. a lower pin would move the release backward, so fail loud instead.
           if [ -n "$LAST_TAG" ] && [ "$MANUAL_VERSION" != "$LAST_VERSION" ]; then
+            if ! bun -e "const a='$MANUAL_VERSION'.split('.').map(Number), b='$LAST_VERSION'.split('.').map(Number); process.exit((a[0]-b[0] || a[1]-b[1] || a[2]-b[2]) > 0 ? 0 : 1)"; then
+              echo "::error::hand-set version $MANUAL_VERSION is not ahead of the last release v$LAST_VERSION"
+              exit 1
+            fi
             AUTO_VERSION=$(bun -e 'console.log(JSON.parse(await Bun.file("package.json").text()).version)')
             if [ "$MANUAL_VERSION" != "$AUTO_VERSION" ]; then
-              sed -i "s|\"version\": \"$AUTO_VERSION\"|\"version\": \"$MANUAL_VERSION\"|" package.json
-              sed -i "s|v${AUTO_VERSION}|v${MANUAL_VERSION}|g" CHANGELOG.md
+              V="$MANUAL_VERSION" bunx fx package.json 'x => ({ ...x, version: process.env.V })' > package.json.tmp && mv package.json.tmp package.json
+              AUTO_ESC=$(printf '%s' "$AUTO_VERSION" | sed 's/[.]/\\./g')
+              sed -i "s|v${AUTO_ESC}|v${MANUAL_VERSION}|g" CHANGELOG.md
             fi
           fi
           bunx oxfmt --write CHANGELOG.md

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - canary
-      - main
     paths:
       - "packages/cli/**"
+  release:
+    types: [published]
   issue_comment:
     types: [created]
 
@@ -20,7 +21,7 @@ permissions:
 
 jobs:
   test:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'release'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -47,6 +48,7 @@ jobs:
     if: |
       always() && !failure() && !cancelled() && (
         github.event_name == 'push' ||
+        github.event_name == 'release' ||
         github.event_name == 'issue_comment' && github.event.comment.user.login == github.repository_owner && startsWith(github.event.comment.body, '/release')
       )
     needs: [test]
@@ -75,23 +77,26 @@ jobs:
         run: |
           PACKAGE_NAME=$(bunx json -f package.json -a name)
           npm view "$PACKAGE_NAME" 2>/dev/null || { echo "$PACKAGE_NAME does not exist in the npm registry. Skipping publish."; exit 0; }
-          PACKAGE_VERSION=$(bunx json -f package.json -a version)
           VERSIONS=$(npm view $PACKAGE_NAME dist-tags --json)
           LATEST_VERSION=$(echo $VERSIONS | bunx json latest)
+          # the CLI has no version of its own (package.json is a 0.0.0 placeholder CI stamps): it ships the repo's release version, read from the tag the release event carries
           if [[ $GITHUB_EVENT_NAME == 'issue_comment' ]]; then
             PR_NUMBER=$(echo "${{ github.event.issue.pull_request.url }}" | grep -o '[0-9]*$')
             LATEST_COMMIT_SHA=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" | bunx json -a sha | tail -n 1)
             git checkout $LATEST_COMMIT_SHA
             TAG="test"
             RELEASE_VERSION="0.0.0-${LATEST_COMMIT_SHA:0:7}"
-          elif [[ $GITHUB_REF_NAME == 'main' ]]; then
-            [[ $PACKAGE_VERSION == $LATEST_VERSION ]] && { echo "No version change on main. Skipping publish."; exit 0; }
-            RELEASE_VERSION=$PACKAGE_VERSION
+          elif [[ $GITHUB_EVENT_NAME == 'release' ]]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            RELEASE_VERSION="${TAG_NAME#v}"
+            [[ $RELEASE_VERSION == $LATEST_VERSION ]] && { echo "CLI already at $RELEASE_VERSION on npm. Skipping publish."; exit 0; }
             TAG="latest"
           else
             TAG="canary"
+            LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "v0.0.0")
+            NEXT_VERSION=$(bun -e "const p='${LAST_TAG#v}'.split('.'); console.log(p[0]+'.'+(Number(p[1])+1)+'.0')")
             TAGGED_VERSION=$(echo $VERSIONS | bunx json $TAG)
-            RELEASE_VERSION=$([[ $TAGGED_VERSION == $PACKAGE_VERSION-canary* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $PACKAGE_VERSION-canary.0)
+            RELEASE_VERSION=$([[ $TAGGED_VERSION == $NEXT_VERSION-canary* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $NEXT_VERSION-canary.0)
           fi
 
           bunx json -I -f package.json -e "this.version=\"$RELEASE_VERSION\""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.99",
+  "version": "0.1.0",
   "private": true,
   "homepage": "https://github.com/nrjdalal/zerostarter#readme",
   "bugs": "https://github.com/nrjdalal/zerostarter/issues",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.26",
+  "version": "0.0.0",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",

--- a/web/next/content/docs/manage/release.mdx
+++ b/web/next/content/docs/manage/release.mdx
@@ -56,7 +56,7 @@ Mark the draft ready, review it, and merge with a **merge commit**. That merge i
 `auto-release.yml` checks out `canary` and:
 
 - generates `CHANGELOG.md` from the last `v*` tag,
-- bumps the **minor** version in `package.json` (or ships the exact version you hand-set, see [Pinning a version](#pinning-a-version)),
+- bumps the **patch** version in `package.json` (or ships the exact version you hand-set, see [Pinning a version](#pinning-a-version)),
 - refreshes the build-graph snapshot at `.github/assets/graph-build.svg`,
 - commits `ci(changelog): update changelog and bump version` directly onto `canary`,
 - tags `v<version>` and pushes branch and tag atomically,
@@ -71,7 +71,7 @@ The changelog commit lands directly on `canary` rather than through a second PR 
 
 ## Pinning a version
 
-Every release bumps the **minor** version by default (`0.1.0`, `0.2.0`, ...). To cut a specific milestone instead (a major like `1.0.0`, or a patch), set the `version` in the root `package.json` yourself on `canary` before you merge the release PR. `auto-release.yml` notices a hand-set version that is ahead of the last `v*` tag and ships that exact number (retargeting the generated changelog section to it), then resumes minor-bumping from it on the next release.
+Ordinary releases bump the **patch** (`0.1.0 -> 0.1.1 -> ...`). To cut something bigger (a minor like `0.2.0` or a major like `1.0.0`), set the `version` in the root `package.json` yourself on `canary` before you merge the release PR. `auto-release.yml` notices a hand-set version that is ahead of the last `v*` tag and ships that exact number (retargeting the generated changelog section to it), then resumes patch-bumping from it on the next release.
 
 ## How it deploys
 

--- a/web/next/content/docs/manage/release.mdx
+++ b/web/next/content/docs/manage/release.mdx
@@ -55,8 +55,8 @@ Mark the draft ready, review it, and merge with a **merge commit**. That merge i
 
 `auto-release.yml` checks out `canary` and:
 
-- generates `CHANGELOG.md` with `changelogen --bump` from the last `v*` tag,
-- bumps the version in `package.json` (or ships the exact version you hand-set, see [Pinning a version](#pinning-a-version)),
+- generates `CHANGELOG.md` from the last `v*` tag,
+- bumps the **minor** version in `package.json` (or ships the exact version you hand-set, see [Pinning a version](#pinning-a-version)),
 - refreshes the build-graph snapshot at `.github/assets/graph-build.svg`,
 - commits `ci(changelog): update changelog and bump version` directly onto `canary`,
 - tags `v<version>` and pushes branch and tag atomically,
@@ -71,7 +71,7 @@ The changelog commit lands directly on `canary` rather than through a second PR 
 
 ## Pinning a version
 
-The version auto-increments by default. To cut a deliberate milestone (say `0.1.0` rather than the next patch), bump the `version` in the root `package.json` yourself on `canary` before you merge the release PR. `auto-release.yml` notices a hand-set version that is ahead of the last `v*` tag, ships that exact number (retargeting the generated changelog section to it), then resumes auto-incrementing from it on the next release. Leave `package.json` alone and it bumps automatically as before.
+Every release bumps the **minor** version by default (`0.1.0`, `0.2.0`, ...). To cut a specific milestone instead (a major like `1.0.0`, or a patch), set the `version` in the root `package.json` yourself on `canary` before you merge the release PR. `auto-release.yml` notices a hand-set version that is ahead of the last `v*` tag and ships that exact number (retargeting the generated changelog section to it), then resumes minor-bumping from it on the next release.
 
 ## How it deploys
 

--- a/web/next/content/docs/manage/release.mdx
+++ b/web/next/content/docs/manage/release.mdx
@@ -56,7 +56,7 @@ Mark the draft ready, review it, and merge with a **merge commit**. That merge i
 `auto-release.yml` checks out `canary` and:
 
 - generates `CHANGELOG.md` with `changelogen --bump` from the last `v*` tag,
-- bumps the version in `package.json`,
+- bumps the version in `package.json` (or ships the exact version you hand-set, see [Pinning a version](#pinning-a-version)),
 - refreshes the build-graph snapshot at `.github/assets/graph-build.svg`,
 - commits `ci(changelog): update changelog and bump version` directly onto `canary`,
 - tags `v<version>` and pushes branch and tag atomically,
@@ -68,6 +68,10 @@ If the commit range holds only filtered-out types (like `ci`), it skips the rele
 </Steps>
 
 The changelog commit lands directly on `canary` rather than through a second PR because it's mechanical, generated from PR titles you already reviewed. If a run tags the version but fails before publishing, the next run backfills the missing GitHub release.
+
+## Pinning a version
+
+The version auto-increments by default. To cut a deliberate milestone (say `0.1.0` rather than the next patch), bump the `version` in the root `package.json` yourself on `canary` before you merge the release PR. `auto-release.yml` notices a hand-set version that is ahead of the last `v*` tag, ships that exact number (retargeting the generated changelog section to it), then resumes auto-incrementing from it on the next release. Leave `package.json` alone and it bumps automatically as before.
 
 ## How it deploys
 


### PR DESCRIPTION
## Summary

Reworks release versioning so the whole project ships under **one number**, computed automatically, with a human pin for anything bigger than a patch. The CLI stops carrying a second version and follows the repo. Also cuts this release as `0.1.0`.

The logic lives in two files, split by audience:

- **`auto-release.yml`** (template, ships to forks) owns the repo version, tag, and GitHub release. It is **CLI-agnostic**.
- **`cli-release.yml`** (fork-excluded, ZeroStarter-only) owns the npm publish of the CLI. It reads the release tag. It is the **only** place with CLI code.

## The rules

| Rule | Where it lives |
|---|---|
| Root not bumped manually -> bump the **patch** (`0.1.0 -> 0.1.1 -> ...`) | `auto-release.yml` |
| Root hand-set ahead of the last tag -> release **that exact number** (a minor or major), then patch-bumps resume from it | `auto-release.yml` |
| All packages incl. the CLI sit at `0.0.0` | `packages/cli` -> `0.0.0` (the rest already were) |
| CLI publishes the repo release version, **every release** | `cli-release.yml` (sourced from the tag) |
| `auto-release` has **no CLI code** | it does not reference the CLI |

## How it works, end to end

**Steady state, one merge = one release:**

1. Feature PRs squash-merge into `canary`.
2. A draft `canary -> main` PR stays open on its own (`auto-canary-into-main.yml`).
3. You merge that PR with a **merge commit**. That fires `auto-release.yml`, which picks the version by one rule: root `package.json` untouched since the last tag -> **patch bump** (changelogen's native 0.x behavior); root hand-set ahead of the last tag -> **that exact number**. It writes the changelog + version onto `canary`, tags `v<version>`, and publishes the GitHub release.
4. The published release fires `cli-release.yml`: it reads the version from the **tag**, stamps `packages/cli` to it, builds, and runs `npm publish` on the `latest` tag -> `zerostarter@<version>`.

The tag, the GitHub release, and the npm CLI all land at the same number from that one merge. There is no version to hand-maintain anywhere except the optional pin.

**Why the CLI reads the tag, not `main`'s `package.json`:** the version bump lands on `canary` (that is how `auto-release` works), so `main`'s file trails. Verified on the live repo: `origin/main` is `0.0.98` while the release is `0.0.99`. Reading `main` would publish the previous number. The tag carries the real release version and is created by the merge, so `cli-release` triggers on the published release and uses the tag.

## This release (`0.1.0`), concretely

- **Merge this PR into `canary`.** `canary` now has root `= 0.1.0`, both new workflows, and `packages/cli = 0.0.0`. Side effect: this touches `packages/cli`, so `cli-release` publishes a `0.1.0-canary.0` preview on the `canary` npm tag (harmless).
- **Merge release PR #676 (`canary -> main`) with a merge commit.**
  - `auto-release`: last tag `v0.0.99`, root pinned `0.1.0`. Since `0.1.0 != 0.0.99`, it ships **`0.1.0`** (changelogen computes a `0.1.1` patch; the retarget step lowers it to the pinned `0.1.0`, header and compare link included). Tags `v0.1.0`, publishes release `v0.1.0`.
  - `cli-release` fires on that release -> publishes **`zerostarter@0.1.0`** as `latest`.

So `0.1.0` itself is a deliberate pin (a minor jump off `0.0.99`); from there, ordinary releases patch-bump.

## Afterwards

- **Next ordinary release:** nobody touches the version -> `auto-release` bumps the **patch** -> `v0.1.1`, CLI publishes `0.1.1`. Then `0.1.2`, and so on.
- **A bigger version (minor `0.2.0`, or a major `1.0.0`):** set root `package.json` to it on `canary`, merge the release PR -> ships that exact number; the next ordinary release resumes patch-bumping from it (`1.0.0 -> 1.0.1`).
- **Canary previews:** a CLI change on `canary` -> `cli-release` publishes `<next-minor>-canary.N` on the `canary` tag.
- **Test builds:** comment `/release` on a PR -> `0.0.0-<sha>` on the `test` tag (`npx zerostarter@0.0.0-<sha>`).

## Verification (local)

- `auto-release`: manual `0.1.0` + last tag `v0.0.99` -> `0.1.0` (header `## v0.1.0`, compare `v0.0.99...v0.1.0`); a later untouched release -> `0.1.1` (patch).
- `cli-release`: release tag `v0.1.0 -> 0.1.0`; canary from last tag `v0.0.99 -> 0.1.0-canary.0`. CLI builds at `0.0.0`; `--version` from source prints `zerostarter@0.0.0` (published is stamped from the tag); `bun test` 92 pass / 0 fail.
- Both workflows are valid YAML.
- Doc: `manage/release.mdx` updated ("bumps the patch" + a "Pinning a version" section).

## One caveat, first cut only

`auto-release` triggers on the #676 merge, and GitHub resolves that workflow from `main`, which only receives the new `auto-release.yml` via that same merge. If GitHub uses the pre-merge (old) version, this first release comes out `0.1.1` instead of `0.1.0` (the old logic patch-bumps the pinned `0.1.0`). It is cosmetic and one-time; every release from the second onward is deterministic. I can watch the `v0.1.0` run and re-cut it if it lands as `0.1.1`.

## Sequencing to cut and publish 0.1.0

1. Merge this PR into `canary` (updates both workflows on the default branch, which governs the release event).
2. Merge release PR #676 (`canary -> main`) with a merge commit -> `auto-release` tags `v0.1.0` and publishes the release -> `cli-release` publishes `zerostarter@0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pinning deliberate milestone versions during automatic releases.
  * CLI releases now use tags and release events to determine published versions, including canary and pull-request builds.
* **Bug Fixes**
  * Improved version validation to prevent releases from using a manual version older than the latest release.
* **Documentation**
  * Clarified automatic versioning and added instructions for pinning and resuming releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->