### PR TITLE
ci(cli-release): track the repo release version, drop the CLI's own version

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - canary
-      - main
     paths:
       - "packages/cli/**"
+  release:
+    types: [published]
   issue_comment:
     types: [created]
 
@@ -20,7 +21,7 @@ permissions:
 
 jobs:
   test:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'release'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -47,6 +48,7 @@ jobs:
     if: |
       always() && !failure() && !cancelled() && (
         github.event_name == 'push' ||
+        github.event_name == 'release' ||
         github.event_name == 'issue_comment' && github.event.comment.user.login == github.repository_owner && startsWith(github.event.comment.body, '/release')
       )
     needs: [test]
@@ -75,23 +77,26 @@ jobs:
         run: |
           PACKAGE_NAME=$(bunx json -f package.json -a name)
           npm view "$PACKAGE_NAME" 2>/dev/null || { echo "$PACKAGE_NAME does not exist in the npm registry. Skipping publish."; exit 0; }
-          PACKAGE_VERSION=$(bunx json -f package.json -a version)
           VERSIONS=$(npm view $PACKAGE_NAME dist-tags --json)
           LATEST_VERSION=$(echo $VERSIONS | bunx json latest)
+          # the CLI has no version of its own (package.json is a 0.0.0 placeholder CI stamps): it ships the repo's release version, read from the tag the release event carries
           if [[ $GITHUB_EVENT_NAME == 'issue_comment' ]]; then
             PR_NUMBER=$(echo "${{ github.event.issue.pull_request.url }}" | grep -o '[0-9]*$')
             LATEST_COMMIT_SHA=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" | bunx json -a sha | tail -n 1)
             git checkout $LATEST_COMMIT_SHA
             TAG="test"
             RELEASE_VERSION="0.0.0-${LATEST_COMMIT_SHA:0:7}"
-          elif [[ $GITHUB_REF_NAME == 'main' ]]; then
-            [[ $PACKAGE_VERSION == $LATEST_VERSION ]] && { echo "No version change on main. Skipping publish."; exit 0; }
-            RELEASE_VERSION=$PACKAGE_VERSION
+          elif [[ $GITHUB_EVENT_NAME == 'release' ]]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
+            RELEASE_VERSION="${TAG_NAME#v}"
+            [[ $RELEASE_VERSION == $LATEST_VERSION ]] && { echo "CLI already at $RELEASE_VERSION on npm. Skipping publish."; exit 0; }
             TAG="latest"
           else
             TAG="canary"
+            LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "v0.0.0")
+            NEXT_VERSION=$(bun -e "const p='${LAST_TAG#v}'.split('.'); console.log(p[0]+'.'+(Number(p[1])+1)+'.0')")
             TAGGED_VERSION=$(echo $VERSIONS | bunx json $TAG)
-            RELEASE_VERSION=$([[ $TAGGED_VERSION == $PACKAGE_VERSION-canary* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $PACKAGE_VERSION-canary.0)
+            RELEASE_VERSION=$([[ $TAGGED_VERSION == $NEXT_VERSION-canary* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $NEXT_VERSION-canary.0)
           fi
 
           bunx json -I -f package.json -e "this.version=\"$RELEASE_VERSION\""

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerostarter",
-  "version": "0.0.26",
+  "version": "0.0.0",
   "description": "Go from zero to a production-ready SaaS, rebranded and ready to ship.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## What

The CLI stops carrying its own version and always ships the repo's release version, on every release. Fully self-contained in the (fork-excluded) `cli-release.yml`; no CLI code touches the shared/template scripts.

- `packages/cli/package.json` version → **`0.0.0`** (a placeholder CI stamps at publish; other packages were already `0.0.0`).
- **`latest` publish is now driven by the release**, not a `main` push. It reads the version from the release **tag** and publishes that.
- Canary prereleases now preview the **next minor** (`<minor(last tag)>-canary.N`) and still only fire on real CLI changes. `/release` test builds unchanged.

## Why the tag, not `main`'s `package.json`

Rule 4 asks for "the root version on merge to main." But the root version bump lands on `canary` (that's how `auto-release` works), so `main`'s file lags. Verified on the live repo right now:

| ref | root version |
|---|---|
| `origin/main` `package.json` | **0.0.98** |
| release tag / `canary` | **0.0.99** |

Reading `main`'s `package.json` would publish `0.0.98` — the previous version. The **tag** carries the real release number (`0.0.99`) and is created by the merge, so `cli-release` fires on the published release and uses the tag. Same intent (CLI == release version, every release), correct source.

## Verification
- `cli-release.yml` valid YAML.
- Version derivation: release tag `v0.1.0 → 0.1.0`; canary from last tag `v0.0.99 → 0.1.0-canary.0`.
- CLI builds with `0.0.0`; `--version` from source prints `zerostarter@0.0.0` (published is stamped from the tag); `bun test` **92 pass / 0 fail**.

## Rules covered
- [x] all other packages incl. CLI stay at `0.0.0`
- [x] CLI releases the repo version, every release (via the tag the main merge creates)
- [x] no CLI code in the shared/template scripts (this is the only place it lives)

Independent of #683 (the template minor-bump practice); both are needed to cut & publish 0.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)