### PR TITLE
fix(cli-release): trigger on workflow_run so the CLI publishes on every release

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,6 +6,9 @@ on:
       - canary
     paths:
       - "packages/cli/**"
+  workflow_run:
+    workflows: ["auto-release"]
+    types: [completed]
   release:
     types: [published]
   issue_comment:
@@ -21,7 +24,7 @@ permissions:
 
 jobs:
   test:
-    if: github.event_name == 'push' || github.event_name == 'release'
+    if: github.event_name == 'push' || github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -49,6 +52,7 @@ jobs:
       always() && !failure() && !cancelled() && (
         github.event_name == 'push' ||
         github.event_name == 'release' ||
+        (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
         github.event_name == 'issue_comment' && github.event.comment.user.login == github.repository_owner && startsWith(github.event.comment.body, '/release')
       )
     needs: [test]
@@ -79,16 +83,19 @@ jobs:
           npm view "$PACKAGE_NAME" 2>/dev/null || { echo "$PACKAGE_NAME does not exist in the npm registry. Skipping publish."; exit 0; }
           VERSIONS=$(npm view $PACKAGE_NAME dist-tags --json)
           LATEST_VERSION=$(echo $VERSIONS | bunx json latest)
-          # the CLI has no version of its own (package.json is a 0.0.0 placeholder CI stamps): it ships the repo's release version, read from the tag the release event carries
+          # the CLI has no version of its own (package.json is a 0.0.0 placeholder CI stamps): it ships the repo's release version, read from the tag auto-release created
           if [[ $GITHUB_EVENT_NAME == 'issue_comment' ]]; then
             PR_NUMBER=$(echo "${{ github.event.issue.pull_request.url }}" | grep -o '[0-9]*$')
             LATEST_COMMIT_SHA=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/commits" | bunx json -a sha | tail -n 1)
             git checkout $LATEST_COMMIT_SHA
             TAG="test"
             RELEASE_VERSION="0.0.0-${LATEST_COMMIT_SHA:0:7}"
-          elif [[ $GITHUB_EVENT_NAME == 'release' ]]; then
-            TAG_NAME="${{ github.event.release.tag_name }}"
-            RELEASE_VERSION="${TAG_NAME#v}"
+          elif [[ $GITHUB_EVENT_NAME == 'workflow_run' || $GITHUB_EVENT_NAME == 'release' ]]; then
+            # after auto-release cuts the release, publish the CLI at that version from the latest tag. workflow_run fires even though auto-release used GITHUB_TOKEN (release:published does not), and gives a default-branch checkout, so read the tag rather than the event payload.
+            git fetch --tags --force --quiet
+            RELEASE_TAG=$(git describe --tags --abbrev=0 --match "v*")
+            git checkout --quiet "$RELEASE_TAG"
+            RELEASE_VERSION="${RELEASE_TAG#v}"
             [[ $RELEASE_VERSION == $LATEST_VERSION ]] && { echo "CLI already at $RELEASE_VERSION on npm. Skipping publish."; exit 0; }
             TAG="latest"
           else


### PR DESCRIPTION
## The bug (found live cutting v0.1.0)

`v0.1.0` was tagged and released, but `zerostarter@0.1.0` did **not** publish to npm on its own; it needed a manual re-fire.

Root cause: #683 switched `cli-release` to trigger on `release: published`. But `auto-release` creates the GitHub release with the built-in `GITHUB_TOKEN`, and **GitHub does not trigger workflows from `GITHUB_TOKEN`-created events** (the anti-recursion rule). So `release: published` never fired, and the CLI silently didn't publish. (The `canary` prerelease was fine because that came from a real `push`.)

## The fix

Trigger `cli-release` on **`workflow_run`** after `auto-release` completes:

```yaml
on:
  workflow_run:
    workflows: ["auto-release"]
    types: [completed]
```

- `workflow_run` fires even though `auto-release` used `GITHUB_TOKEN` (it is the mechanism GitHub provides for exactly this chaining), and it runs after the tag exists.
- It gives a default-branch checkout, so the publish path now reads the release version from the **latest tag** (`git describe`), checks out that tag, stamps, builds, publishes `latest`. Guarded to only run when `auto-release` concluded `success`.
- Kept `release: published` as a **manual escape hatch** (e.g. re-creating a release by hand, as I did to unblock 0.1.0). The two never double-fire: a normal auto release fires only `workflow_run`; a hand-created release fires only `release`.
- Stays decoupled and fork-safe: `cli-release` (fork-excluded) listens to `auto-release`; `auto-release` (template) stays CLI-agnostic.

## Verification

- Valid YAML.
- `git describe --tags` from `canary` resolves to the release tag (verified `v0.1.0`).
- `workflow_run` can't be exercised locally, so like the auto-release change this wants a **watched first run**: the next release should publish the CLI automatically. Until this merges, releases still need the manual re-fire.

## Note

`v0.1.0` is already fully out (tag, GitHub release, `zerostarter@0.1.0` on npm, `--version` verified). This only fixes the automation for the next release onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)