### PR TITLE
docs(agents): reorganize AGENTS.md into themed sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,33 @@
 # AGENTS.md
 
-This file provides guidance to AI coding agents when working with code in this repository.
+Guidance for AI coding agents working in this repository, a Bun monorepo: the `packages/cli` npm binary, the `web/next` app, the `api/hono` service, and shared `packages/*` (auth, config, db, env). Start each task with the `codebase-map` skill to orient, then load the task skill that fits (see [Skills](#skills)).
 
-## Instructions
+## Workflow
+
+- ALWAYS: Do every change in its own git worktree, never on the primary checked-out branch. Create it under `.claude/worktrees/` (repo-root relative, one directory per worktree; never `/tmp`, home, or a sibling of the repo), and merge the latest `canary` into the working branch before starting so the change builds on current main.
+- ALWAYS: Keep documentation in sync with every change. Whenever code, structure, conventions, or tooling change, update the matching docs in the same change (e.g. `web/next/content/docs/`, `README.md`, the `llms.txt`/`llms-full.txt` context routes, skill docs under `.agents/skills/` and `.claude/skills/`, and these agent guides `AGENTS.md`/`CLAUDE.md`). Docs must never drift. See the `doc-sync` skill.
+- ALWAYS: When code, a convention, a command, a path, or tooling changes, review the skills in `.agents/skills/` that touch it and update them in the same change, so every skill stays accurate and relevant. A skill that describes old behavior misleads every agent that loads it, which is worse than no skill. If a change makes a skill obsolete, remove it; if it reveals a gap, consider adding one.
+
+## Code
 
 - ALWAYS: Use `@/` for imports, if applicable.
-- ALWAYS: Do every change in its own git worktree, never on the primary checked-out branch. Create it under `.claude/worktrees/` (repo-root relative, one directory per worktree; never `/tmp`, home, or a sibling of the repo), and merge the latest `canary` into the working branch before starting so the change builds on current main.
 - ALWAYS: Prefer a Bun-native API when the file runs under Bun and one exists (`Bun.file`, `Bun.write`, `Bun.spawn`); otherwise use a Node built-in with the `node:` protocol prefix (`import { join } from "node:path"`, `require("node:fs")`), never the bare specifier. Node-runtime code (the `packages/cli` npm binary, `web/next`, and shared `packages/env`) stays on `node:`. See the `runtime-apis` skill.
-- ALWAYS: Follow the `design` skill for UI, styling, and design decisions (it holds the canonical conventions). Update it in the same change when a convention changes.
-- ALWAYS: For any frontend or UI change, verify it in a real browser with agent-browser before opening or updating a PR; drive the actual page or flow, do not rely on type-check and lint alone. Run the end-to-end flow when the change spans it or when asked. Capture screenshots, upload them to litterbox (72h), and attach the URLs to the PR. See the `ui-verify` skill.
-- ALWAYS: Keep documentation in sync with every change. Whenever code, structure, conventions, or tooling change, update the matching docs in the same change (e.g. `web/next/content/docs/`, `README.md`, the `llms.txt`/`llms-full.txt` context routes, skill docs under `.agents/skills/` and `.claude/skills/`, and these agent guides `AGENTS.md`/`CLAUDE.md`). Docs must never drift.
-- ALWAYS: When code, a convention, a command, a path, or tooling changes, review the skills in `.agents/skills/` that touch it and update them in the same change, so every skill stays accurate and relevant. A skill that describes old behavior misleads every agent that loads it, which is worse than no skill. If a change makes a skill obsolete, remove it; if it reveals a gap, consider adding one.
-- NEVER: Include "Co-authored-by" in commit messages.
-- NEVER: Use em-dashes (the long dash, U+2014) in code, comments, docs, or copy. Regular hyphens are fine; for a pause or aside, use a comma, colon, or period.
 - Do not comment unnecessarily. Only comment if it is absolutely necessary.
 - Keep comments on a single line; do not split one across multiple `//` lines or use multi-line `/* */` blocks.
+- NEVER: Use em-dashes (the long dash, U+2014) in code, comments, docs, or copy. Regular hyphens are fine; for a pause or aside, use a comma, colon, or period.
+
+## UI
+
+- ALWAYS: Follow the `design` skill for UI, styling, and design decisions (it holds the canonical conventions). Update it in the same change when a convention changes.
+- ALWAYS: For any frontend or UI change, verify it in a real browser with agent-browser before opening or updating a PR; drive the actual page or flow, do not rely on type-check and lint alone. Run the end-to-end flow when the change spans it or when asked. Capture screenshots, upload them to litterbox (72h), and attach the URLs to the PR. See the `ui-verify` skill.
+
+## Commits
+
+- Make atomic commits in the Conventional Commits format. See the `gh-commit` skill.
+- NEVER: Include "Co-authored-by" in commit messages.
+
+## Working notes
+
 - Write audit reports (any kind) to `.github/notes/audits/` as dated files (`YYYY-MM-DD-<topic>.md`). Audits are transient working docs: delete one once its findings are fully addressed (shipped or consciously won't-fixed) so the directory does not accumulate stale records.
 - Track planned, in-progress, and parked work in `.github/notes/plans/` (an index plus one file per item), not in dated audit files or scattered across issues; issues are the inbox, folded in and closed once captured.
 


### PR DESCRIPTION
## What

Refactors `AGENTS.md` (the agent guide; `CLAUDE.md` symlinks to it) from a flat 13-item "Instructions" list into themed sections, so agents can find the relevant rule faster.

**All existing rules preserved verbatim** - only regrouped. Changes:

- **Grouped** into `Workflow` / `Code` / `UI` / `Commits` / `Working notes`.
- **Added a one-line orientation** at the top (what the repo is + "start with `codebase-map`").
- **Added the one missing cross-reference:** a `Commits` bullet pointing to the `gh-commit` skill (the commit rules previously only said what *not* to do).
- Cross-linked the `doc-sync` skill from the docs-in-sync rule.

Net: 13 rules -> 14 bullets (the extra is the `gh-commit` pointer). No rule weakened, dropped, or reworded in substance.

## Verification

- Grepped every load-bearing phrase (worktree, `node:`, `@/` imports, em-dash ban, comment rules, audits/plans notes, doc/skill sync, co-author ban) - all present.
- `CLAUDE.md` symlink still resolves to `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized project guidance into clearer sections covering workflow, code, UI, commits, and working notes.
  * Updated introductory guidance to reflect the current development setup and task-starting process.
  * Preserved existing standards for documentation, implementation practices, UI verification, and commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->