### PR TITLE
test(cli): tolerate read-only isTTY in the multiselect test on CI

### DIFF
--- a/packages/cli/test/prompt.test.ts
+++ b/packages/cli/test/prompt.test.ts
@@ -4,19 +4,26 @@ import { promptMultiselect } from "../bin/commands/_prompt"
 
 type Tty = { isTTY?: boolean }
 
-// Force the non-interactive branch so the test never blocks on raw-mode stdin, even when `bun test` runs in a real terminal.
+// Force the non-interactive branch so the test never blocks on raw-mode stdin when bun test runs in a real terminal. Best-effort: piped streams (CI) already report isTTY false but expose it read-only, so swallow that assignment and rely on the already-non-interactive streams there.
+const setTty = (out: boolean | undefined, inp: boolean | undefined): void => {
+  try {
+    ;(process.stdout as Tty).isTTY = out
+    ;(process.stdin as Tty).isTTY = inp
+  } catch {
+    // isTTY is read-only on piped streams (CI); they are already non-interactive, so no override is needed there.
+  }
+}
+
 describe("promptMultiselect (non-interactive)", () => {
   let stdout: boolean | undefined
   let stdin: boolean | undefined
   beforeEach(() => {
     stdout = process.stdout.isTTY
     stdin = process.stdin.isTTY
-    ;(process.stdout as Tty).isTTY = false
-    ;(process.stdin as Tty).isTTY = false
+    setTty(false, false)
   })
   afterEach(() => {
-    ;(process.stdout as Tty).isTTY = stdout
-    ;(process.stdin as Tty).isTTY = stdin
+    setTty(stdout, stdin)
   })
 
   test("echoes and returns the pre-checked defaults", async () => {


### PR DESCRIPTION
The `promptMultiselect` non-interactive test (added in #691) overrode `process.stdout/stdin.isTTY`, which throws `Attempted to assign to readonly property` on CI where the streams are piped — breaking the Release Package test matrix on canary and skipping the release job.

Make the override best-effort (`try/catch`): CI's piped streams already report `isTTY` false, so the non-interactive branch runs regardless. Verified by simulating read-only `isTTY` locally (assignment throws → caught → returns `[apiDocs, docs]` and `[]`, no hang) and the full suite (107 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)