### PR TITLE
refactor(ci): run check-types and tests in the PR workflow

### DIFF
--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -9,6 +9,7 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 ## In progress
 
 - [TanStack Start migration](tanstack-start-migration.md) - complete and verified locally, blocked on the Vercel Bun-runtime deploy (#650).
+- [Hardening refactors from the external evaluation](hardening-refactors.md) - gate the agent sign-in behind an explicit secret, read the auth secret directly, and gate tests + check-types in PR CI.
 
 ## Planned
 

--- a/.github/notes/plans/hardening-refactors.md
+++ b/.github/notes/plans/hardening-refactors.md
@@ -1,0 +1,22 @@
+# Hardening refactors from the external evaluation
+
+- Status: in progress
+- Links: external SaaS-starter evaluation (nrjdalal/saas-starter-evals), `ZEROSTARTER-RECOMMENDATIONS.md` §4
+
+A set of small, self-contained refactors surfaced by an external, evidence-based evaluation of the repo (at v0.1.2). Each is its own PR into canary, verified end to end. Preserve the evaluation's noted strengths: the agent-DX login is a differentiator (tighten the gate, keep the route); one canonical way; docs in sync.
+
+## Gate check-types and tests in PR CI [done first]
+
+The PR gate (`auto-check-build.yml`) ran `audit + lint + build` only, so a type error the build tolerates or a failing test surfaced only in the release workflow after merge. Add a turbo `test` task + a root `test` script, run `check-types` + `test` in the PR gate, and make `web/next` `check-types` self-sufficient (generate the docs `meta.json` like `dev`/`build` do) so a fresh checkout type-checks.
+
+## Read the auth secret directly and fail closed when required
+
+`packages/env/src/auth.ts` substituted a placeholder for a missing `BETTER_AUTH_SECRET` under `SKIP_ENV_VALIDATION`. A security secret should never resolve to a constant. Add a `serverSecret()` helper: under the skip flag the schema is optional (a tooling build passes with `undefined`), otherwise it stays required, failing closed at runtime. Read the raw `process.env` value.
+
+## Gate the agent sign-in route behind an explicit secret
+
+`api/hono/src/routers/agents.ts` `/api/agents/sign-in-as` (the local-only agent login) was gated on `NODE_ENV=local`, which is the `.env.example` default, so it could stay reachable in a default self-host. Add an `AGENT_AUTH_SECRET` (unset by default) and mount the route only when it is set, so agent login is opted into deliberately in dev and a default env never exposes it. Thread it through `packages/env`, `.env.example`, `AGENTS.md`, and the `dev`/docs. The deferred route test lands with the product-test harness below.
+
+## Larger, tracked separately
+
+Default security headers/CSP + a durable rate-limit store, and a full product-test harness (Playwright e2e + example org-scoped tests, where the deferred route/env tests land), are larger; scope them after these.

--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -27,10 +27,12 @@ jobs:
       - name: Install dependencies
         run: bun install --ignore-scripts
 
-      - name: Audit, Lint, and Build
+      - name: Audit, Lint, Check-types, Test, and Build
         run: |
           bun audit --audit-level high
           bun run lint
+          bun run check-types
+          bun run test
           bun run build
         env:
           NODE_ENV: production

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ That is the whole setup. When Docker is running, `init` provisions a local Postg
 | `bun dev`                         | Start the api and web dev servers           |
 | `bun run build`                   | Build every workspace                       |
 | `bun run check-types`             | Type-check every workspace                  |
+| `bun run test`                    | Run every workspace's tests                 |
 | `bun run lint` / `bun run format` | Lint with Oxlint / format with Oxfmt        |
 | `bun run db:generate`             | Generate Drizzle migrations from the schema |
 | `bun run db:migrate`              | Apply pending migrations                    |

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint": "oxlint",
     "prepare": "bunx lefthook install",
     "shadcn:update": "bash .github/scripts/shadcn-update.sh && bun i",
-    "start": "turbo run start"
+    "start": "turbo run start",
+    "test": "turbo run test"
   },
   "devDependencies": {
     "@commitlint/cli": "catalog:",

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,9 @@
     "start": {
       "persistent": true,
       "cache": false
+    },
+    "test": {
+      "dependsOn": ["^build"]
     }
   },
   "globalEnv": [

--- a/web/next/content/docs/getting-started/scripts.mdx
+++ b/web/next/content/docs/getting-started/scripts.mdx
@@ -32,6 +32,7 @@ Each of these builds `@packages/env` first, then runs Drizzle Kit against `packa
 - `bun run format`: Oxfmt, writing fixes.
 - `bun run format:check`: Oxfmt, report only.
 - `bun run check-types`: type-check every workspace, then the repo scripts (`check-types:scripts`, `tsgo` over `.github/scripts`).
+- `bun run test`: run every workspace's tests through Turbo (the `packages/cli` suite today). PR CI runs this and `check-types` too, so a failing test or type error blocks the merge.
 
 ## Release / production
 

--- a/web/next/content/docs/manage/code-quality.mdx
+++ b/web/next/content/docs/manage/code-quality.mdx
@@ -74,6 +74,8 @@ pre-push:
 
 **pre-push**: `bun audit --audit-level high` runs, but only from `canary` (`only: ref: canary`), so a vulnerable dependency is caught before the branch leaves your machine without blocking your offline commits. `ensure-remote-branches.ts` seeds the release branches (default `main`) that drive the release PR (see [Releases](/docs/manage/release)).
 
+**On a pull request**, the `auto-check-build` workflow re-runs the full gate on GitHub: `bun audit`, `bun run lint`, `bun run check-types`, `bun run test`, and `bun run build`. A failing type error or test blocks the merge, so the checks that are cheap to skip locally (the pre-commit build tolerates type errors that `tsc` would reject) still cannot reach `canary`.
+
 <Callout type="warn" title="The local build sees your real .env">
 
 Unlike CI (which sets `SKIP_ENV_VALIDATION=true`), the pre-commit build validates your actual `.env`. A missing or invalid required variable fails the commit locally even though the same build passes in CI.

--- a/web/next/package.json
+++ b/web/next/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "bun ../../.github/scripts/compress-images.ts && bun ../../.github/scripts/docs.ts --strict && fumadocs-mdx && next build",
-    "check-types": "fumadocs-mdx && tsc --noEmit",
+    "check-types": "bun ../../.github/scripts/docs.ts && fumadocs-mdx && tsc --noEmit",
     "dev": "bun ../../.github/scripts/docs.ts && next dev",
     "start": "bun .next/standalone/web/next/server.js"
   },


### PR DESCRIPTION
Expand the PR gate (`auto-check-build`) to cover `check-types` and tests, not just `audit + lint + build`, so type errors and test failures surface in review rather than after merge. One of the [hardening refactors](https://github.com/nrjdalal/zerostarter/blob/canary/.github/notes/plans/hardening-refactors.md) from the external [evaluation](https://github.com/nrjdalal/saas-starter-evals).

## Change
- Add a turbo `test` task and a root `test` script (`turbo run test`).
- Run `bun run check-types` and `bun run test` in `auto-check-build` (same `NODE_ENV=production SKIP_ENV_VALIDATION=true` step, since `check-types` builds deps).
- Make `web/next` `check-types` self-sufficient: generate the docs `meta.json` first (as `dev`/`build` already do), so a fresh checkout type-checks without a prior build.

The job name (`Audit, Lint, and Build`, the required-check name) is unchanged so branch protection keeps matching; only the step name + commands changed.

## Verified
`bun run check-types` (regenerates `meta.json` from a clean tree) and `bun run test` (107 tests) both pass under the CI env; docs `--strict` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated test execution to the project’s validation workflow.
  * Added a standard test command and test-task pipeline.

* **Bug Fixes**
  * Pull request checks now include type checking and tests alongside auditing, linting, and builds.
  * Improved type-check preparation for documentation content.

* **Documentation**
  * Updated quality documentation to describe the complete pull request validation process.
  * Documented planned authentication hardening and related safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->