### PR TITLE
ci(cli-release): fix the canary prerelease version (patch default + pins)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -101,7 +101,10 @@ jobs:
           else
             TAG="canary"
             LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "v0.0.0")
-            NEXT_VERSION=$(bun -e "const p='${LAST_TAG#v}'.split('.'); console.log(p[0]+'.'+(Number(p[1])+1)+'.0')")
+            LAST_VERSION="${LAST_TAG#v}"
+            ROOT_VERSION=$(bunx json -f ../../package.json -a version)
+            # preview the next release: a hand-set root version (a pin) or the default patch bump, matching auto-release
+            NEXT_VERSION=$([ "$ROOT_VERSION" != "$LAST_VERSION" ] && echo "$ROOT_VERSION" || bun -e "const p='$LAST_VERSION'.split('.'); console.log(p[0]+'.'+p[1]+'.'+(Number(p[2])+1))")
             TAGGED_VERSION=$(echo $VERSIONS | bunx json $TAG)
             RELEASE_VERSION=$([[ $TAGGED_VERSION == $NEXT_VERSION-canary* ]] && bunx semver $TAGGED_VERSION -i prerelease || echo $NEXT_VERSION-canary.0)
           fi


### PR DESCRIPTION
## The issue

The `canary` prerelease derived its version as a **minor** bump of the last tag:

```bash
NEXT_VERSION=$(bun -e "…(Number(p[1])+1)+'.0'")   # minor
```

That was correct when the default bump was minor, but #683 switched the default to **patch**. So the next canary prerelease would compute `0.2.0-canary` while the actual next release is `0.1.2` - the preview leaps *past* the real version. The drift is already visible: the `canary` dist-tag is `0.1.0-canary.0`, now behind `latest 0.1.1`.

(The `release`/`workflow_run` and `/release` test paths were never affected - this is only the canary preview branch.)

## The fix

Mirror `auto-release`'s target logic: a hand-set root version (a pin) wins, otherwise a **patch** bump.

```bash
LAST_VERSION="${LAST_TAG#v}"
ROOT_VERSION=$(bunx json -f ../../package.json -a version)
NEXT_VERSION=$([ "$ROOT_VERSION" != "$LAST_VERSION" ] && echo "$ROOT_VERSION" \
  || bun -e "const p='$LAST_VERSION'.split('.'); console.log(p[0]+'.'+p[1]+'.'+(Number(p[2])+1))")
```

## Verification (simulated)

| last tag | root `package.json` | preview |
|---|---|---|
| `v0.1.1` | `0.1.1` (steady) | `0.1.2-canary.N` ✅ (was `0.2.0`) |
| `v0.1.9` | `0.1.9` | `0.1.10-canary.N` ✅ (numeric, not `0.2.0`) |
| `v0.1.1` | `0.2.0` (pinned) | `0.2.0-canary.N` ✅ |
| `v0.1.1` | `1.0.0` (pinned) | `1.0.0-canary.N` ✅ |

Valid YAML. `ci`-scoped (fork-excluded plumbing), so it doesn't itself cut a release; it just corrects the preview version for the next canary CLI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)