### PR TITLE
feat: toggle optional surfaces with feature flags, behind a contentSource seam

### DIFF
--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -30,7 +30,6 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 Candidate refactors that turn a scattered cluster into one deep module, ordered by strength.
 
 - [Own the fork boundary with one forkLayout module](cli-fork-layout.md) - in progress on `refactor/cli-fork-layout`; one `.gitpickignore` parser feeds convert + sync + tests.
-- [Collapse the content readers into one ContentSource](content-source-consolidation.md) - highest leverage; "add a collection" goes from ~8 edits to 1.
 - [One nav model and a deep SidebarShell](sidebar-nav-model.md) - collapse close/active/item-shape across the three sidebars; delete `sidebar-adaptive.tsx`.
 - [One typed API envelope and a defineRoute helper](api-envelope-typed-endpoint.md) - shared `Envelope<T>` + boilerplate collapse; subsumes #664.
 - [Consolidate OG rendering behind one seam](og-render-consolidation.md) - #485; broadened to own size + URL scheme + defaults.

--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -24,6 +24,8 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 - [Bun-native file APIs in .github/scripts](bun-native-scripts.md) - #423.
 - [Org-creation name and other restrictions](org-creation-restrictions.md) - #349.
 - [Standardize and pin the release-workflow tooling](workflow-tooling-consistency.md) - deferred from #683 (JSON tool standardized on `json`; pinning + read-helper unification left).
+- [Unit-test the contentSource seam](web-content-source-tests.md) - the load-bearing web gate; needs a web test harness first (PR #691 review).
+- [Console not-found returns HTTP 200](console-notfound-status.md) - pre-existing force-dynamic soft-404, admin-only, low severity (PR #691 review).
 
 ### Architecture deepenings (2026-07-12 review, deep-module lens)
 

--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -26,6 +26,7 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 - [Standardize and pin the release-workflow tooling](workflow-tooling-consistency.md) - deferred from #683 (JSON tool standardized on `json`; pinning + read-helper unification left).
 - [Unit-test the contentSource seam](web-content-source-tests.md) - the load-bearing web gate; needs a web test harness first (PR #691 review).
 - [Console not-found returns HTTP 200](console-notfound-status.md) - pre-existing force-dynamic soft-404, admin-only, low severity (PR #691 review).
+- [Derive BlogPostMeta from the blog zod schema](blog-meta-from-schema.md) - carved out of content-source-consolidation; a decouple-vs-derive tradeoff, not a mechanical rename (PR #691 review).
 
 ### Architecture deepenings (2026-07-12 review, deep-module lens)
 

--- a/.github/notes/plans/blog-meta-from-schema.md
+++ b/.github/notes/plans/blog-meta-from-schema.md
@@ -1,0 +1,8 @@
+# Derive BlogPostMeta from the blog zod schema
+
+- Status: backlog
+- Links: PR #691 review (carved out of the shipped content-source-consolidation)
+
+The content-source-consolidation plan (its seam shipped in #691) named an "on the way" cleanup that was not done, so it is tracked here rather than closed silently: derive `BlogPostMeta` from the blog frontmatter zod schema and drop the hand-written type plus the `toBlogPostMeta` mapper (`web/next/src/lib/blog-policy.ts`, `web/next/src/lib/blog.ts`).
+
+Deliberately deferred, because it is a tradeoff, not a mechanical rename. `blog-policy.ts` is currently pure (zero fumadocs imports); `BlogPostMeta` is the decoupling interface and `toBlogPostMeta` maps a fumadocs page onto it, which keeps the publish policy unit-testable without fumadocs. Deriving the type from `blogSchema` (which lives in the fumadocs-coupled `source.config.ts`) and dropping the mapper would couple the pure policy module to fumadocs, trading testability for less duplication. Decide that on its own merits: keep the decoupling and only DRY the shared field list, versus couple-and-derive. Not worth riding on the feature-flags PR.

--- a/.github/notes/plans/console-notfound-status.md
+++ b/.github/notes/plans/console-notfound-status.md
@@ -1,0 +1,10 @@
+# Console not-found returns HTTP 200 (soft 404)
+
+- Status: backlog
+- Links: PR #691 review
+
+A `notFound()` inside the `(console)` area renders the not-found UI but returns HTTP 200, not 404. Cause: `console/layout.tsx` is `export const dynamic = "force-dynamic"` (so the admin gate runs on every request), and Next.js commits the 200 status line before a page-level `notFound()` fires mid-stream.
+
+Pre-existing, not introduced by the feature flags: a genuinely missing slug (`/console/docs/does-not-exist`) returns 200 with every feature on, and the old console docs page already called `notFound()` for missing slugs. Note the asymmetry: a URL matching no route at all (`/console/nope`) still returns a real router-level 404, and the layout-level auth `notFound()` also returns 404 (it fires before streaming starts); only a page-level `notFound()` degrades to 200.
+
+Low severity: the correct not-found UI shows (no content leaks), and `/console` is `robots: noindex` and admin-gated, so there is no SEO cost. The only practical downside is that a programmatic client cannot distinguish missing-vs-ok by status on console routes. A real fix is framework-rooted (decide existence before the force-dynamic stream, e.g. in middleware or a segment that can set the status pre-stream); not worth that surgery for a noindex admin area.

--- a/.github/notes/plans/content-source-consolidation.md
+++ b/.github/notes/plans/content-source-consolidation.md
@@ -1,8 +1,0 @@
-# Collapse the content readers into one ContentSource
-
-- Status: backlog
-- Links: 2026-07-12 architecture review (deep-module lens)
-
-Docs, blog, and console-docs each re-derive "which collection is this" from URL strings and reimplement "load a page or 404". The pattern `source.getPage(slug); if (!page) notFound()` appears six times (`lib/fumadocs.tsx`, `lib/og-image.tsx`, `lib/blog.ts`, `llms.txt/[[...slug]]/route.ts`), collection identity is sniffed via `slug[0] === "blog"` and `page.url.startsWith("/docs")` in ~6 more, and every new collection forces edits to the `Source` union plus the `if (source === blogSource)` branches in `fumadocs.tsx`. One concept, sprayed across the pipeline.
-
-Deepen into one `contentSource(kind)` module exposing `getPageOr404`, `listPublished`, `params`, `tree`, and `href`, with publish policy, `baseUrl`, and collection identity baked in behind it. Collapses the six duplicated get+404 sites and the prefix-sniffing, and turns "add a collection" from ~8 edits into one entry. Pairs with [og-render-consolidation](og-render-consolidation.md); on the way, derive `BlogPostMeta` from the zod schema and drop the hand-written type plus the `toBlogPostMeta` mapper. Medium-large effort.

--- a/.github/notes/plans/og-render-consolidation.md
+++ b/.github/notes/plans/og-render-consolidation.md
@@ -9,4 +9,4 @@ Narrow (#485): `web/next/src/app/og/home/route.tsx` calls only `renderOgElement`
 
 Broad (architecture review): the OG contract is smeared. `1200x630` is hardcoded in 6+ places (`lib/og-image.tsx`, `lib/fumadocs.tsx`, the docs and blog layouts, the marketing pages), the `/og/{kind}/{slug}?t=` URL scheme is built in `fumadocs.tsx` while the images are rendered in `og-image.tsx` (two owners of one contract), and the `og/docs` and `og/blog` routes are near-identical. Deepen into `ogForPage(kind, slug)` owning the size, the URL scheme, and the defaults; the metadata builder imports the same size/URL helper, and `og/docs` plus `og/blog` collapse into one parameterized route.
 
-Pairs with [content-source-consolidation](content-source-consolidation.md). Small to medium effort.
+Builds on the shipped `contentSource(kind)` seam (`web/next/src/lib/content.ts`), which already removed the `Source` union and the get-or-404 duplication from `og-image.tsx`. Small to medium effort.

--- a/.github/notes/plans/web-content-source-tests.md
+++ b/.github/notes/plans/web-content-source-tests.md
@@ -1,0 +1,8 @@
+# Unit-test the contentSource seam
+
+- Status: backlog
+- Links: PR #691 review
+
+`web/next/src/lib/content.ts` is the load-bearing gate for docs/blog/console (`enabled`, `getPageOr404`, `pages`, `params`, `tree`), but it has no unit tests; PR #691 verified it via browser + authenticated-SSR e2e instead, matching this repo's convention of no web unit-test harness yet.
+
+When a web test harness lands (see the deferred cafe `web/next` test port), assert `contentSource(kind)` against a mocked `features`: `enabled` follows the flag, `getPageOr404` 404s when off (and for blog gates unpublished posts via `isPublicBlogPage`), and `pages()`/`params()`/`tree()` return empty when off. That one seam backs every gated surface, so it is the highest-leverage place to add the first web unit tests.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Every item below is wired and working out of the box, not just a dependency in `
 - **Database**: [PostgreSQL](https://www.postgresql.org) with [Drizzle ORM](https://orm.drizzle.team) and migrations
 - **Authentication**: [Better Auth](https://better-auth.com) with GitHub and Google OAuth, organizations, and teams
 - **Authorization**: a role-gated admin console at `/console`, backed by the Better Auth admin plugin
-- **Public Waitlist**: a waitlist landing + signup API (`/api/waitlist`) with an approximate count; the default home for a fresh fork
+- **Public Waitlist**: a waitlist landing + signup API (`/api/waitlist`) with an approximate count; an optional surface that, when enabled, becomes a fresh fork's home
+- **Configurable Features**: toggle the docs, blog, API reference, internal docs, and waitlist per fork from one config, chosen at `init` and flippable anytime
 - **Rate Limiting**: [hono-rate-limiter](https://www.npmjs.com/package/hono-rate-limiter) keyed per user, API key, or IP (with [Arcjet](https://arcjet.com) IP detection)
 - **Data & Forms**: [TanStack Query](https://tanstack.com/query) for server state and [TanStack Form](https://tanstack.com/form) for forms
 - **Validation**: [Zod](https://zod.dev), shared across the API, forms, and type-safe environment variables

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -1,4 +1,4 @@
-import { site } from "@packages/config/site"
+import { features, site } from "@packages/config/site"
 import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
@@ -15,6 +15,18 @@ import { rateLimiterMiddleware } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
+
+// The Scalar API reference UI, gated by the apiDocs feature. Built once; a fork can flip the flag on later without changing this route.
+const apiReference = Scalar({
+  pageTitle: `API Reference | ${site.name}`,
+  defaultHttpClient: {
+    targetKey: "js",
+    clientKey: "hono/client",
+  },
+  defaultOpenAllTags: true,
+  expandAllResponses: true,
+  url: "/api/openapi.json",
+})
 
 const app = new Hono()
 
@@ -156,19 +168,11 @@ socket.addEventListener("message", (event) => {
       },
     }),
   )
-  .get(
-    "/docs",
-    Scalar({
-      pageTitle: `API Reference | ${site.name}`,
-      defaultHttpClient: {
-        targetKey: "js",
-        clientKey: "hono/client",
-      },
-      defaultOpenAllTags: true,
-      expandAllResponses: true,
-      url: "/api/openapi.json",
-    }),
-  )
+  .use("/docs", async (c, next) => {
+    if (!features.apiDocs) return c.notFound()
+    await next()
+  })
+  .get("/docs", apiReference)
 
 export type AppType = typeof routes
 export type { ErrorCode } from "@/lib/error"

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -1,8 +1,8 @@
-import { features, site } from "@packages/config/site"
+import { site } from "@packages/config/site"
 import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
-import { Hono, type MiddlewareHandler } from "hono"
+import { Hono } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
@@ -11,7 +11,7 @@ import { z } from "zod"
 
 import { errorHandler, globalErrorResponses, jsonError } from "@/lib/error"
 import { createServer, upgradeWebSocket } from "@/lib/server"
-import { rateLimiterMiddleware } from "@/middlewares"
+import { rateLimiterMiddleware, requireFeature } from "@/middlewares"
 import { agentsRouter, authRouter, v1Router, waitlistRouter } from "@/routers"
 
 const BUILD_VERSION = getBuildVersion()
@@ -27,12 +27,6 @@ const apiReference = Scalar({
   expandAllResponses: true,
   url: "/api/openapi.json",
 })
-
-// 404 both the reference UI and its OpenAPI document when apiDocs is off. Both stay mounted so a fork can flip the flag on later; the Scalar UI fetches the spec, so gating only the UI would still leave the full spec public.
-const requireApiDocs: MiddlewareHandler = async (c, next) => {
-  if (!features.apiDocs) return c.notFound()
-  await next()
-}
 
 const app = new Hono()
 
@@ -157,7 +151,8 @@ socket.addEventListener("message", (event) => {
   .route("/auth", authRouter)
   .route("/v1", v1Router)
   .route("/waitlist", waitlistRouter)
-  .use("/openapi.json", requireApiDocs)
+  // Gate both the OpenAPI document and the Scalar UI on apiDocs; the UI fetches the spec, so gating only the UI would leave the full spec public.
+  .use("/openapi.json", requireFeature("apiDocs"))
   .get(
     "/openapi.json",
     openAPIRouteHandler(app, {
@@ -175,7 +170,7 @@ socket.addEventListener("message", (event) => {
       },
     }),
   )
-  .use("/docs", requireApiDocs)
+  .use("/docs", requireFeature("apiDocs"))
   .get("/docs", apiReference)
 
 export type AppType = typeof routes

--- a/api/hono/src/index.ts
+++ b/api/hono/src/index.ts
@@ -2,7 +2,7 @@ import { features, site } from "@packages/config/site"
 import { getBuildVersion } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { Scalar } from "@scalar/hono-api-reference"
-import { Hono } from "hono"
+import { Hono, type MiddlewareHandler } from "hono"
 import { describeRoute, openAPIRouteHandler, resolver } from "hono-openapi"
 import { cors } from "hono/cors"
 import { HTTPException } from "hono/http-exception"
@@ -27,6 +27,12 @@ const apiReference = Scalar({
   expandAllResponses: true,
   url: "/api/openapi.json",
 })
+
+// 404 both the reference UI and its OpenAPI document when apiDocs is off. Both stay mounted so a fork can flip the flag on later; the Scalar UI fetches the spec, so gating only the UI would still leave the full spec public.
+const requireApiDocs: MiddlewareHandler = async (c, next) => {
+  if (!features.apiDocs) return c.notFound()
+  await next()
+}
 
 const app = new Hono()
 
@@ -151,6 +157,7 @@ socket.addEventListener("message", (event) => {
   .route("/auth", authRouter)
   .route("/v1", v1Router)
   .route("/waitlist", waitlistRouter)
+  .use("/openapi.json", requireApiDocs)
   .get(
     "/openapi.json",
     openAPIRouteHandler(app, {
@@ -168,10 +175,7 @@ socket.addEventListener("message", (event) => {
       },
     }),
   )
-  .use("/docs", async (c, next) => {
-    if (!features.apiDocs) return c.notFound()
-    await next()
-  })
+  .use("/docs", requireApiDocs)
   .get("/docs", apiReference)
 
 export type AppType = typeof routes

--- a/api/hono/src/middlewares/feature.ts
+++ b/api/hono/src/middlewares/feature.ts
@@ -1,0 +1,10 @@
+import { features, type Feature } from "@packages/config/site"
+import type { MiddlewareHandler } from "hono"
+
+// 404 a route when its feature flag is off. Apply with .use() so the route stays mounted (AppType is unchanged) and a fork can flip the flag on later without a code change.
+export const requireFeature =
+  (flag: Feature): MiddlewareHandler =>
+  async (c, next) => {
+    if (!features[flag]) return c.notFound()
+    await next()
+  }

--- a/api/hono/src/middlewares/index.ts
+++ b/api/hono/src/middlewares/index.ts
@@ -1,2 +1,3 @@
 export * from "@/middlewares/auth"
+export * from "@/middlewares/feature"
 export * from "@/middlewares/rate-limiter"

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -1,11 +1,11 @@
 import { sValidator } from "@hono/standard-validator"
-import { features } from "@packages/config/site"
 import { db, waitlist } from "@packages/db"
 import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
 import { z } from "zod"
 
 import { ApiError, validationErrorResponses } from "@/lib/error"
+import { requireFeature } from "@/middlewares"
 
 const joinSchema = z.object({
   email: z.string().trim().pipe(z.email().max(254)).meta({ example: "you@example.com" }),
@@ -19,10 +19,7 @@ const COUNT_STEP = 5
 
 export const waitlistRouter = new Hono()
   // 404 both endpoints when the waitlist feature is off; the router stays mounted so a fork can flip the flag on later.
-  .use("*", async (c, next) => {
-    if (!features.waitlist) return c.notFound()
-    await next()
-  })
+  .use("*", requireFeature("waitlist"))
   .get(
     "/",
     describeRoute({

--- a/api/hono/src/routers/waitlist.ts
+++ b/api/hono/src/routers/waitlist.ts
@@ -1,4 +1,5 @@
 import { sValidator } from "@hono/standard-validator"
+import { features } from "@packages/config/site"
 import { db, waitlist } from "@packages/db"
 import { Hono } from "hono"
 import { describeRoute, resolver } from "hono-openapi"
@@ -17,6 +18,11 @@ const COUNT_MIN = 10
 const COUNT_STEP = 5
 
 export const waitlistRouter = new Hono()
+  // 404 both endpoints when the waitlist feature is off; the router stays mounted so a fork can flip the flag on later.
+  .use("*", async (c, next) => {
+    if (!features.waitlist) return c.notFound()
+    await next()
+  })
   .get(
     "/",
     describeRoute({

--- a/packages/cli/bin/commands/_prompt.ts
+++ b/packages/cli/bin/commands/_prompt.ts
@@ -217,6 +217,7 @@ export const promptMultiselect = async (
       stdin.removeListener("data", onData)
     }
 
+    // Assumes each keypress arrives as one data chunk (raw mode can split an escape sequence or coalesce a paste); fine for a single interactive picker.
     function onData(key: string): void {
       if (key === "\x03") {
         cleanup()

--- a/packages/cli/bin/commands/_prompt.ts
+++ b/packages/cli/bin/commands/_prompt.ts
@@ -170,6 +170,82 @@ export const promptConfirm = async (question: string, def = true): Promise<boole
   })
 }
 
+// clack-style multiselect: `◇ question` + a checkbox line per option, moved with arrows (or j/k), toggled with space, submitted with enter. On submit it collapses to a single `◇ question  selected` summary. Off a TTY it takes the pre-checked defaults and echoes them, so non-interactive logs record the choice.
+export const promptMultiselect = async (
+  question: string,
+  options: { value: string; label: string; checked: boolean }[],
+): Promise<string[]> => {
+  const out = process.stdout
+  const selected = new Set(options.filter((o) => o.checked).map((o) => o.value))
+
+  const summary = (): string =>
+    options
+      .filter((o) => selected.has(o.value))
+      .map((o) => o.label)
+      .join(", ") || "none"
+
+  if (!isInteractive()) {
+    out.write(`${P}${cyan(S.submit)}  ${question}  ${dim(summary())}\n`)
+    return [...selected]
+  }
+
+  return new Promise<string[]>((resolve) => {
+    const stdin = process.stdin
+    let cursor = 0
+
+    const renderOption = (index: number): string => {
+      const o = options[index]
+      const box = selected.has(o.value) ? green(S.checkboxOn) : dim(S.checkboxOff)
+      const label = index === cursor ? o.label : dim(o.label)
+      return `${P}${gray(S.bar)}  ${box} ${label}`
+    }
+
+    const draw = (initial: boolean): void => {
+      if (!initial) out.write(`\x1b[${options.length}A`)
+      for (let i = 0; i < options.length; i++) out.write(`\r\x1b[K${renderOption(i)}\n`)
+    }
+
+    out.write(`${P}${cyan(S.submit)}  ${question}\n`)
+    draw(true)
+    stdin.setRawMode(true)
+    stdin.resume()
+    stdin.setEncoding("utf8")
+
+    const cleanup = (): void => {
+      stdin.setRawMode(false)
+      stdin.pause()
+      stdin.removeListener("data", onData)
+    }
+
+    function onData(key: string): void {
+      if (key === "\x03") {
+        cleanup()
+        out.write(`\x1b[${options.length + 1}A\r\x1b[0J${P}${cyan(S.submit)}  ${dim(question)}\n`)
+        cancel()
+        process.exit(130)
+      } else if (key === "\r" || key === "\n") {
+        cleanup()
+        out.write(
+          `\x1b[${options.length + 1}A\r\x1b[0J${P}${cyan(S.submit)}  ${question}  ${dim(summary())}\n`,
+        )
+        resolve([...selected])
+      } else if (key === "\x1b[A" || key === "k") {
+        cursor = (cursor - 1 + options.length) % options.length
+        draw(false)
+      } else if (key === "\x1b[B" || key === "j") {
+        cursor = (cursor + 1) % options.length
+        draw(false)
+      } else if (key === " ") {
+        const value = options[cursor].value
+        if (selected.has(value)) selected.delete(value)
+        else selected.add(value)
+        draw(false)
+      }
+    }
+    stdin.on("data", onData)
+  })
+}
+
 // A single-line text prompt in the gutter; the entered value stays under the bar.
 export const promptText = async (question: string, def = ""): Promise<string> => {
   process.stdout.write(`${P}${cyan(S.submit)}  ${question}${def ? ` ${dim(`(${def})`)}` : ""}\n`)

--- a/packages/cli/bin/commands/_prompt.ts
+++ b/packages/cli/bin/commands/_prompt.ts
@@ -175,6 +175,8 @@ export const promptMultiselect = async (
   question: string,
   options: { value: string; label: string; checked: boolean }[],
 ): Promise<string[]> => {
+  // Nothing to pick: return before any cursor math (avoids the empty-list divide/`\x1b[0A` edge).
+  if (options.length === 0) return []
   const out = process.stdout
   const selected = new Set(options.filter((o) => o.checked).map((o) => o.value))
 

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -25,8 +25,8 @@ import {
   withSpinner,
 } from "./_prompt"
 
-// The optional surfaces init can toggle, their CLI flags (--<flag> / --no-<flag>), and prompt labels. Alphabetical, to match the config's features export.
-const FEATURE_DEFS = [
+// The optional surfaces init can toggle, their CLI flags (--<flag> / --no-<flag>), and prompt labels. Alphabetical, to match the config's features export. Kept in lockstep with @packages/config/site's `features` by test/features-consistency.test.ts.
+export const FEATURE_DEFS = [
   { value: "apiDocs", flag: "api-docs", label: "API docs" },
   { value: "blog", flag: "blog", label: "Blog" },
   { value: "docs", flag: "docs", label: "Docs" },

--- a/packages/cli/bin/commands/init.ts
+++ b/packages/cli/bin/commands/init.ts
@@ -5,6 +5,7 @@ import { convertRepo } from "@/convert"
 import { dockerRunning, hasPostgresUrl, provisionDatabase, seedEnv } from "@/db"
 import { bunInstall, fetchZerostarter, gitBranch, gitCommitAll, gitInit } from "@/git"
 import { exists } from "@/io"
+import { DEFAULT_FEATURES, type FeatureFlags } from "@/templates"
 
 import { parseArgsOrExit } from "./_args"
 import { ensureBun } from "./_bun"
@@ -19,9 +20,19 @@ import {
   orange,
   outro,
   promptConfirm,
+  promptMultiselect,
   promptText,
   withSpinner,
 } from "./_prompt"
+
+// The optional surfaces init can toggle, their CLI flags (--<flag> / --no-<flag>), and prompt labels. Alphabetical, to match the config's features export.
+const FEATURE_DEFS = [
+  { value: "apiDocs", flag: "api-docs", label: "API docs" },
+  { value: "blog", flag: "blog", label: "Blog" },
+  { value: "docs", flag: "docs", label: "Docs" },
+  { value: "internalDocs", flag: "internal-docs", label: "Internal (console) docs" },
+  { value: "waitlist", flag: "waitlist", label: "Waitlist (else a plain landing home)" },
+] as const
 
 const helpMessage = `Usage:
   $ bunx zerostarter init [dir] [options]
@@ -37,7 +48,14 @@ Options:
       --canary   Scaffold from the canary branch instead of main (for testing)
       --db       Provision a local Postgres (pglaunch) and migrate; needs Docker
       --dry-run  Print the plan without writing anything
-  -h, --help     Display help`
+  -h, --help     Display help
+
+Features (default on, except the waitlist; pass any flag to skip the interactive picker):
+      --api-docs,       --no-api-docs        The /api/docs API reference
+      --blog,           --no-blog            The /blog
+      --docs,           --no-docs            The /docs
+      --internal-docs,  --no-internal-docs   The /console/docs internal docs
+      --waitlist,       --no-waitlist        The /waitlist (off leaves a plain landing home)`
 
 const isEmptyDir = (dir: string): boolean =>
   !existsSync(dir) || readdirSync(dir).filter((f) => f !== ".git").length === 0
@@ -73,6 +91,16 @@ export const init = async (argv: string[]) => {
       "dry-run": { type: "boolean" },
       help: { short: "h", type: "boolean" },
       yes: { short: "y", type: "boolean" },
+      "api-docs": { type: "boolean" },
+      "no-api-docs": { type: "boolean" },
+      blog: { type: "boolean" },
+      "no-blog": { type: "boolean" },
+      docs: { type: "boolean" },
+      "no-docs": { type: "boolean" },
+      "internal-docs": { type: "boolean" },
+      "no-internal-docs": { type: "boolean" },
+      waitlist: { type: "boolean" },
+      "no-waitlist": { type: "boolean" },
     },
   })
 
@@ -87,6 +115,18 @@ export const init = async (argv: string[]) => {
   const interactive = isInteractive() && !values.yes
   // Which starter branch to scaffold from: main (stable) by default, canary for testing unreleased changes.
   const ref = values.canary ? "canary" : "main"
+
+  // Resolve the feature set from flags over the fork defaults: --no-<flag> wins, then --<flag>, else the default. Passing any feature flag (or --yes) skips the interactive picker.
+  const flags = values as Record<string, boolean | undefined>
+  const anyFeatureFlag = FEATURE_DEFS.some((f) => flags[f.flag] || flags[`no-${f.flag}`])
+  const chosenFeatures: FeatureFlags = { ...DEFAULT_FEATURES }
+  for (const f of FEATURE_DEFS) {
+    chosenFeatures[f.value] = flags[`no-${f.flag}`]
+      ? false
+      : flags[f.flag]
+        ? true
+        : DEFAULT_FEATURES[f.value]
+  }
 
   let dir = positionals[0] ?? "."
   const firstTarget = resolve(dir)
@@ -125,13 +165,19 @@ export const init = async (argv: string[]) => {
   const canaryInPlaceNote =
     "--canary ignored: converting the existing checkout in place, so nothing is fetched."
 
+  const featureList = (features: FeatureFlags): string =>
+    FEATURE_DEFS.filter((f) => features[f.value])
+      .map((f) => f.value)
+      .join(", ") || "none"
+
   if (values["dry-run"]) {
     console.log("bunx zerostarter init (dry run)")
-    console.log(`  target: ${target}`)
-    console.log(`  name:   ${name}`)
-    console.log(`  mode:   ${isZerostarter(target) ? "in place" : `fetch ${ref}`}`)
+    console.log(`  target:   ${target}`)
+    console.log(`  name:     ${name}`)
+    console.log(`  mode:     ${isZerostarter(target) ? "in place" : `fetch ${ref}`}`)
+    console.log(`  features: ${featureList(chosenFeatures)}`)
     if (isZerostarter(target) && values.canary) {
-      console.log(`  note:   ${canaryInPlaceNote}`)
+      console.log(`  note:     ${canaryInPlaceNote}`)
     }
     return
   }
@@ -145,6 +191,21 @@ export const init = async (argv: string[]) => {
       cancel("Aborted")
       return
     }
+  }
+
+  // Interactive picker only when no feature flag steered the choice; skipping it keeps the defaults.
+  if (interactive && !anyFeatureFlag) {
+    const selected = new Set(
+      await promptMultiselect(
+        "Which optional surfaces should this fork ship with?",
+        FEATURE_DEFS.map((f) => ({
+          value: f.value,
+          label: f.label,
+          checked: DEFAULT_FEATURES[f.value],
+        })),
+      ),
+    )
+    for (const f of FEATURE_DEFS) chosenFeatures[f.value] = selected.has(f.value)
   }
 
   if (!isZerostarter(target)) {
@@ -167,7 +228,7 @@ export const init = async (argv: string[]) => {
   }
 
   await withSpinner(`Rebranding to ${name}`, `Rebranded to ${name}`, () =>
-    convertRepo(target, brand),
+    convertRepo(target, brand, chosenFeatures),
   )
 
   await bunInstall(target)

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -8,8 +8,10 @@ import {
   blogIndexTemplate,
   type Brand,
   consoleIndexTemplate,
+  DEFAULT_FEATURES,
   docsConfigTemplate,
   docsIndexTemplate,
+  type FeatureFlags,
   homeTemplate,
   readmeTemplate,
   sampleBlogPostTemplate,
@@ -87,9 +89,9 @@ export const fixDangling = (root: string): void => {
   }
 }
 
-// Regenerate the centralized brand file and rename the root package.
-const rebrand = (root: string, b: Brand): void => {
-  write(p(root, "packages/config/src/site.ts"), siteTemplate(b))
+// Regenerate the centralized brand file (brand + chosen feature flags) and rename the root package.
+const rebrand = (root: string, b: Brand, features: FeatureFlags): void => {
+  write(p(root, "packages/config/src/site.ts"), siteTemplate(b, features))
   const path = p(root, "package.json")
   const pkg = readJson<Record<string, unknown>>(path)
   pkg.name = slugify(b.name)
@@ -98,9 +100,13 @@ const rebrand = (root: string, b: Brand): void => {
   writeJson(path, pkg)
 }
 
-export const convertRepo = (root: string, brand: Brand): void => {
+export const convertRepo = (
+  root: string,
+  brand: Brand,
+  features: FeatureFlags = DEFAULT_FEATURES,
+): void => {
   removeForkExcludes(root)
   scaffoldContent(root, brand)
   fixDangling(root)
-  rebrand(root, brand)
+  rebrand(root, brand, features)
 }

--- a/packages/cli/src/style.ts
+++ b/packages/cli/src/style.ts
@@ -36,6 +36,8 @@ export const S = {
   submit: "◇",
   radioOn: "●",
   radioOff: "○",
+  checkboxOn: "◼",
+  checkboxOff: "◻",
   warn: "▲",
   error: "■",
   barH: "─",

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -2,8 +2,39 @@ export interface Brand {
   name: string
 }
 
+export type FeatureFlags = {
+  apiDocs: boolean
+  blog: boolean
+  docs: boolean
+  internalDocs: boolean
+  waitlist: boolean
+}
+
+// A fresh fork's default surfaces: docs, blog, internal docs, and the API reference on; the waitlist off, so the home is a plain landing page. Any can be flipped later in the config.
+export const DEFAULT_FEATURES: FeatureFlags = {
+  apiDocs: true,
+  blog: true,
+  docs: true,
+  internalDocs: true,
+  waitlist: false,
+}
+
+const featuresBlock = (features: FeatureFlags): string => `// Optional surfaces a fork enables or disables. Typed boolean (not \`as const\`) so a fork can flip them and the runtime gates are not dead code. Off means the routes 404 and the links, nav, sitemap, llms, and search drop the surface. waitlist off makes the home a plain landing page.
+export const features = {
+  apiDocs: ${features.apiDocs},
+  blog: ${features.blog},
+  docs: ${features.docs},
+  internalDocs: ${features.internalDocs},
+  waitlist: ${features.waitlist},
+}
+
+export type Feature = keyof typeof features`
+
 // packages/config/src/site.ts: regenerated with the product name, repo URL, and placeholders.
-export const siteTemplate = ({ name }: Brand): string => {
+export const siteTemplate = (
+  { name }: Brand,
+  features: FeatureFlags = DEFAULT_FEATURES,
+): string => {
   const display = name.charAt(0).toUpperCase() + name.slice(1)
   return `// Brand identity for this app: the single source a fork edits to rebrand. web reads it via lib/config.ts.
 export const site = {
@@ -26,15 +57,27 @@ export const site = {
 } as const
 
 export type Site = typeof site
+
+${featuresBlock(features)}
 `
 }
 
-// web/next/src/app/page.tsx: a fresh fork has no product yet, so the home redirects to the waitlist.
-export const homeTemplate = (): string => `import { redirect } from "next/navigation"
+// web/next/src/app/page.tsx: a fresh fork home. With the waitlist on it redirects to the capture page; with it off it renders a plain landing. Flip features.waitlist in the config to switch, no regeneration needed.
+export const homeTemplate = (): string => `import { features, site } from "@packages/config/site"
+import { redirect } from "next/navigation"
 
-// Fresh fork: redirect to the waitlist until you build your real home page.
+// Fresh fork: the waitlist capture when the waitlist feature is on, otherwise a plain landing page. Replace this with your real home when ready.
 export default function Home() {
-  redirect("/waitlist")
+  if (features.waitlist) redirect("/waitlist")
+
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center p-8 text-center">
+      <div className="mx-auto flex w-full max-w-xl flex-col items-center">
+        <h1 className="mb-4 text-5xl font-bold tracking-tight sm:text-6xl">{site.name}</h1>
+        <p className="text-muted-foreground max-w-md text-lg">{site.tagline}</p>
+      </div>
+    </main>
+  )
 }
 `
 

--- a/packages/cli/test/convert.test.ts
+++ b/packages/cli/test/convert.test.ts
@@ -156,6 +156,21 @@ describe("convertRepo (in-place)", () => {
     expect(read(join(dir, "README.md"))).not.toContain("nrjdalal")
   })
 
+  test("writes the chosen feature flags into site.ts", () => {
+    scaffold()
+    convertRepo(dir, { name: "acme" }, {
+      apiDocs: true,
+      blog: false,
+      docs: true,
+      internalDocs: true,
+      waitlist: true,
+    })
+    const site = read(join(dir, "packages/config/src/site.ts"))
+    expect(site).toContain("export const features")
+    expect(site).toContain("blog: false")
+    expect(site).toContain("waitlist: true")
+  })
+
   test("reconciles the dangling /hire link and removes the marketing font module", () => {
     scaffold()
     convertRepo(dir, { name: "acme" })

--- a/packages/cli/test/features-consistency.test.ts
+++ b/packages/cli/test/features-consistency.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { FEATURE_DEFS } from "../bin/commands/init"
+import { DEFAULT_FEATURES, siteTemplate } from "../src/templates"
+
+// The canonical feature keys, read from the config source (not its build) so this guard needs no build step and runs in any test env. Guards the four places a flag lives against drift: the config's `features`, the CLI's DEFAULT_FEATURES + FEATURE_DEFS, and the generated site.ts block.
+const configFeatureKeys = (() => {
+  const src = readFileSync(join(import.meta.dir, "../../config/src/site.ts"), "utf8")
+  const match = src.match(/export const features = \{([^}]*)\}/)
+  const block = match ? match[1] : ""
+  return [...block.matchAll(/(\w+):/g)].map((m) => m[1]).sort()
+})()
+
+test("config declares a non-empty features set", () => {
+  expect(configFeatureKeys.length).toBeGreaterThan(0)
+})
+
+test("CLI DEFAULT_FEATURES and FEATURE_DEFS cover exactly the config feature keys", () => {
+  expect(Object.keys(DEFAULT_FEATURES).sort()).toEqual(configFeatureKeys)
+  expect(FEATURE_DEFS.map((f) => String(f.value)).sort()).toEqual(configFeatureKeys)
+})
+
+test("siteTemplate emits every config feature key", () => {
+  const out = siteTemplate({ name: "acme" })
+  for (const key of configFeatureKeys) expect(out).toContain(`${key}:`)
+})

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -53,11 +53,14 @@ describe("init --dry-run plan", () => {
   test("defaults to the four on-by-default features (waitlist off)", async () => {
     const out = await planFor([])
     expect(out).toContain("features: apiDocs, blog, docs, internalDocs")
+    // toContain is a prefix match, so assert waitlist is actually absent.
+    expect(out).not.toContain("waitlist")
   })
 
   test("--no-blog drops the blog from the plan", async () => {
     const out = await planFor(["--no-blog"])
     expect(out).toContain("features: apiDocs, docs, internalDocs")
+    expect(out).not.toContain("waitlist")
   })
 
   test("--waitlist adds the waitlist to the plan", async () => {

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -40,13 +40,28 @@ describe("init --dry-run plan", () => {
 
   test("--canary on an existing checkout is noted as ignored (in place)", async () => {
     const out = await planFor(["--canary"], scaffoldCheckout)
-    expect(out).toContain("mode:   in place")
+    expect(out).toContain("mode:     in place")
     expect(out).toContain("--canary ignored")
   })
 
   test("an in-place plan without --canary shows no note", async () => {
     const out = await planFor([], scaffoldCheckout)
-    expect(out).toContain("mode:   in place")
+    expect(out).toContain("mode:     in place")
     expect(out).not.toContain("--canary ignored")
+  })
+
+  test("defaults to the four on-by-default features (waitlist off)", async () => {
+    const out = await planFor([])
+    expect(out).toContain("features: apiDocs, blog, docs, internalDocs")
+  })
+
+  test("--no-blog drops the blog from the plan", async () => {
+    const out = await planFor(["--no-blog"])
+    expect(out).toContain("features: apiDocs, docs, internalDocs")
+  })
+
+  test("--waitlist adds the waitlist to the plan", async () => {
+    const out = await planFor(["--waitlist"])
+    expect(out).toContain("features: apiDocs, blog, docs, internalDocs, waitlist")
   })
 })

--- a/packages/cli/test/init.test.ts
+++ b/packages/cli/test/init.test.ts
@@ -64,4 +64,9 @@ describe("init --dry-run plan", () => {
     const out = await planFor(["--waitlist"])
     expect(out).toContain("features: apiDocs, blog, docs, internalDocs, waitlist")
   })
+
+  test("--no-blog wins over --blog (--no- takes precedence)", async () => {
+    const out = await planFor(["--blog", "--no-blog"])
+    expect(out).toContain("features: apiDocs, docs, internalDocs")
+  })
 })

--- a/packages/cli/test/prompt.test.ts
+++ b/packages/cli/test/prompt.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+import { promptMultiselect } from "../bin/commands/_prompt"
+
+type Tty = { isTTY?: boolean }
+
+// Force the non-interactive branch so the test never blocks on raw-mode stdin, even when `bun test` runs in a real terminal.
+describe("promptMultiselect (non-interactive)", () => {
+  let stdout: boolean | undefined
+  let stdin: boolean | undefined
+  beforeEach(() => {
+    stdout = process.stdout.isTTY
+    stdin = process.stdin.isTTY
+    ;(process.stdout as Tty).isTTY = false
+    ;(process.stdin as Tty).isTTY = false
+  })
+  afterEach(() => {
+    ;(process.stdout as Tty).isTTY = stdout
+    ;(process.stdin as Tty).isTTY = stdin
+  })
+
+  test("echoes and returns the pre-checked defaults", async () => {
+    const result = await promptMultiselect("Which features?", [
+      { value: "apiDocs", label: "API docs", checked: true },
+      { value: "blog", label: "Blog", checked: false },
+      { value: "docs", label: "Docs", checked: true },
+    ])
+    expect(result).toEqual(["apiDocs", "docs"])
+  })
+
+  test("returns [] when nothing is pre-checked", async () => {
+    const result = await promptMultiselect("Which features?", [
+      { value: "a", label: "A", checked: false },
+      { value: "b", label: "B", checked: false },
+    ])
+    expect(result).toEqual([])
+  })
+})

--- a/packages/cli/test/prompt.test.ts
+++ b/packages/cli/test/prompt.test.ts
@@ -35,4 +35,8 @@ describe("promptMultiselect (non-interactive)", () => {
     ])
     expect(result).toEqual([])
   })
+
+  test("returns [] for an empty option list", async () => {
+    expect(await promptMultiselect("Which features?", [])).toEqual([])
+  })
 })

--- a/packages/cli/test/templates.test.ts
+++ b/packages/cli/test/templates.test.ts
@@ -20,10 +20,32 @@ test("siteTemplate capitalizes the brand and leaks no upstream identity", () => 
   expect(out).not.toContain("nrjdalal")
 })
 
-test("homeTemplate redirects a fresh fork to the waitlist", () => {
+test("siteTemplate emits the fork feature defaults (waitlist off)", () => {
+  const out = siteTemplate(brand)
+  expect(out).toContain("export const features")
+  expect(out).toContain("waitlist: false")
+  expect(out).toContain("docs: true")
+  expect(out).toContain("export type Feature = keyof typeof features")
+})
+
+test("siteTemplate honors an explicit feature set", () => {
+  const out = siteTemplate(brand, {
+    apiDocs: false,
+    blog: false,
+    docs: true,
+    internalDocs: false,
+    waitlist: true,
+  })
+  expect(out).toContain("apiDocs: false")
+  expect(out).toContain("blog: false")
+  expect(out).toContain("waitlist: true")
+})
+
+test("homeTemplate branches between the waitlist and a plain landing", () => {
   const out = homeTemplate()
   expect(out).toContain('from "next/navigation"')
-  expect(out).toContain('redirect("/waitlist")')
+  expect(out).toContain("if (features.waitlist) redirect(\"/waitlist\")")
+  expect(out).toContain("{site.name}")
   expect(out).not.toContain("zerostarter")
 })
 

--- a/packages/config/src/site.ts
+++ b/packages/config/src/site.ts
@@ -73,3 +73,14 @@ Major versions are listed where they matter; see the root \`package.json\` catal
 } as const
 
 export type Site = typeof site
+
+// Optional surfaces a fork enables or disables. Typed boolean (not `as const`) so a fork can flip them and the runtime gates are not dead code. Off means the routes 404 and the links, nav, sitemap, llms, and search drop the surface; the CLI init sets these per fork, and any can be turned back on later. waitlist off makes the home a plain landing page.
+export const features = {
+  apiDocs: true,
+  blog: true,
+  docs: true,
+  internalDocs: true,
+  waitlist: true,
+}
+
+export type Feature = keyof typeof features

--- a/web/next/content/docs/getting-started/roadmap.mdx
+++ b/web/next/content/docs/getting-started/roadmap.mdx
@@ -18,7 +18,8 @@ Available out of the box in a fresh scaffold:
 - **[llms.txt + llms-full.txt](/docs/manage/llms-txt)**: auto-generated AI context routes: the index and the full corpus.
 - **[SEO routes](/docs/manage/seo)**: `robots.ts` and `sitemap.ts` generate `robots.txt` and the sitemap.
 - **[PostHog analytics](/docs/manage/analytics)**: product analytics, feature flags, and session replay. Optional; on only when `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` and `NEXT_PUBLIC_POSTHOG_HOST` are set.
-- **[Public waitlist](/docs/manage/database)**: a `/waitlist` page backed by `POST /api/waitlist` and the `waitlist` table; a fresh fork's home redirects here until you build your product.
+- **[Public waitlist](/docs/manage/database)**: a `/waitlist` page backed by `POST /api/waitlist` and the `waitlist` table; an optional [feature](/docs/manage/features) that becomes a fresh fork's home when enabled.
+- **[Configurable features](/docs/manage/features)**: turn the docs, blog, API reference, internal docs, or waitlist on or off per fork, from `init` flags or an interactive picker, and flip any of them later in config.
 - **[The `zerostarter` CLI](/docs/getting-started/setup)**: `bunx zerostarter init` scaffolds a rebranded fork, strips the sample content, installs dependencies, and provisions a local Postgres.
 
 ## Planned

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -25,11 +25,12 @@ The rest of this page is what those commands do, and the one thing to check if t
 
 - fetches the latest ZeroStarter and strips the sample content,
 - rebrands the copy to your project name,
+- sets your [feature flags](/docs/manage/features) (docs, blog, API reference, internal docs, waitlist), from an interactive checklist or `--<flag>`/`--no-<flag>` flags,
 - installs dependencies with Bun from the shipped `bun.lock`, so the first install resolves from locked versions instead of a slow cold resolve (progress streams live),
 - provisions a local Postgres in Docker (via [pglaunch](https://github.com/nrjdalal/pglaunch)), reusing an already-running one when you re-run `init`, and applies the migrations,
 - writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET`.
 
-Everything else has a working default, so the scaffold runs as-is. The database step defaults to yes when Docker is running; pass `--db` to provision it without the prompt.
+Everything else has a working default, so the scaffold runs as-is. The feature checklist is pre-checked to the defaults (all on except the waitlist), and any feature can be flipped later in config. The database step defaults to yes when Docker is running; pass `--db` to provision it without the prompt.
 
 <Callout type="info" title="If Docker isn't running">
 

--- a/web/next/content/docs/manage/content.mdx
+++ b/web/next/content/docs/manage/content.mdx
@@ -10,6 +10,8 @@ Everything you publish is MDX, and it lives in one place: `web/next/content/`. U
 - **Docs** declare their structure and metadata _centrally_, in `web/next/docs.config.ts`. You write only the body.
 - **Blog** posts carry their own metadata in frontmatter, and the listing builds itself from the posts.
 
+Docs, the blog, and the private console docs are each an optional [feature](/docs/manage/features): turn one off and its routes 404 and it drops from the nav, sitemap, `llms.txt`, and search. The rest of this page assumes they are on.
+
 ## Docs: the config is the source of truth
 
 `web/next/docs.config.ts` is the single source for docs structure and metadata. Each collection maps to ordered sidebar groups, and every entry is keyed by the page's URL:
@@ -68,5 +70,6 @@ Full-text search is powered by [Orama](https://orama.com) through Fumadocs, buil
 
 ## Next
 
+- [Features](/docs/manage/features): turn the docs, blog, or console docs on or off per fork.
 - [SEO & Metadata](/docs/manage/seo): the OG images, sitemap, and robots that cover everything you publish.
 - [llms.txt](/docs/manage/llms-txt): how the docs collection becomes agent-readable context.

--- a/web/next/content/docs/manage/content.mdx
+++ b/web/next/content/docs/manage/content.mdx
@@ -10,7 +10,7 @@ Everything you publish is MDX, and it lives in one place: `web/next/content/`. U
 - **Docs** declare their structure and metadata _centrally_, in `web/next/docs.config.ts`. You write only the body.
 - **Blog** posts carry their own metadata in frontmatter, and the listing builds itself from the posts.
 
-Docs, the blog, and the private console docs are each an optional [feature](/docs/manage/features): turn one off and its routes 404 and it drops from the nav, sitemap, `llms.txt`, and search. The rest of this page assumes they are on.
+Docs, the blog, and the private console docs are each an optional [feature](/docs/manage/features): turn one off and its routes 404 and it drops from the nav and search; docs and blog also drop from the sitemap and `llms.txt` (console docs are never in those by construction). The rest of this page assumes they are on.
 
 ## Docs: the config is the source of truth
 

--- a/web/next/content/docs/manage/features.mdx
+++ b/web/next/content/docs/manage/features.mdx
@@ -30,6 +30,8 @@ export const features = {
 
 "Off" is not a stub: the route returns a real 404, the links and navigation entries disappear, and the surface is dropped from the sitemap, `llms.txt`, and search, so nothing points at a page that no longer exists.
 
+One exception: the API routers stay mounted behind a runtime 404 guard (so a fork can flip them on later without an `AppType` change), so a disabled `/api/waitlist` still appears in the OpenAPI document at `/api/openapi.json`. It returns 404 until re-enabled; the generated spec does not follow the flags.
+
 ## The home and the waitlist
 
 A fresh fork's home (`web/next/src/app/page.tsx`) reads `features.waitlist` at runtime:

--- a/web/next/content/docs/manage/features.mdx
+++ b/web/next/content/docs/manage/features.mdx
@@ -25,10 +25,16 @@ export const features = {
 | `apiDocs`      | `/api/docs` Scalar reference UI + the `/api/openapi.json` spec | both 404 and the navbar "API Docs" link is hidden                            |
 | `blog`         | `/blog` and its posts                          | `/blog` 404s, the navbar link, `/og/blog`, sitemap, and `llms.txt` blog entries all drop      |
 | `docs`         | `/docs`                                        | `/docs` 404s, the navbar link, `/og/docs`, search (`/api/search`), sitemap, and `llms.txt` docs entries all drop |
-| `internalDocs` | `/console/docs` (admin-gated internal docs)    | `/console/docs` and its search (`/api/console/search`) 404                                     |
+| `internalDocs` | `/console/docs` (admin-gated internal docs)    | the console docs render the not-found page and their search (`/api/console/search`) 404s        |
 | `waitlist`     | `/waitlist` page and its API                   | `/waitlist` and `/api/waitlist` 404, and a fresh fork's home becomes a plain landing page      |
 
 "Off" is not a stub: the route returns a real 404, the links and navigation entries disappear, and the surface is dropped from the sitemap, `llms.txt`, and search, so nothing points at a page that no longer exists.
+
+<Callout type="info" title="One soft 404">
+
+The console area is `force-dynamic` (its admin gate runs per request), and Next commits a 200 status before a page-level `notFound()` fires mid-stream, so a disabled `/console/docs` renders the not-found page with an HTTP 200, not a 404. It is admin-gated and `noindex` with no content leak, and the console docs search still returns a hard 404. Every other disabled surface returns a real 404.
+
+</Callout>
 
 One nuance: the API routers stay mounted behind a runtime 404 guard so a fork can flip a flag on later without an `AppType` change. `apiDocs` gates the Scalar UI and the `/api/openapi.json` spec together, but the other flags do not rewrite the spec, so with `apiDocs` on and, say, `waitlist` off, `/api/waitlist` still appears in the document and returns 404 at runtime.
 

--- a/web/next/content/docs/manage/features.mdx
+++ b/web/next/content/docs/manage/features.mdx
@@ -1,0 +1,78 @@
+---
+slug: /docs/manage/features
+title: Features
+description: Toggle optional surfaces (docs, blog, API reference, waitlist) from one config, chosen at init and flippable anytime.
+---
+
+Not every product wants a public blog, a docs site, or a waitlist. ZeroStarter makes each optional surface a **feature flag**: one boolean in config that turns the whole surface on or off. The starter ships with every feature on (it demos them all); a fork picks its set at `init` and can change it at any time.
+
+## The flags
+
+The flags live next to the brand in `packages/config/src/site.ts`, as a separate `features` export (typed `boolean`, not `as const`, so a fork can flip them and the runtime gates stay live):
+
+```ts
+export const features = {
+  apiDocs: true,
+  blog: true,
+  docs: true,
+  internalDocs: true,
+  waitlist: true,
+}
+```
+
+| Flag           | Surface                                        | Off means                                                                                     |
+| -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `apiDocs`      | `/api/docs` OpenAPI + Scalar reference (the API) | the route 404s and the navbar "API Docs" link is hidden                                       |
+| `blog`         | `/blog` and its posts                          | `/blog` 404s, the navbar link, `/og/blog`, sitemap, and `llms.txt` blog entries all drop      |
+| `docs`         | `/docs`                                        | `/docs` 404s, the navbar link, `/og/docs`, search (`/api/search`), sitemap, and `llms.txt` docs entries all drop |
+| `internalDocs` | `/console/docs` (admin-gated internal docs)    | `/console/docs` and its search (`/api/console/search`) 404                                     |
+| `waitlist`     | `/waitlist` page and its API                   | `/waitlist` and `/api/waitlist` 404, and a fresh fork's home becomes a plain landing page      |
+
+"Off" is not a stub: the route returns a real 404, the links and navigation entries disappear, and the surface is dropped from the sitemap, `llms.txt`, and search, so nothing points at a page that no longer exists.
+
+## The home and the waitlist
+
+A fresh fork's home (`web/next/src/app/page.tsx`) reads `features.waitlist` at runtime:
+
+- **on** it redirects to the `/waitlist` capture page;
+- **off** it renders a plain landing page (your product name and tagline).
+
+Flip `features.waitlist` and the home re-themes on the next request. Nothing is regenerated. (The starter's own marketing home is separate and always renders; the landing branch is for forks.)
+
+## Choosing at `init`
+
+`zerostarter init` sets the fork's `features` for you. Non-interactively, pass a flag per surface (its `--no-` form turns it off); interactively, a checklist appears, pre-checked to the fork defaults:
+
+```bash
+# flags: any --<flag>/--no-<flag> skips the picker
+bunx zerostarter init my-app --no-blog --waitlist
+
+# no flags + a TTY: pick from the checklist (space toggles, enter confirms)
+bunx zerostarter init my-app
+```
+
+The fork defaults are **docs, blog, internal docs, and the API reference on; the waitlist off** (so a fresh fork lands on a plain home). Skipping the picker keeps those defaults. `--yes` takes them without prompting.
+
+## Enable anytime
+
+Toggling a feature never strips code. `init` only writes the flags, and every surface stays in the tree gated behind a runtime read of `features`. So turning a feature back on is a one-line config edit, no re-scaffolding:
+
+```ts
+// packages/config/src/site.ts
+export const features = {
+  // ...
+  blog: true, // was false; the /blog, its nav link, sitemap, and llms entries all return
+}
+```
+
+<Callout type="info" title="Bigger surfaces stay on">
+
+Auth, the dashboard, the console shell, and organizations are foundational (they reach into the database, login, and route protection), so they are not feature-flagged. The waitlist's database table also stays when the flag is off; dropping it would be a migration.
+
+</Callout>
+
+## Next
+
+- [Content (Blog & Docs)](/docs/manage/content): how the docs, blog, and console collections are authored behind these flags.
+- [SEO & Metadata](/docs/manage/seo): the sitemap and OG routes that read the flags.
+- [Quickstart](/docs/getting-started/setup): the `init` run that sets them.

--- a/web/next/content/docs/manage/features.mdx
+++ b/web/next/content/docs/manage/features.mdx
@@ -22,7 +22,7 @@ export const features = {
 
 | Flag           | Surface                                        | Off means                                                                                     |
 | -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `apiDocs`      | `/api/docs` OpenAPI + Scalar reference (the API) | the route 404s and the navbar "API Docs" link is hidden                                       |
+| `apiDocs`      | `/api/docs` Scalar reference UI + the `/api/openapi.json` spec | both 404 and the navbar "API Docs" link is hidden                            |
 | `blog`         | `/blog` and its posts                          | `/blog` 404s, the navbar link, `/og/blog`, sitemap, and `llms.txt` blog entries all drop      |
 | `docs`         | `/docs`                                        | `/docs` 404s, the navbar link, `/og/docs`, search (`/api/search`), sitemap, and `llms.txt` docs entries all drop |
 | `internalDocs` | `/console/docs` (admin-gated internal docs)    | `/console/docs` and its search (`/api/console/search`) 404                                     |
@@ -30,7 +30,7 @@ export const features = {
 
 "Off" is not a stub: the route returns a real 404, the links and navigation entries disappear, and the surface is dropped from the sitemap, `llms.txt`, and search, so nothing points at a page that no longer exists.
 
-One exception: the API routers stay mounted behind a runtime 404 guard (so a fork can flip them on later without an `AppType` change), so a disabled `/api/waitlist` still appears in the OpenAPI document at `/api/openapi.json`. It returns 404 until re-enabled; the generated spec does not follow the flags.
+One nuance: the API routers stay mounted behind a runtime 404 guard so a fork can flip a flag on later without an `AppType` change. `apiDocs` gates the Scalar UI and the `/api/openapi.json` spec together, but the other flags do not rewrite the spec, so with `apiDocs` on and, say, `waitlist` off, `/api/waitlist` still appears in the document and returns 404 at runtime.
 
 ## The home and the waitlist
 

--- a/web/next/content/docs/manage/llms-txt.mdx
+++ b/web/next/content/docs/manage/llms-txt.mdx
@@ -22,6 +22,8 @@ Two `force-static` route handlers (both `revalidate = 60`) build the files from 
 - `web/next/src/app/(llms.txt)/llms.txt/[[...slug]]/route.ts`: the `/llms.txt` index, the `/docs` and `/blog` section indexes, and every per-page alias. It sorts docs by `meta.json` order and lists only published blog posts. Console docs are excluded on purpose (privacy boundary).
 - `web/next/src/app/(llms.txt)/llms-full.txt/route.ts`: the single-file dump, preamble first.
 
+The docs and blog are [features](/docs/manage/features): turn one off and its pages, section index, and per-page aliases drop from both files, so `/llms.txt` never points at a route that 404s.
+
 Page bodies come from `getLLMText` in `web/next/src/lib/llms.ts`. It reads each page's processed markdown (available because every collection in `web/next/source.config.ts` sets `includeProcessedMarkdown: true`), runs `decodeHTML` to undo Fumadocs' HTML-escaping, and prefixes a `# [title](url)` heading that links back to the live page. Each per-page docs alias also appends a footer pointing back to `/llms.txt`, so an agent that lands on one page can find the rest of the navigation.
 
 <Callout type="info" title="Only /docs and /blog aliases are routes">

--- a/web/next/content/docs/manage/seo.mdx
+++ b/web/next/content/docs/manage/seo.mdx
@@ -43,25 +43,36 @@ These routes live at `/og` on purpose. `robots.txt` disallows `/api/`, so keepin
 
 The docs route is prerendered at build (`force-static` + `generateStaticParams`); the blog route prebuilds published posts and revalidates every 60s so scheduled posts appear without a rebuild; `/og/home` is static; and the generic `/og` route is `force-dynamic`. Page metadata wires each image in automatically through `generatePageMetadata()` in `web/next/src/lib/fumadocs.tsx`, so every docs and blog page gets a unique preview.
 
-All routes forward to the shared helper in `web/next/src/lib/og-image.tsx`. To add a section, create `web/next/src/app/og/<section>/[[...slug]]/route.tsx` and call `generateOgImage` with your source:
+All routes render through `renderOgImage` in `web/next/src/lib/og-image.tsx`, resolving the page through the [`contentSource`](/docs/manage/features) seam so the feature gate and publish policy apply for free. To add a section, register its kind in `web/next/src/lib/content.ts`, then create `web/next/src/app/og/<section>/[[...slug]]/route.tsx`:
 
 ```tsx
+import { site } from "@packages/config/site"
+
+import { contentSource } from "@/lib/content"
+import { renderOgImage } from "@/lib/og-image"
+
 export const dynamic = "force-static"
+
+const section = contentSource("docs") // your content kind
 
 export async function GET(_req: Request, { params }: { params: Promise<{ slug?: string[] }> }) {
   const { slug } = await params
-  return generateOgImage(slug, {
-    source: yourSource,
+  const page = section.getPageOr404(slug)
+  return renderOgImage({
     sectionName: "Your Section",
-    defaultTitle: `${site.name} - Your Section`,
-    defaultDescription: "Your default description",
+    title: page.data.title || `${site.name} - Your Section`,
+    description: page.data.description || "Your default description",
   })
+}
+
+export function generateStaticParams() {
+  return section.params()
 }
 ```
 
-<Callout type="warn" title="Time-gated sources need gating">
+<Callout type="info" title="Publish gating is built in">
 
-`force-static` is fine for always-public sources like docs. For content with a `publishedAt` (the blog), it would prerender previews for _unpublished_ posts. Gate on the published set and add `revalidate = 60`. See `web/next/src/app/og/blog/[[...slug]]/route.tsx` for the pattern.
+`getPageOr404` and `params()` apply each kind's publish policy, so you never hand-filter: the blog kind excludes unpublished or scheduled posts (via `isPublicBlogPage`), and a `force-static` OG route therefore never prerenders a preview for a post that isn't live. Keep `revalidate = 60` for a time-gated kind so a scheduled post gets its preview without a rebuild, as `web/next/src/app/og/blog/[[...slug]]/route.tsx` does.
 
 </Callout>
 

--- a/web/next/content/docs/manage/seo.mdx
+++ b/web/next/content/docs/manage/seo.mdx
@@ -22,7 +22,7 @@ The starter ships with **no** `noindex` directive and no `X-Robots-Tag` header, 
 
 `sitemap.ts` (a `MetadataRoute.Sitemap`) discovers pages from the Fumadocs sources instead of a hand-kept list: the home route, every page in `docsSource`, and the published posts from `getPublishedBlogPosts()`. It is `force-static` with `revalidate = 60`, so it regenerates at most once a minute, and its URLs are sorted alphabetically.
 
-Priorities and change frequencies are set per type: the home page at `1.0`, docs and blog pages at `0.9`; home and docs refresh weekly, blog posts monthly. Home and docs entries set `lastModified` to the build time; blog entries use `updatedAt` when present, else `publishedAt`. The `/blog` index is absent because `getPublishedBlogPosts()` returns only individual published posts. The sitemap does no filtering of its own, so unpublished posts never leak in.
+Priorities and change frequencies are set per type: the home page at `1.0`, docs and blog pages at `0.9`; home and docs refresh weekly, blog posts monthly. Home and docs entries set `lastModified` to the build time; blog entries use `updatedAt` when present, else `publishedAt`. The `/blog` index is absent because `getPublishedBlogPosts()` returns only individual published posts. The sitemap does no filtering of its own, so unpublished posts never leak in. The docs and blog blocks follow their [feature flags](/docs/manage/features): turn one off and its entries drop from the sitemap.
 
 ## OG images
 

--- a/web/next/docs.config.ts
+++ b/web/next/docs.config.ts
@@ -118,6 +118,13 @@ const docsConfig = {
         },
       },
       {
+        "/docs/manage/features": {
+          title: "Features",
+          description:
+            "Toggle optional surfaces (docs, blog, API reference, waitlist) from one config, chosen at init and flippable anytime.",
+        },
+      },
+      {
         "/docs/manage/seo": {
           title: "SEO & Metadata",
           description:

--- a/web/next/src/app/(console)/console/docs/[[...slug]]/page.tsx
+++ b/web/next/src/app/(console)/console/docs/[[...slug]]/page.tsx
@@ -1,7 +1,9 @@
-import { getPageData, renderPageContent } from "@/lib/fumadocs"
-import { consoleSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
+import { renderPageContent } from "@/lib/fumadocs"
+
+const consoleDocs = contentSource("console")
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
-  const pageData = await getPageData(props.params, consoleSource)
-  return renderPageContent(pageData)
+  const { slug } = await props.params
+  return renderPageContent(consoleDocs, consoleDocs.getPageOr404(slug))
 }

--- a/web/next/src/app/(console)/console/docs/layout.tsx
+++ b/web/next/src/app/(console)/console/docs/layout.tsx
@@ -4,6 +4,8 @@ import { RootProvider } from "fumadocs-ui/provider/next"
 import { contentSource } from "@/lib/content"
 import { baseOptions } from "@/lib/fumadocs"
 
+const consoleDocs = contentSource("console")
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <main className="console-docs">
@@ -21,7 +23,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           {...baseOptions()}
           nav={{ enabled: false }}
           sidebar={{ enabled: false }}
-          tree={contentSource("console").tree()}
+          tree={consoleDocs.tree()}
         >
           {children}
         </DocsLayout>

--- a/web/next/src/app/(console)/console/docs/layout.tsx
+++ b/web/next/src/app/(console)/console/docs/layout.tsx
@@ -1,8 +1,8 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs"
 import { RootProvider } from "fumadocs-ui/provider/next"
 
+import { contentSource } from "@/lib/content"
 import { baseOptions } from "@/lib/fumadocs"
-import { consoleSource } from "@/lib/source"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -21,7 +21,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           {...baseOptions()}
           nav={{ enabled: false }}
           sidebar={{ enabled: false }}
-          tree={consoleSource.getPageTree()}
+          tree={contentSource("console").tree()}
         >
           {children}
         </DocsLayout>

--- a/web/next/src/app/(content)/blog/[[...slug]]/page.tsx
+++ b/web/next/src/app/(content)/blog/[[...slug]]/page.tsx
@@ -1,33 +1,26 @@
 import type { Metadata } from "next"
 
-import { generatePublicBlogParams, getPublicBlogPage, isBlogIndexPage } from "@/lib/blog"
+import { contentSource } from "@/lib/content"
 import { generatePageMetadata, renderPageContent } from "@/lib/fumadocs"
-import { blogSource } from "@/lib/source"
+
+const blog = contentSource("blog")
 
 // Scheduling depends on Next's default dynamicParams (true): a scheduled post not prebuilt by generateStaticParams renders on demand once published, and revalidate=60 refreshes cached surfaces within ~60s. Setting dynamicParams=false would 404 scheduled posts until a redeploy.
 export const dynamic = "force-static"
 export const revalidate = 60
 
 export function generateStaticParams() {
-  return generatePublicBlogParams()
+  return blog.params()
 }
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
   const { slug } = await props.params
-  const page = getPublicBlogPage(slug)
-
-  return renderPageContent({ page, source: blogSource })
+  return renderPageContent(blog, blog.getPageOr404(slug))
 }
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>
 }): Promise<Metadata> {
-  const params = await props.params
-  const page = getPublicBlogPage(params.slug)
-
-  return generatePageMetadata(Promise.resolve(params), {
-    source: blogSource,
-    ogPath: "/og/blog",
-    ogType: isBlogIndexPage(page) ? "website" : "article",
-  })
+  const { slug } = await props.params
+  return generatePageMetadata(blog, blog.getPageOr404(slug))
 }

--- a/web/next/src/app/(content)/blog/layout.tsx
+++ b/web/next/src/app/(content)/blog/layout.tsx
@@ -4,6 +4,8 @@ import { RootProvider } from "fumadocs-ui/provider/next"
 import { contentSource } from "@/lib/content"
 import { baseOptions } from "@/lib/fumadocs"
 
+const blog = contentSource("blog")
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <main>
@@ -19,7 +21,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           {...baseOptions()}
           nav={{ enabled: false }}
           sidebar={{ enabled: false }}
-          tree={contentSource("blog").tree()}
+          tree={blog.tree()}
         >
           {children}
         </DocsLayout>

--- a/web/next/src/app/(content)/blog/layout.tsx
+++ b/web/next/src/app/(content)/blog/layout.tsx
@@ -1,7 +1,7 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs"
 import { RootProvider } from "fumadocs-ui/provider/next"
 
-import { getPublicBlogPageTree } from "@/lib/blog"
+import { contentSource } from "@/lib/content"
 import { baseOptions } from "@/lib/fumadocs"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
@@ -19,7 +19,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           {...baseOptions()}
           nav={{ enabled: false }}
           sidebar={{ enabled: false }}
-          tree={getPublicBlogPageTree()}
+          tree={contentSource("blog").tree()}
         >
           {children}
         </DocsLayout>

--- a/web/next/src/app/(content)/docs/[[...slug]]/page.tsx
+++ b/web/next/src/app/(content)/docs/[[...slug]]/page.tsx
@@ -1,26 +1,22 @@
 import type { Metadata } from "next"
 
-import {
-  createGenerateStaticParams,
-  generatePageMetadata,
-  getPageData,
-  renderPageContent,
-} from "@/lib/fumadocs"
-import { docsSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
+import { generatePageMetadata, renderPageContent } from "@/lib/fumadocs"
+
+const docs = contentSource("docs")
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
-  const pageData = await getPageData(props.params, docsSource)
-  return renderPageContent(pageData)
+  const { slug } = await props.params
+  return renderPageContent(docs, docs.getPageOr404(slug))
 }
 
-export const generateStaticParams = createGenerateStaticParams(docsSource)
+export function generateStaticParams() {
+  return docs.params()
+}
 
 export async function generateMetadata(props: {
   params: Promise<{ slug?: string[] }>
 }): Promise<Metadata> {
-  return generatePageMetadata(props.params, {
-    source: docsSource,
-    ogPath: "/og/docs",
-    ogType: "website",
-  })
+  const { slug } = await props.params
+  return generatePageMetadata(docs, docs.getPageOr404(slug))
 }

--- a/web/next/src/app/(content)/docs/layout.tsx
+++ b/web/next/src/app/(content)/docs/layout.tsx
@@ -15,6 +15,8 @@ import { contentSource } from "@/lib/content"
 import { resolveDocsNav } from "@/lib/docs"
 import { baseOptions } from "@/lib/fumadocs"
 
+const docs = contentSource("docs")
+
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <SidebarProvider>
@@ -41,7 +43,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             {...baseOptions()}
             nav={{ enabled: false }}
             sidebar={{ enabled: false }}
-            tree={contentSource("docs").tree()}
+            tree={docs.tree()}
           >
             {children}
           </DocsLayout>

--- a/web/next/src/app/(content)/docs/layout.tsx
+++ b/web/next/src/app/(content)/docs/layout.tsx
@@ -11,9 +11,9 @@ import {
   SidebarProvider,
   SidebarRail,
 } from "@/components/ui/sidebar"
+import { contentSource } from "@/lib/content"
 import { resolveDocsNav } from "@/lib/docs"
 import { baseOptions } from "@/lib/fumadocs"
-import { docsSource } from "@/lib/source"
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -41,7 +41,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
             {...baseOptions()}
             nav={{ enabled: false }}
             sidebar={{ enabled: false }}
-            tree={docsSource.getPageTree()}
+            tree={contentSource("docs").tree()}
           >
             {children}
           </DocsLayout>

--- a/web/next/src/app/(llms.txt)/llms-full.txt/route.ts
+++ b/web/next/src/app/(llms.txt)/llms-full.txt/route.ts
@@ -1,7 +1,6 @@
 import { site } from "@packages/config/site"
 
 import docsMeta from "@/../content/docs/meta.json"
-import { getPublishedBlogPosts } from "@/lib/blog"
 import { contentSource } from "@/lib/content"
 import { getLLMText, llmTextHeaders, sortByMeta } from "@/lib/llms"
 
@@ -9,9 +8,10 @@ export const dynamic = "force-static"
 export const revalidate = 60
 
 export async function GET() {
+  // pages() already applies each kind's feature gate and blog publish policy, returning [] when off.
   const pages = [
     ...sortByMeta(contentSource("docs").pages(), docsMeta.pages, "/docs"),
-    ...(contentSource("blog").enabled ? getPublishedBlogPosts() : []),
+    ...contentSource("blog").pages(),
   ]
 
   const scanned = await Promise.all(pages.map(getLLMText))

--- a/web/next/src/app/(llms.txt)/llms-full.txt/route.ts
+++ b/web/next/src/app/(llms.txt)/llms-full.txt/route.ts
@@ -2,16 +2,16 @@ import { site } from "@packages/config/site"
 
 import docsMeta from "@/../content/docs/meta.json"
 import { getPublishedBlogPosts } from "@/lib/blog"
+import { contentSource } from "@/lib/content"
 import { getLLMText, llmTextHeaders, sortByMeta } from "@/lib/llms"
-import { docsSource } from "@/lib/source"
 
 export const dynamic = "force-static"
 export const revalidate = 60
 
 export async function GET() {
   const pages = [
-    ...sortByMeta(docsSource.getPages(), docsMeta.pages, "/docs"),
-    ...getPublishedBlogPosts(),
+    ...sortByMeta(contentSource("docs").pages(), docsMeta.pages, "/docs"),
+    ...(contentSource("blog").enabled ? getPublishedBlogPosts() : []),
   ]
 
   const scanned = await Promise.all(pages.map(getLLMText))

--- a/web/next/src/app/(llms.txt)/llms.txt/[[...slug]]/route.ts
+++ b/web/next/src/app/(llms.txt)/llms.txt/[[...slug]]/route.ts
@@ -2,20 +2,17 @@ import { site } from "@packages/config/site"
 import { notFound } from "next/navigation"
 
 import docsMeta from "@/../content/docs/meta.json"
-import { generatePublicBlogParams, getPublicBlogPage, getPublishedBlogPosts } from "@/lib/blog"
 import { config } from "@/lib/config"
+import { contentSource } from "@/lib/content"
 import { getLLMText, llmTextHeaders, sortByMeta } from "@/lib/llms"
-import { blogSource, docsSource } from "@/lib/source"
 
 export const dynamic = "force-static"
 export const revalidate = 60
 
-async function createPageResponse(
-  page: ReturnType<typeof blogSource.getPage> | ReturnType<typeof docsSource.getPage>,
-  isDocs: boolean,
-) {
-  if (!page) notFound()
+const docs = contentSource("docs")
+const blog = contentSource("blog")
 
+async function createPageResponse(page: Parameters<typeof getLLMText>[0], isDocs: boolean) {
   const content = await getLLMText(page)
 
   const footer = isDocs
@@ -33,25 +30,29 @@ export async function GET(_req: Request, { params }: { params: Promise<{ slug?: 
   const { slug } = await params
 
   if (!slug || slug.length === 0) {
-    const docsPages = sortByMeta(docsSource.getPages(), docsMeta.pages, "/docs")
-    const docsIndex = docsPages
-      .map((p) => `- [${p.data.title}](${config.app.url}${p.url}.md): ${p.data.description}`)
-      .join("\n")
-
-    return new Response(
-      `# ${site.name}
-
-> ${site.description}
+    const docsSection = docs.enabled
+      ? `
 
 ## Documentation
 
 > Complete documentation for ${site.name}
 
-${docsIndex}
+${sortByMeta(docs.pages(), docsMeta.pages, "/docs")
+  .map((p) => `- [${p.data.title}](${config.app.url}${p.url}.md): ${p.data.description}`)
+  .join("\n")}`
+      : ""
+    const blogSection = blog.enabled
+      ? `
 
 ## Optional
 
-- [Blog](${config.app.url}/blog.md): Latest articles and updates about ${site.name}
+- [Blog](${config.app.url}/blog.md): Latest articles and updates about ${site.name}`
+      : ""
+
+    return new Response(
+      `# ${site.name}
+
+> ${site.description}${docsSection}${blogSection}
 `,
       {
         headers: llmTextHeaders,
@@ -59,16 +60,15 @@ ${docsIndex}
     )
   }
 
-  const isBlog = slug[0] === "blog"
-  const isDocs = slug[0] === "docs"
+  const kind = slug[0] === "blog" ? "blog" : slug[0] === "docs" ? "docs" : null
+  if (!kind) notFound()
 
-  if (!isBlog && !isDocs) {
-    notFound()
-  }
+  const source = kind === "blog" ? blog : docs
+  if (!source.enabled) notFound()
 
-  if (isBlog && slug.length === 1) {
-    const blogPages = getPublishedBlogPosts()
-    const blogIndex = blogPages
+  if (kind === "blog" && slug.length === 1) {
+    const blogIndex = blog
+      .pages()
       .map((p) => `- [${p.data.title}](${config.app.url}${p.url}.md): ${p.data.description}`)
       .join("\n")
 
@@ -93,25 +93,13 @@ ${blogIndex}
     )
   }
 
-  if (isDocs && slug.length === 1) {
-    return createPageResponse(docsSource.getPage([]), true)
-  }
-
-  const pageSlug = slug.slice(1)
-  if (isBlog) {
-    return createPageResponse(getPublicBlogPage(pageSlug), false)
-  }
-
-  return createPageResponse(docsSource.getPage(pageSlug), true)
+  const pageSlug = slug.length === 1 ? [] : slug.slice(1)
+  return createPageResponse(source.getPageOr404(pageSlug), kind === "docs")
 }
 
 export function generateStaticParams() {
   const indexParams = [{ slug: [] }]
-  const docsParams = docsSource.generateParams().map((params) => ({
-    slug: ["docs", ...(params.slug ?? [])],
-  }))
-  const blogParams = generatePublicBlogParams().map((params) => ({
-    slug: ["blog", ...(params.slug ?? [])],
-  }))
+  const docsParams = docs.params().map((p) => ({ slug: ["docs", ...p.slug] }))
+  const blogParams = blog.params().map((p) => ({ slug: ["blog", ...p.slug] }))
   return [...indexParams, ...docsParams, ...blogParams]
 }

--- a/web/next/src/app/api/console/search/route.ts
+++ b/web/next/src/app/api/console/search/route.ts
@@ -1,18 +1,20 @@
 import { createFromSource } from "fumadocs-core/search/server"
 
 import { getConsoleSession } from "@/lib/auth/console"
-import { consoleSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
 
 // Gated console docs search: 404 for anyone without console access so the index never leaks; never statically cached.
 export const dynamic = "force-dynamic"
 
-const search = createFromSource(consoleSource, {
+const consoleDocs = contentSource("console")
+
+const search = createFromSource(consoleDocs.source, {
   // https://docs.orama.com/docs/orama-js/supported-languages
   language: "english",
 })
 
 export async function GET(request: Request) {
-  if (!(await getConsoleSession())) {
+  if (!consoleDocs.enabled || !(await getConsoleSession())) {
     return new Response(null, { status: 404 })
   }
   return search.GET(request)

--- a/web/next/src/app/api/search/route.ts
+++ b/web/next/src/app/api/search/route.ts
@@ -1,8 +1,15 @@
 import { createFromSource } from "fumadocs-core/search/server"
 
-import { docsSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
 
-export const { GET } = createFromSource(docsSource, {
+const docs = contentSource("docs")
+
+const search = createFromSource(docs.source, {
   // https://docs.orama.com/docs/orama-js/supported-languages
   language: "english",
 })
+
+export async function GET(request: Request) {
+  if (!docs.enabled) return new Response(null, { status: 404 })
+  return search.GET(request)
+}

--- a/web/next/src/app/og/blog/[[...slug]]/route.tsx
+++ b/web/next/src/app/og/blog/[[...slug]]/route.tsx
@@ -1,26 +1,24 @@
 import { site } from "@packages/config/site"
 
-import { generatePublicBlogParams, getPublicBlogPage } from "@/lib/blog"
-import { generateOgImage } from "@/lib/og-image"
-import { blogSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
+import { renderOgImage } from "@/lib/og-image"
 
 export const dynamic = "force-static"
 export const revalidate = 60
 
+const blog = contentSource("blog")
+
 export function generateStaticParams() {
-  return generatePublicBlogParams().map((params) => ({
-    slug: params.slug ?? [],
-  }))
+  return blog.params()
 }
 
 export async function GET(_req: Request, { params }: { params: Promise<{ slug?: string[] }> }) {
   const { slug } = await params
-  void getPublicBlogPage(slug)
+  const page = blog.getPageOr404(slug)
 
-  return generateOgImage(slug, {
-    source: blogSource,
+  return renderOgImage({
     sectionName: "Blog",
-    defaultTitle: `${site.name} - Blog`,
-    defaultDescription: `Blog post from ${site.name}`,
+    title: page.data.title || `${site.name} - Blog`,
+    description: page.data.description || `Blog post from ${site.name}`,
   })
 }

--- a/web/next/src/app/og/docs/[[...slug]]/route.tsx
+++ b/web/next/src/app/og/docs/[[...slug]]/route.tsx
@@ -1,23 +1,23 @@
 import { site } from "@packages/config/site"
 
-import { generateOgImage } from "@/lib/og-image"
-import { docsSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
+import { renderOgImage } from "@/lib/og-image"
 
 export const dynamic = "force-static"
 
+const docs = contentSource("docs")
+
 export async function GET(_req: Request, { params }: { params: Promise<{ slug?: string[] }> }) {
   const { slug } = await params
+  const page = docs.getPageOr404(slug)
 
-  return generateOgImage(slug, {
-    source: docsSource,
+  return renderOgImage({
     sectionName: "Documentation",
-    defaultTitle: `${site.name} - Documentation`,
-    defaultDescription: `Documentation for ${site.name}`,
+    title: page.data.title || `${site.name} - Documentation`,
+    description: page.data.description || `Documentation for ${site.name}`,
   })
 }
 
 export function generateStaticParams() {
-  return docsSource.generateParams().map((params) => ({
-    slug: params.slug ?? [],
-  }))
+  return docs.params()
 }

--- a/web/next/src/app/sitemap.ts
+++ b/web/next/src/app/sitemap.ts
@@ -3,7 +3,7 @@ import { MetadataRoute } from "next"
 import { getPublishedBlogPosts } from "@/lib/blog"
 import { toBlogDate } from "@/lib/blog-policy"
 import { config } from "@/lib/config"
-import { docsSource } from "@/lib/source"
+import { contentSource } from "@/lib/content"
 
 export const dynamic = "force-static"
 export const revalidate = 60
@@ -20,23 +20,25 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  // Docs pages
-  const docsPages = docsSource.getPages()
-  const docsRoutes: MetadataRoute.Sitemap = docsPages.map((page) => ({
-    url: `${baseUrl}${page.url}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
-    priority: 0.9,
-  }))
+  // Docs pages (empty when the docs feature is off)
+  const docsRoutes: MetadataRoute.Sitemap = contentSource("docs")
+    .pages()
+    .map((page) => ({
+      url: `${baseUrl}${page.url}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.9,
+    }))
 
-  // Blog pages
-  const blogPages = getPublishedBlogPosts()
-  const blogRoutes: MetadataRoute.Sitemap = blogPages.map((page) => ({
-    url: `${baseUrl}${page.url}`,
-    lastModified: toBlogDate(page.data.updatedAt ?? page.data.publishedAt),
-    changeFrequency: "monthly" as const,
-    priority: 0.9,
-  }))
+  // Blog pages (empty when the blog feature is off)
+  const blogRoutes: MetadataRoute.Sitemap = contentSource("blog").enabled
+    ? getPublishedBlogPosts().map((page) => ({
+        url: `${baseUrl}${page.url}`,
+        lastModified: toBlogDate(page.data.updatedAt ?? page.data.publishedAt),
+        changeFrequency: "monthly" as const,
+        priority: 0.9,
+      }))
+    : []
 
   // Combine all pages and sort
   const allPages = [...staticRoutes, ...docsRoutes, ...blogRoutes]

--- a/web/next/src/app/sitemap.ts
+++ b/web/next/src/app/sitemap.ts
@@ -8,6 +8,9 @@ import { contentSource } from "@/lib/content"
 export const dynamic = "force-static"
 export const revalidate = 60
 
+const docs = contentSource("docs")
+const blog = contentSource("blog")
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = config.app.url
 
@@ -21,7 +24,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   // Docs pages (empty when the docs feature is off)
-  const docsRoutes: MetadataRoute.Sitemap = contentSource("docs")
+  const docsRoutes: MetadataRoute.Sitemap = docs
     .pages()
     .map((page) => ({
       url: `${baseUrl}${page.url}`,
@@ -31,7 +34,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }))
 
   // Blog pages: gate on the seam's `enabled`, but read through getPublishedBlogPosts() (not pages()) for its narrowed `publishedAt: string`, which lastModified needs. Empty when the blog feature is off.
-  const blogRoutes: MetadataRoute.Sitemap = contentSource("blog").enabled
+  const blogRoutes: MetadataRoute.Sitemap = blog.enabled
     ? getPublishedBlogPosts().map((page) => ({
         url: `${baseUrl}${page.url}`,
         lastModified: toBlogDate(page.data.updatedAt ?? page.data.publishedAt),

--- a/web/next/src/app/sitemap.ts
+++ b/web/next/src/app/sitemap.ts
@@ -30,7 +30,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     }))
 
-  // Blog pages (empty when the blog feature is off)
+  // Blog pages: gate on the seam's `enabled`, but read through getPublishedBlogPosts() (not pages()) for its narrowed `publishedAt: string`, which lastModified needs. Empty when the blog feature is off.
   const blogRoutes: MetadataRoute.Sitemap = contentSource("blog").enabled
     ? getPublishedBlogPosts().map((page) => ({
         url: `${baseUrl}${page.url}`,

--- a/web/next/src/app/waitlist/page.tsx
+++ b/web/next/src/app/waitlist/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { site } from "@packages/config/site"
+import { features, site } from "@packages/config/site"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { notFound } from "next/navigation"
 import { useState } from "react"
 import { toast } from "sonner"
 import { z } from "zod"
@@ -58,6 +59,8 @@ function WaitlistCount() {
 }
 
 export default function WaitlistPage() {
+  if (!features.waitlist) notFound()
+
   const [joined, setJoined] = useState(false)
   const queryClient = useQueryClient()
 

--- a/web/next/src/components/common/navbar.tsx
+++ b/web/next/src/components/common/navbar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { site } from "@packages/config/site"
+import { features, type Feature, site } from "@packages/config/site"
 import {
   RiArrowRightUpLine,
   RiDiscordFill,
@@ -80,12 +80,14 @@ export function Navbar() {
 
   if (pathname?.startsWith("/console") || pathname?.startsWith("/dashboard")) return null
 
-  const navLinks = [
-    { href: "/docs", label: "Documentation" },
-    { href: "/api/docs", label: "API Docs", external: true },
-    { href: "/blog", label: "Blog" },
+  // A link with a `feature` is shown only when that feature is enabled; /hire has none, so it always shows (and is stripped from forks by the CLI).
+  const allNavLinks: { href: string; label: string; external?: boolean; feature?: Feature }[] = [
+    { href: "/docs", label: "Documentation", feature: "docs" },
+    { href: "/api/docs", label: "API Docs", external: true, feature: "apiDocs" },
+    { href: "/blog", label: "Blog", feature: "blog" },
     { href: "/hire", label: "Hire" },
   ]
+  const navLinks = allNavLinks.filter((link) => !link.feature || features[link.feature])
 
   return (
     <header className="bg-background fixed top-0 left-0 z-50 w-full border-b">

--- a/web/next/src/components/console/sidebar.tsx
+++ b/web/next/src/components/console/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { features } from "@packages/config/site"
 import { RiBookLine, RiDashboardLine } from "@remixicon/react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -17,7 +18,7 @@ import type { NavGroup } from "@/lib/docs"
 import { isActive } from "@/lib/utils"
 
 const mainItems = [
-  { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false },
+  { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false, feature: "internalDocs" },
 ] as const
 
 // Sidebar-header slot: the console home ("Dashboard") link, plus the docs search inside /console/docs (matching public /docs).
@@ -67,11 +68,15 @@ export function ConsoleNav({ docsGroups }: { docsGroups: NavGroup[] }) {
     return <DocsNav groups={docsGroups} />
   }
 
+  // Drop items whose feature is off, and the whole group with them when nothing is left.
+  const items = mainItems.filter((item) => features[item.feature])
+  if (items.length === 0) return null
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel className="pl-2.5">Getting Started</SidebarGroupLabel>
       <SidebarMenu className="space-y-0.5">
-        {mainItems.map((item) => {
+        {items.map((item) => {
           const active = isActive(pathname, item.url, { exact: item.exact })
 
           return (

--- a/web/next/src/components/dashboard/sidebar.tsx
+++ b/web/next/src/components/dashboard/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { features } from "@packages/config/site"
 import { RiAddLine, RiBookLine, RiBuildingLine } from "@remixicon/react"
 import { useForm } from "@tanstack/react-form"
 import { type User } from "better-auth/types"
@@ -236,13 +237,15 @@ export function DashboardFooter({
   }
   return (
     <SidebarMenu className="space-y-1.5">
-      <SidebarMenuItem>
-        <SidebarMenuButton render={<Link href="/docs" onClick={close} />}>
-          <RiBookLine />
-          <span>Documentation</span>
-          <span className="text-muted-foreground ml-auto text-xs">v{config.app.version}</span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
+      {features.docs && (
+        <SidebarMenuItem>
+          <SidebarMenuButton render={<Link href="/docs" onClick={close} />}>
+            <RiBookLine />
+            <span>Documentation</span>
+            <span className="text-muted-foreground ml-auto text-xs">v{config.app.version}</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      )}
       <SidebarUserMenu user={user} area={canAccessConsole ? "dashboard" : undefined} />
     </SidebarMenu>
   )

--- a/web/next/src/lib/blog.ts
+++ b/web/next/src/lib/blog.ts
@@ -1,5 +1,4 @@
 import type { Folder, Node, Root } from "fumadocs-core/page-tree"
-import { notFound } from "next/navigation"
 
 import {
   compareBlogPostPublishOrder,
@@ -22,15 +21,9 @@ function isPublishedBlogPost(page: BlogPage, now = new Date()): page is Publishe
   return !isBlogIndexPage(page) && isBlogPostPublished(page.data, now)
 }
 
-function isPublicBlogPage(page: BlogPage, now = new Date()): boolean {
+// The /blog index plus published posts; the publish gate contentSource("blog") applies.
+export function isPublicBlogPage(page: BlogPage, now = new Date()): boolean {
   return isBlogIndexPage(page) || isPublishedBlogPost(page, now)
-}
-
-// Calls notFound(), so only valid in a request context (Server Component or route handler).
-export function getPublicBlogPage(slug?: string[], now = new Date()): BlogPage {
-  const page = blogSource.getPage(slug)
-  if (!page || !isPublicBlogPage(page, now)) notFound()
-  return page
 }
 
 function toBlogPostMeta(page: BlogPage): BlogPostMeta {

--- a/web/next/src/lib/content.ts
+++ b/web/next/src/lib/content.ts
@@ -70,9 +70,12 @@ export function contentSource<K extends ContentKind>(kind: K): ContentSource<K> 
     return source.getPageTree()
   }
 
-  // All three sources share the loader shape createRelativeLink resolves against, so the cast to the docs source/page is behavior-safe and spares callers a per-kind dispatch.
-  const relativeLink = (page: PageOf<K>): ReturnType<typeof createRelativeLink> =>
-    createRelativeLink(docsSource, page as PageOf<"docs">)
+  // Resolve relative markdown links against this kind's own source: each has its own baseUrl and file tree, so a blog or console page must not resolve against docs. kind pins the source, so the per-branch cast is safe.
+  const relativeLink = (page: PageOf<K>): ReturnType<typeof createRelativeLink> => {
+    if (kind === "blog") return createRelativeLink(blogSource, page as PageOf<"blog">)
+    if (kind === "console") return createRelativeLink(consoleSource, page as PageOf<"console">)
+    return createRelativeLink(docsSource, page as PageOf<"docs">)
+  }
 
   return { kind, baseUrl: entry.baseUrl, enabled, source, getPageOr404, pages, params, tree, relativeLink }
 }

--- a/web/next/src/lib/content.ts
+++ b/web/next/src/lib/content.ts
@@ -13,11 +13,11 @@ import { blogSource, consoleSource, docsSource } from "@/lib/source"
 
 export type ContentKind = "blog" | "console" | "docs"
 
-// The one place that knows each content kind's source, base URL, and the feature flag that gates it. baseUrl is `/console/docs` for the admin-gated internal docs, whose feature is `internalDocs`.
+// The one place that knows each content kind's source, base URL, the feature flag that gates it, and whether it has an /og route. baseUrl is `/console/docs` for the admin-gated internal docs (feature `internalDocs`), which has no OG route.
 const REGISTRY = {
-  blog: { source: blogSource, baseUrl: "/blog", feature: "blog" },
-  console: { source: consoleSource, baseUrl: "/console/docs", feature: "internalDocs" },
-  docs: { source: docsSource, baseUrl: "/docs", feature: "docs" },
+  blog: { source: blogSource, baseUrl: "/blog", feature: "blog", og: true },
+  console: { source: consoleSource, baseUrl: "/console/docs", feature: "internalDocs", og: false },
+  docs: { source: docsSource, baseUrl: "/docs", feature: "docs", og: true },
 } as const
 
 type Registry = typeof REGISTRY
@@ -30,6 +30,8 @@ export interface ContentSource<K extends ContentKind> {
   kind: K
   baseUrl: string
   enabled: boolean
+  // Whether this kind has an /og${baseUrl} route; false for console, so metadata omits the OG image rather than pointing at a route that does not exist.
+  og: boolean
   source: SourceOf<K>
   getPageOr404: (slug: string[] | undefined) => PageOf<K>
   pages: () => PageOf<K>[]
@@ -77,5 +79,5 @@ export function contentSource<K extends ContentKind>(kind: K): ContentSource<K> 
     return createRelativeLink(docsSource, page as PageOf<"docs">)
   }
 
-  return { kind, baseUrl: entry.baseUrl, enabled, source, getPageOr404, pages, params, tree, relativeLink }
+  return { kind, baseUrl: entry.baseUrl, enabled, og: entry.og, source, getPageOr404, pages, params, tree, relativeLink }
 }

--- a/web/next/src/lib/content.ts
+++ b/web/next/src/lib/content.ts
@@ -1,0 +1,78 @@
+import { features } from "@packages/config/site"
+import type { Root } from "fumadocs-core/page-tree"
+import { createRelativeLink } from "fumadocs-ui/mdx"
+import { notFound } from "next/navigation"
+
+import {
+  generatePublicBlogParams,
+  getPublicBlogPageTree,
+  getPublishedBlogPosts,
+  isPublicBlogPage,
+} from "@/lib/blog"
+import { blogSource, consoleSource, docsSource } from "@/lib/source"
+
+export type ContentKind = "blog" | "console" | "docs"
+
+// The one place that knows each content kind's source, base URL, and the feature flag that gates it. baseUrl is `/console/docs` for the admin-gated internal docs, whose feature is `internalDocs`.
+const REGISTRY = {
+  blog: { source: blogSource, baseUrl: "/blog", feature: "blog" },
+  console: { source: consoleSource, baseUrl: "/console/docs", feature: "internalDocs" },
+  docs: { source: docsSource, baseUrl: "/docs", feature: "docs" },
+} as const
+
+type Registry = typeof REGISTRY
+type SourceOf<K extends ContentKind> = Registry[K]["source"]
+export type PageOf<K extends ContentKind> = NonNullable<ReturnType<SourceOf<K>["getPage"]>>
+
+const EMPTY_TREE: Root = { name: "", children: [] }
+
+export interface ContentSource<K extends ContentKind> {
+  kind: K
+  baseUrl: string
+  enabled: boolean
+  source: SourceOf<K>
+  getPageOr404: (slug: string[] | undefined) => PageOf<K>
+  pages: () => PageOf<K>[]
+  params: () => { slug: string[] }[]
+  tree: () => Root
+  relativeLink: (page: PageOf<K>) => ReturnType<typeof createRelativeLink>
+}
+
+// A handle to one content kind. When the kind's feature is off, every accessor behaves as if the collection were empty: getPageOr404 404s, pages/params return [], and tree is empty, so routes, static params, sitemap, llms, and search all drop the surface with no per-caller checks. The blog handle also applies the publish gate (index plus published posts).
+export function contentSource<K extends ContentKind>(kind: K): ContentSource<K> {
+  const entry = REGISTRY[kind]
+  const source = entry.source
+  const enabled = features[entry.feature]
+  const isBlog = kind === "blog"
+
+  const getPageOr404 = (slug: string[] | undefined): PageOf<K> => {
+    if (!enabled) notFound()
+    const page = source.getPage(slug)
+    if (!page || (isBlog && !isPublicBlogPage(page as PageOf<"blog">))) notFound()
+    return page as PageOf<K>
+  }
+
+  const pages = (): PageOf<K>[] => {
+    if (!enabled) return []
+    if (isBlog) return getPublishedBlogPosts() as unknown as PageOf<K>[]
+    return source.getPages() as PageOf<K>[]
+  }
+
+  const params = (): { slug: string[] }[] => {
+    if (!enabled) return []
+    const raw = isBlog ? generatePublicBlogParams() : source.generateParams()
+    return raw.map((p) => ({ slug: p.slug ?? [] }))
+  }
+
+  const tree = (): Root => {
+    if (!enabled) return EMPTY_TREE
+    if (isBlog) return getPublicBlogPageTree()
+    return source.getPageTree()
+  }
+
+  // All three sources share the loader shape createRelativeLink resolves against, so the cast to the docs source/page is behavior-safe and spares callers a per-kind dispatch.
+  const relativeLink = (page: PageOf<K>): ReturnType<typeof createRelativeLink> =>
+    createRelativeLink(docsSource, page as PageOf<"docs">)
+
+  return { kind, baseUrl: entry.baseUrl, enabled, source, getPageOr404, pages, params, tree, relativeLink }
+}

--- a/web/next/src/lib/fumadocs.tsx
+++ b/web/next/src/lib/fumadocs.tsx
@@ -66,6 +66,7 @@ export async function generatePageMetadata<K extends ContentKind>(
   page: PageOf<K>,
 ): Promise<Metadata> {
   const pageUrl = `${config.app.url}${page.url}`
+  // page.url always starts with cs.baseUrl (the loader prefixes it), so slicing the base off yields the slug path. This assumes no frontmatter slug override makes page.url diverge from the route param slug; none exists in the starter.
   const slugPath = page.url.slice(cs.baseUrl.length).replace(/^\//, "")
   // Intentional cache-bust: the build/revalidation timestamp ties the OG URL to each deploy so social and CDN scrapers refetch the regenerated image instead of serving a stale one; not a bug.
   const imageUrl = `${config.app.url}/og${cs.baseUrl}${slugPath ? `/${slugPath}` : ""}?t=${Date.now()}`

--- a/web/next/src/lib/fumadocs.tsx
+++ b/web/next/src/lib/fumadocs.tsx
@@ -66,7 +66,7 @@ export async function generatePageMetadata<K extends ContentKind>(
   page: PageOf<K>,
 ): Promise<Metadata> {
   const pageUrl = `${config.app.url}${page.url}`
-  const slugPath = page.url.replace(cs.baseUrl, "").replace(/^\//, "")
+  const slugPath = page.url.slice(cs.baseUrl.length).replace(/^\//, "")
   // Intentional cache-bust: the build/revalidation timestamp ties the OG URL to each deploy so social and CDN scrapers refetch the regenerated image instead of serving a stale one; not a bug.
   const imageUrl = `${config.app.url}/og${cs.baseUrl}${slugPath ? `/${slugPath}` : ""}?t=${Date.now()}`
   const article = blogArticle(cs, page)

--- a/web/next/src/lib/fumadocs.tsx
+++ b/web/next/src/lib/fumadocs.tsx
@@ -68,8 +68,11 @@ export async function generatePageMetadata<K extends ContentKind>(
   const pageUrl = `${config.app.url}${page.url}`
   // page.url always starts with cs.baseUrl (the loader prefixes it), so slicing the base off yields the slug path. This assumes no frontmatter slug override makes page.url diverge from the route param slug; none exists in the starter.
   const slugPath = page.url.slice(cs.baseUrl.length).replace(/^\//, "")
+  // Only kinds with an /og route (docs, blog) get an OG image; console has none, so omit it rather than link a nonexistent /og/console/docs.
   // Intentional cache-bust: the build/revalidation timestamp ties the OG URL to each deploy so social and CDN scrapers refetch the regenerated image instead of serving a stale one; not a bug.
-  const imageUrl = `${config.app.url}/og${cs.baseUrl}${slugPath ? `/${slugPath}` : ""}?t=${Date.now()}`
+  const imageUrl = cs.og
+    ? `${config.app.url}/og${cs.baseUrl}${slugPath ? `/${slugPath}` : ""}?t=${Date.now()}`
+    : undefined
   const article = blogArticle(cs, page)
   const publishedTime = article?.data.publishedAt
     ? toBlogDate(article.data.publishedAt).toISOString()
@@ -77,7 +80,9 @@ export async function generatePageMetadata<K extends ContentKind>(
   const modifiedTime = article?.data.publishedAt
     ? toBlogDate(article.data.updatedAt ?? article.data.publishedAt).toISOString()
     : undefined
-  const image = { url: imageUrl, width: 1200, height: 630, alt: page.data.title }
+  const images = imageUrl
+    ? [{ url: imageUrl, width: 1200, height: 630, alt: page.data.title }]
+    : undefined
   const openGraph = article
     ? {
         type: "article" as const,
@@ -85,7 +90,7 @@ export async function generatePageMetadata<K extends ContentKind>(
         description: page.data.description,
         siteName: site.name,
         url: pageUrl,
-        images: [image],
+        images,
         publishedTime,
         modifiedTime,
         authors: article.data.author ? [article.data.author] : undefined,
@@ -97,7 +102,7 @@ export async function generatePageMetadata<K extends ContentKind>(
         description: page.data.description,
         siteName: site.name,
         url: pageUrl,
-        images: [image],
+        images,
       }
 
   return {
@@ -109,7 +114,7 @@ export async function generatePageMetadata<K extends ContentKind>(
     },
     twitter: {
       card: "summary_large_image",
-      images: [imageUrl],
+      images: imageUrl ? [imageUrl] : undefined,
     },
   }
 }

--- a/web/next/src/lib/fumadocs.tsx
+++ b/web/next/src/lib/fumadocs.tsx
@@ -1,14 +1,12 @@
 import { site } from "@packages/config/site"
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/layouts/docs/page"
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared"
-import { createRelativeLink } from "fumadocs-ui/mdx"
 import type { Metadata } from "next"
-import { notFound } from "next/navigation"
 
 import { CopyAsMarkdown } from "@/components/docs/copy-as-markdown"
 import { formatBlogDate, toBlogDate } from "@/lib/blog-policy"
 import { config } from "@/lib/config"
-import { blogSource, consoleSource, docsSource } from "@/lib/source"
+import type { ContentKind, ContentSource, PageOf } from "@/lib/content"
 import { getMDXComponents } from "@/mdx-components"
 
 export function baseOptions(): BaseLayoutProps {
@@ -19,57 +17,18 @@ export function baseOptions(): BaseLayoutProps {
   }
 }
 
-type Source = typeof blogSource | typeof docsSource | typeof consoleSource
-type Page<S extends Source> = Parameters<S["resolveHref"]>[1]
-
-interface PageData<S extends Source> {
-  page: Page<S>
-  source: S
+// A blog article is any published post, i.e. a blog page that is not the /blog index.
+function blogArticle<K extends ContentKind>(cs: ContentSource<K>, page: PageOf<K>) {
+  if (cs.kind !== "blog" || page.url === "/blog") return null
+  return page as PageOf<"blog">
 }
 
-type AnyPageData =
-  | PageData<typeof docsSource>
-  | PageData<typeof blogSource>
-  | PageData<typeof consoleSource>
-
-export async function getPageData<S extends Source>(
-  params: Promise<{ slug?: string[] }>,
-  source: S,
-): Promise<PageData<S>> {
-  const resolvedParams = await params
-  const page = source.getPage(resolvedParams.slug)
-  if (!page) notFound()
-  return { page: page as Page<S>, source }
-}
-
-function createPageRelativeLink(data: AnyPageData): ReturnType<typeof createRelativeLink> {
-  if (data.source === blogSource) {
-    return createRelativeLink(blogSource, data.page as Page<typeof blogSource>)
-  }
-  if (data.source === consoleSource) {
-    return createRelativeLink(consoleSource, data.page as Page<typeof consoleSource>)
-  }
-  return createRelativeLink(docsSource, data.page as Page<typeof docsSource>)
-}
-
-function getBlogArticleDates(data: AnyPageData) {
-  if (data.source !== blogSource || data.page.url === "/blog") return null
-
-  const page = data.page as Page<typeof blogSource>
-  if (!page.data.publishedAt) return null
-
-  return {
-    publishedAt: page.data.publishedAt,
-    updatedAt: page.data.updatedAt,
-  }
-}
-
-export function renderPageContent(data: AnyPageData) {
-  const { page } = data
+export function renderPageContent<K extends ContentKind>(cs: ContentSource<K>, page: PageOf<K>) {
   const MDX = page.data.body
-  const isDocsPage = page.url.startsWith("/docs")
-  const isBlogMainPage = page.url === "/blog"
-  const blogArticleDates = getBlogArticleDates(data)
+  const isDocsPage = cs.kind === "docs"
+  const isBlogMainPage = cs.kind === "blog" && page.url === "/blog"
+  const article = blogArticle(cs, page)
+  const publishedAt = article?.data.publishedAt
 
   return (
     <DocsPage
@@ -84,97 +43,61 @@ export function renderPageContent(data: AnyPageData) {
       <DocsBody>
         <MDX
           components={getMDXComponents({
-            a: createPageRelativeLink(data),
+            a: cs.relativeLink(page),
           })}
         />
       </DocsBody>
-      {blogArticleDates && (
+      {article && publishedAt && (
         <div className="not-prose text-muted-foreground mt-4 flex flex-wrap justify-end gap-x-3 gap-y-1 text-right text-sm">
-          <time dateTime={blogArticleDates.publishedAt}>
-            Published {formatBlogDate(blogArticleDates.publishedAt)}
-          </time>
-          {blogArticleDates.updatedAt &&
-            blogArticleDates.updatedAt !== blogArticleDates.publishedAt && (
-              <time dateTime={blogArticleDates.updatedAt}>
-                Updated {formatBlogDate(blogArticleDates.updatedAt)}
-              </time>
-            )}
+          <time dateTime={publishedAt}>Published {formatBlogDate(publishedAt)}</time>
+          {article.data.updatedAt && article.data.updatedAt !== publishedAt && (
+            <time dateTime={article.data.updatedAt}>
+              Updated {formatBlogDate(article.data.updatedAt)}
+            </time>
+          )}
         </div>
       )}
     </DocsPage>
   )
 }
 
-export function createGenerateStaticParams(source: Source) {
-  return async function generateStaticParams() {
-    return source.generateParams()
-  }
-}
-
-interface GenerateMetadataOptions {
-  source: Source
-  ogPath: string
-  ogType: "article" | "website"
-}
-
-export async function generatePageMetadata(
-  params: Promise<{ slug?: string[] }>,
-  options: GenerateMetadataOptions,
+export async function generatePageMetadata<K extends ContentKind>(
+  cs: ContentSource<K>,
+  page: PageOf<K>,
 ): Promise<Metadata> {
-  const resolvedParams = await params
-  const { source, ogPath, ogType } = options
-  const page = source.getPage(resolvedParams.slug)
-  if (!page) notFound()
-
   const pageUrl = `${config.app.url}${page.url}`
-  const slugPath =
-    resolvedParams.slug && resolvedParams.slug.length > 0 ? resolvedParams.slug.join("/") : ""
+  const slugPath = page.url.replace(cs.baseUrl, "").replace(/^\//, "")
   // Intentional cache-bust: the build/revalidation timestamp ties the OG URL to each deploy so social and CDN scrapers refetch the regenerated image instead of serving a stale one; not a bug.
-  const imageUrl = `${config.app.url}${ogPath}${slugPath ? `/${slugPath}` : ""}?t=${Date.now()}`
-  const blogArticle =
-    options.source === blogSource && page.url !== "/blog" ? (page as Page<typeof blogSource>) : null
-  const publishedTime = blogArticle?.data.publishedAt
-    ? toBlogDate(blogArticle.data.publishedAt).toISOString()
+  const imageUrl = `${config.app.url}/og${cs.baseUrl}${slugPath ? `/${slugPath}` : ""}?t=${Date.now()}`
+  const article = blogArticle(cs, page)
+  const publishedTime = article?.data.publishedAt
+    ? toBlogDate(article.data.publishedAt).toISOString()
     : undefined
-  const modifiedTime = blogArticle?.data.publishedAt
-    ? toBlogDate(blogArticle.data.updatedAt ?? blogArticle.data.publishedAt).toISOString()
+  const modifiedTime = article?.data.publishedAt
+    ? toBlogDate(article.data.updatedAt ?? article.data.publishedAt).toISOString()
     : undefined
-  const openGraph =
-    ogType === "article"
-      ? {
-          type: "article" as const,
-          title: page.data.title,
-          description: page.data.description,
-          siteName: site.name,
-          url: pageUrl,
-          images: [
-            {
-              url: imageUrl,
-              width: 1200,
-              height: 630,
-              alt: page.data.title,
-            },
-          ],
-          publishedTime,
-          modifiedTime,
-          authors: blogArticle?.data.author ? [blogArticle.data.author] : undefined,
-          tags: blogArticle?.data.tags,
-        }
-      : {
-          type: "website" as const,
-          title: page.data.title,
-          description: page.data.description,
-          siteName: site.name,
-          url: pageUrl,
-          images: [
-            {
-              url: imageUrl,
-              width: 1200,
-              height: 630,
-              alt: page.data.title,
-            },
-          ],
-        }
+  const image = { url: imageUrl, width: 1200, height: 630, alt: page.data.title }
+  const openGraph = article
+    ? {
+        type: "article" as const,
+        title: page.data.title,
+        description: page.data.description,
+        siteName: site.name,
+        url: pageUrl,
+        images: [image],
+        publishedTime,
+        modifiedTime,
+        authors: article.data.author ? [article.data.author] : undefined,
+        tags: article.data.tags,
+      }
+    : {
+        type: "website" as const,
+        title: page.data.title,
+        description: page.data.description,
+        siteName: site.name,
+        url: pageUrl,
+        images: [image],
+      }
 
   return {
     title: page.data.title,

--- a/web/next/src/lib/og-image.tsx
+++ b/web/next/src/lib/og-image.tsx
@@ -1,23 +1,11 @@
 import { site } from "@packages/config/site"
-import { notFound } from "next/navigation"
 import type { ReactElement } from "react"
 import { render } from "takumi-js"
-
-import type { blogSource, docsSource } from "@/lib/source"
-
-type Source = typeof blogSource | typeof docsSource
 
 interface RenderOgImageOptions {
   sectionName?: string
   title: string
   description: string
-}
-
-interface OgImageOptions {
-  source: Source
-  sectionName: string
-  defaultTitle: string
-  defaultDescription: string
 }
 
 export async function renderOgElement(element: ReactElement): Promise<Response> {
@@ -100,20 +88,4 @@ export async function renderOgImage(options: RenderOgImageOptions): Promise<Resp
   )
 
   return renderOgElement(element)
-}
-
-export async function generateOgImage(
-  slug: string[] | undefined,
-  options: OgImageOptions,
-): Promise<Response> {
-  const { source, sectionName, defaultTitle, defaultDescription } = options
-
-  const page = source.getPage(slug)
-  if (!page) notFound()
-
-  return renderOgImage({
-    sectionName,
-    title: page.data.title || defaultTitle,
-    description: page.data.description || defaultDescription,
-  })
 }


### PR DESCRIPTION
## Summary

Makes each optional surface a **feature flag** a fork toggles from one config, and lands the `contentSource` seam that makes the gating clean. Two changes that reinforce each other: the seam collapses the duplicated content-access code, and the flags ride its single `enabled` gate.

Five flags live in a new `features` export in `@packages/config/site`, typed `boolean` (not `as const`) so the runtime gates stay live and a fork can flip any of them. **"Off" is a real 404 plus removal from nav, sitemap, `llms.txt`, and search — not a stub.** Nothing is stripped at scaffold time, so re-enabling is a one-line config edit.

| Flag | Surface | Off means |
| --- | --- | --- |
| `apiDocs` | `/api/docs` Scalar UI + `/api/openapi.json` spec | both 404, navbar "API Docs" link hidden |
| `blog` | `/blog` + posts | `/blog` 404s; nav link, `/og/blog`, sitemap, and `llms.txt` blog entries drop |
| `docs` | `/docs` | `/docs` 404s; nav link, `/og/docs`, search, sitemap, and `llms.txt` docs entries drop |
| `internalDocs` | `/console/docs` (admin-gated) | `/console/docs` + its search 404; dashboard/console shell links hidden |
| `waitlist` | `/waitlist` page + API | `/waitlist` and `/api/waitlist` 404; a fresh fork's home becomes a plain landing |

## How it works

- **The seam** — new `web/next/src/lib/content.ts` exposes one `contentSource(kind)` owning each collection's source, base URL, publish policy, `/og`-route fact, and feature gate. When a kind is off, `getPageOr404` 404s and `pages`/`params`/`tree` return empty, so routes, static params, sitemap, llms, OG, and search all drop the surface with no per-caller checks. This collapses the six duplicated `getPage`-or-404 sites, the `source === blogSource` identity checks, the `slug[0]` sniffing, and the `Source`/`AnyPageData` unions in `fumadocs.tsx`/`og-image.tsx` (closes the *content-source-consolidation* plan).
- **API** — `/api/docs` and the waitlist router gate behind a runtime 404 guard and **stay mounted**, so `AppType` never shifts when a fork flips a flag (the OpenAPI doc consequently still lists gated routes, documented in `features.mdx`).
- **CLI** — `zerostarter init` writes the chosen `features` into the fork config from `--<flag>`/`--no-<flag>` flags (`--no-` wins) or an interactive multiselect pre-checked to the fork defaults (docs, blog, internal docs, API reference on; **waitlist off**). The generated home branches on `features.waitlist` at runtime (capture page or plain landing).
- **Enable-anytime** — every surface stays in the tree behind a runtime read of `features`; init only writes the flags. Even a disabled feature keeps its content (a `blog: false` fork still ships `content/blog/`), so flipping it on needs no re-scaffold.

## Commits

**Feature (5):** `feat(config)` flags → `feat(web)` gate via the seam → `feat(api)` gate reference + waitlist → `feat(cli)` choose at init → `docs` document the system.

**Review hardening (9):** per-kind relative-link dispatch · gate the retained dashboard/console shell links · multiselect + `--no-` precedence tests · follow-up plan notes · `seo.mdx` OG example → seam · omit OG image for kinds with no `/og` route · assert waitlist absent (not prefix) · console-docs sitemap/llms accuracy · hoist `contentSource` handles.

49 files, +789/−365 — most of it mechanical call-site migration to the seam.

## Verification

- ✅ CI green (Audit/Lint/Build, GitGuardian, CodeRabbit) + both **Vercel previews deployed**
- ✅ `check-types`, `oxlint`, docs `--strict`, **106 CLI tests** (flag resolution, generated `features` block, branching home stub, non-interactive multiselect, and a config↔CLI drift guard that fails if a flag is added to one place but not the others)
- ✅ Web gating verified **in-browser** (public nav) and via **authenticated SSR** (dashboard + console shells: "Documentation" absent when its flag is off, present when on)
- ✅ API gating (`/api/docs`, `/api/waitlist` → 404 when off, with the `{ error: NOT_FOUND }` envelope)
- ✅ Full **`npx zerostarter@0.0.0-9ed3044 init`** scaffold: flags, dry-run, real fork generation (`features` block matches flags, branching home stub, blog content retained while `blog: false`), fork type-checks clean
- ✅ **OG render path** (`renderOgImage`) confirmed byte-identical on local + Vercel preview (`/og/docs` 46006 B, `/og/blog` 27038 B), so per-function tracing still bundles the takumi binary

### Full route matrix — every impacted path, all flags on vs off

Live-curled 34 routes with all five flags **on**, then all **off** (admin session for the console/dashboard/console-search paths), plus content assertions. Every row behaved as expected; **0 regressions**.

| Route class | All on | All off |
| --- | --- | --- |
| Gated content — `/docs`, `/blog`, `.md` aliases, `/og/docs`, `/og/blog` | `200` | **`404`** |
| `/waitlist` · `GET`+`POST /api/waitlist` | `200` | **`404`** (`NOT_FOUND` envelope) |
| `/api/docs` · `/api/openapi.json` | `200` | **`404`** (gated together) |
| `/api/search` · `/api/console/search` | `200` | **`404`** |
| `/llms.txt/docs` · `/llms.txt/blog` | `200` | **`404`** |
| `/sitemap.xml` | home + docs + blog | **only `/`** |
| `/llms.txt` · `/llms-full.txt` | full | **header only · 0 pages** |
| navbar · `/dashboard` footer | all links | **only Hire · Docs link gone** |
| `/console/docs` | docs | not-found UI (soft-404, no leak\*) |
| Ungated controls — `/`, `/hire`, `/robots.txt`, `/api/health`, `/og/home`, generic `/og` | `200` | **`200`** |

Content assertions (all-off) confirmed nothing stale leaks: sitemap holds only `/`, `llms.txt` is header-only, `llms-full.txt` has 0 page entries, `/console/docs` renders the not-found page with no doc-body leak, the dashboard "Documentation" link is gone, and the navbar shows only Hire.

\*`/console/docs` off returns the not-found UI with HTTP 200 (the `force-dynamic` console soft-404), documented in `features.mdx` and `console-notfound-status.md`. Pre-existing, admin-only, `noindex`, no content leak; every other disabled surface is a real 404.

### Before / after (feature enabled vs disabled)

| Surface | Enabled | Disabled |
| --- | --- | --- |
| Navbar | [on](https://litter.catbox.moe/60jcje.png) | [off](https://litter.catbox.moe/tb4lce.png) |
| `/docs` | [on](https://litter.catbox.moe/q9c7jt.png) | [off](https://litter.catbox.moe/lc5m9k.png) |
| `/blog` | [on](https://litter.catbox.moe/1ku8tx.png) | [off](https://litter.catbox.moe/lyw0gc.png) |
| `/waitlist` | [on](https://litter.catbox.moe/gkm92g.png) | [off](https://litter.catbox.moe/4f7pjb.png) |
| `/api/docs` | [on](https://litter.catbox.moe/lzfjpv.png) | [off](https://litter.catbox.moe/0mp5om.png) |
| `/sitemap.xml` | [on](https://litter.catbox.moe/xth03g.png) | [off](https://litter.catbox.moe/kj7nwo.png) |
| `/llms.txt` | [on](https://litter.catbox.moe/1uojzl.png) | [off](https://litter.catbox.moe/cskw6x.png) |
| `/llms-full.txt` | [on](https://litter.catbox.moe/mklwsm.png) | [off](https://litter.catbox.moe/14kwr3.png) |

OG renders (path moved to `renderOgImage`): [/og/docs](https://litter.catbox.moe/gxka4b.png) · [/og/blog](https://litter.catbox.moe/6fg1sn.png)

## Review findings addressed

Across several review passes (see the [post-review comment](https://github.com/nrjdalal/zerostarter/pull/691#issuecomment-4952067381)) + CodeRabbit:

- **Relative links** resolved against `docsSource` for all kinds → restored per-kind dispatch (blog/console have their own base URL + tree).
- **Ungated shell links** — the retained dashboard + console shells still linked `/docs` and `/console/docs`; now gated on `features.docs` / `features.internalDocs`.
- **OG URL for a kind with no `/og` route** (console) → `og` is now a registry fact; metadata omits the image.
- **Test weakness** — the "waitlist off" assertions were prefix matches; now assert waitlist is absent.
- **Doc drift** — `seo.mdx` documented the removed `generateOgImage` (fixed to the seam pattern); `content.mdx` wrongly implied console docs are in sitemap/llms (corrected).
- **OpenAPI spec left public** — `apiDocs: false` hid `/api/docs` but not `/api/openapi.json`; now both gate on `apiDocs` via one shared middleware (verified 404 off / 200 on).
- **Flag-set drift risk** — a feature key lives in four places (config `features`, CLI `DEFAULT_FEATURES` + `FEATURE_DEFS`, the generated block); added a test that reads the config source and fails if they diverge.
- **`internalDocs` doc accuracy** — the table implied a hard 404, but its `/console/docs` is the one soft-404; corrected the row and added a callout.
- **Duplicated 404 guard** — the feature-gate middleware was copied in `index.ts` and the waitlist router; extracted one shared `requireFeature(flag)` in `@/middlewares`.
- **Consistency** — hoisted inline `contentSource()` handles to module scope; added tests + comments where reviewers asked.

**Deliberately left (documented):** the OpenAPI document still lists routes gated by the *other* flags (a waitlist-off, apiDocs-on fork lists `/api/waitlist`, which 404s at call) — the AppType-stability tradeoff; `og/blog` uses `notFound()` for a missing post (pre-existing, returns 404).

## Follow-ups tracked

Filed in `.github/notes/plans/`, not blocking:
- **Unit-test the `contentSource` seam** — the load-bearing web gate; needs a web test harness first.
- **Console soft-404** — `notFound()` under the `force-dynamic` `(console)` area returns HTTP 200 with the not-found UI. Pre-existing (a genuinely missing slug does this with every flag on), admin-only, `noindex`, no content leak.
- **`BlogPostMeta` from the zod schema** — the content-source-consolidation plan named an on-the-way cleanup (derive the type from `blogSchema`, drop `toBlogPostMeta`) that this PR did not do. Tracked rather than closed silently: it's a decouple-vs-derive tradeoff (`blog-policy.ts` is pure of fumadocs today), not a mechanical rename.

## Out of scope

Auth, dashboard, the console shell, and organizations are **not** flagged (they reach into the DB, login, and route protection). The waitlist DB table is retained when the flag is off (dropping it would be a migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
