### PR TITLE
refactor(api): gate the agent sign-in route behind AGENT_AUTH_SECRET

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -39,11 +39,12 @@ Restart the same way after changing `@packages/*` exports the API consumes; they
 
 ## Agent login
 
-Sign in as `LocalAgent` (local only, trusted Origin required):
+Sign in as `LocalAgent` (local only, trusted Origin required). The route is gated on `AGENT_AUTH_SECRET`: set it to any high-entropy value in `.env` first, or the route 404s. It is unset by default, so a fresh clone and any deploy expose no admin-minting route.
 
 ```bash
+grep -q '^AGENT_AUTH_SECRET=.\+' .env || echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # once, to enable
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```
 
-In the browser: click **Login** in the top navbar (hidden on `/console` and `/dashboard`), then **Login (agents)** in the dialog (development only).
+In the browser: click **Login** in the top navbar (hidden on `/console` and `/dashboard`), then **Login (agents)** in the dialog (development only, with `AGENT_AUTH_SECRET` set).

--- a/.agents/skills/ui-verify/SKILL.md
+++ b/.agents/skills/ui-verify/SKILL.md
@@ -22,7 +22,7 @@ agent-browser open http://localhost:3000/<route>
 agent-browser snapshot   # read the page, then click/type/verify
 ```
 
-Behind auth: sign in first with the **Login (agents)** button, or the local sign-in (`dev` skill). For an end-to-end change, or whenever asked, drive the whole flow, not just the screen you touched. Done when you have observed the change render and behave, not merely that the route loaded.
+Behind auth: sign in first with the **Login (agents)** button (shown once `AGENT_AUTH_SECRET` is set) or the local sign-in (`dev` skill). For an end-to-end change, or whenever asked, drive the whole flow, not just the screen you touched. Done when you have observed the change render and behave, not merely that the route loaded.
 
 ### 3. Check it holds up
 

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ HONO_RATE_LIMIT_WINDOW_MS=60000 # 1 minute (default)
 # Generate using `openssl rand -base64 32`
 BETTER_AUTH_SECRET=
 
+# Optional (local dev only): set to any high-entropy value to enable the agent sign-in route (`/api/agents/sign-in-as`), which mints an admin session for AI-agent testing. Leave blank everywhere else, including production; the route stays unmounted without it.
+AGENT_AUTH_SECRET=
+
 # Optional: GitHub OAuth (`https://github.com/settings/developers`). Leave blank to hide the button.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/.github/notes/plans/hardening-refactors.md
+++ b/.github/notes/plans/hardening-refactors.md
@@ -17,6 +17,8 @@ The PR gate (`auto-check-build.yml`) ran `audit + lint + build` only, so a type 
 
 `api/hono/src/routers/agents.ts` `/api/agents/sign-in-as` (the local-only agent login) was gated on `NODE_ENV=local`, which is the `.env.example` default, so it could stay reachable in a default self-host. Add an `AGENT_AUTH_SECRET` (unset by default) and mount the route only when it is set, so agent login is opted into deliberately in dev and a default env never exposes it. Thread it through `packages/env`, `.env.example`, `AGENTS.md`, and the `dev`/docs. The deferred route test lands with the product-test harness below.
 
+To keep the agent-DX differentiator intact, `packages/cli` `seedEnv` also seeds a generated `AGENT_AUTH_SECRET` into the scaffolded project's `.env` alongside `BETTER_AUTH_SECRET`, so `bunx zerostarter init` yields working agent login out of the box. This only touches the gitignored `.env`, never the committed `.env.example`, so clone/deploy defaults stay blank and the `isLocal(NODE_ENV)` gate keeps a seeded secret inert on a real deploy.
+
 ## Larger, tracked separately
 
 Default security headers/CSP + a durable rate-limit store, and a full product-test harness (Playwright e2e + example org-scoped tests, where the deferred route/env tests land), are larger; scope them after these.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,14 +33,14 @@ Guidance for AI coding agents working in this repository, a Bun monorepo: the `p
 
 ## Logging in (agents)
 
-Signs in as `LocalAgent` (`agent@local.host`). Click **Login (agents)** in the dev UI, or use curl:
+Signs in as `LocalAgent` (`agent@local.host`). The route is gated: set `AGENT_AUTH_SECRET` to any high-entropy value in `.env` first (it is unset by default, so the route 404s without it and a deployed default env never exposes it). Then click **Login (agents)** in the dev UI, or use curl:
 
 ```bash
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```
 
-Local-only and requires a trusted `Origin` header. See `api/hono/src/routers/agents.ts` if needed.
+Local-only (needs `NODE_ENV=local` and a set `AGENT_AUTH_SECRET`) and requires a trusted `Origin` header. See `api/hono/src/routers/agents.ts` if needed.
 
 ## Skills
 

--- a/api/hono/src/lib/agent-auth.ts
+++ b/api/hono/src/lib/agent-auth.ts
@@ -1,0 +1,6 @@
+import { isLocal } from "@packages/env"
+import { env } from "@packages/env/api-hono"
+
+// The local-only agent sign-in is enabled only when a fork deliberately sets AGENT_AUTH_SECRET in a local dev env: a default clone leaves it unset, so no admin-minting route mounts even though NODE_ENV ships as local, and a production env never qualifies. The agents router gates its route on this and the auth router advertises "agent" in /providers on the same value, so the UI button never drifts from the route it posts to.
+export const agentSignInEnabled = (): boolean =>
+  isLocal(env.NODE_ENV) && Boolean(env.AGENT_AUTH_SECRET)

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -14,7 +14,10 @@ const AGENT_EMAIL = site.agent.email
 const AGENT_NAME = site.agent.name
 
 export const agentsRouter = new Hono()
-  .use(async (c, next) => (isLocal(env.NODE_ENV) ? next() : c.notFound()))
+  // Mount only when a fork deliberately provisions AGENT_AUTH_SECRET in a local dev env. A default clone (secret unset) exposes no admin-minting route, even though it ships NODE_ENV=local; a production env never reaches it. The secret gates availability; the Origin check below still guards the request.
+  .use(async (c, next) =>
+    isLocal(env.NODE_ENV) && env.AGENT_AUTH_SECRET ? next() : c.notFound(),
+  )
   .post("/sign-in-as", async (c) => {
     const fail = (message: string): never => {
       throw new ApiError(500, "AGENT_LOGIN_FAILED", message)

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -1,23 +1,21 @@
 import { auth } from "@packages/auth"
 import { site } from "@packages/config/site"
 import { db, user as userTable } from "@packages/db"
-import { isLocal } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { makeSignature } from "better-auth/crypto"
 import { eq } from "drizzle-orm"
 import { Hono } from "hono"
 import { setCookie } from "hono/cookie"
 
+import { agentSignInEnabled } from "@/lib/agent-auth"
 import { ApiError } from "@/lib/error"
 
 const AGENT_EMAIL = site.agent.email
 const AGENT_NAME = site.agent.name
 
 export const agentsRouter = new Hono()
-  // Mount only when a fork deliberately provisions AGENT_AUTH_SECRET in a local dev env. A default clone (secret unset) exposes no admin-minting route, even though it ships NODE_ENV=local; a production env never reaches it. The secret gates availability; the Origin check below still guards the request.
-  .use(async (c, next) =>
-    isLocal(env.NODE_ENV) && env.AGENT_AUTH_SECRET ? next() : c.notFound(),
-  )
+  // Mount only when agent sign-in is enabled (see agentSignInEnabled). The Origin check below still guards each request.
+  .use(async (c, next) => (agentSignInEnabled() ? next() : c.notFound()))
   .post("/sign-in-as", async (c) => {
     const fail = (message: string): never => {
       throw new ApiError(500, "AGENT_LOGIN_FAILED", message)

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,16 +1,15 @@
 import { auth, enabledProviders } from "@packages/auth"
-import { isLocal } from "@packages/env"
-import { env } from "@packages/env/api-hono"
 import { Hono } from "hono"
 
-// Advertise the agent sign-in under the exact condition that mounts its route (see agents.ts), so the UI button never drifts from the route it posts to: local env with AGENT_AUTH_SECRET set.
-const agentEnabled = isLocal(env.NODE_ENV) && Boolean(env.AGENT_AUTH_SECRET)
+import { agentSignInEnabled } from "@/lib/agent-auth"
 
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
   .get("/providers", (c) =>
     c.json({
-      data: { providers: [...enabledProviders, ...(agentEnabled ? ["agent" as const] : [])] },
+      data: {
+        providers: [...enabledProviders, ...(agentSignInEnabled() ? ["agent" as const] : [])],
+      },
     }),
   )
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,7 +1,16 @@
 import { auth, enabledProviders } from "@packages/auth"
+import { isLocal } from "@packages/env"
+import { env } from "@packages/env/api-hono"
 import { Hono } from "hono"
+
+// Advertise the agent sign-in under the exact condition that mounts its route (see agents.ts), so the UI button never drifts from the route it posts to: local env with AGENT_AUTH_SECRET set.
+const agentEnabled = isLocal(env.NODE_ENV) && Boolean(env.AGENT_AUTH_SECRET)
 
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
-  .get("/providers", (c) => c.json({ data: { providers: enabledProviders } }))
+  .get("/providers", (c) =>
+    c.json({
+      data: { providers: [...enabledProviders, ...(agentEnabled ? ["agent" as const] : [])] },
+    }),
+  )
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -42,11 +42,13 @@ const setEnvVar = (envPath: string, key: string, value: string): void => {
   write(envPath, lines.join("\n"))
 }
 
-// Create .env from .env.example and fill a generated BETTER_AUTH_SECRET when it is empty.
+// Create .env from .env.example and fill a generated secret for any auth key left empty: BETTER_AUTH_SECRET (required) and AGENT_AUTH_SECRET (enables the local agent sign-in). Both land only in the gitignored .env, never in the committed .env.example, so a clone or deploy still ships them blank.
 export const seedEnv = (dir: string): void => {
   const envPath = ensureEnv(dir)
-  if (!getEnvVar(envPath, "BETTER_AUTH_SECRET")) {
-    setEnvVar(envPath, "BETTER_AUTH_SECRET", randomBytes(32).toString("base64"))
+  for (const key of ["BETTER_AUTH_SECRET", "AGENT_AUTH_SECRET"]) {
+    if (!getEnvVar(envPath, key)) {
+      setEnvVar(envPath, key, randomBytes(32).toString("base64"))
+    }
   }
 }
 

--- a/packages/cli/test/db.test.ts
+++ b/packages/cli/test/db.test.ts
@@ -15,11 +15,13 @@ afterEach(() => {
   rmSync(dir, { force: true, recursive: true })
 })
 
-const secretOf = (env: string): string =>
+const valueOf = (env: string, key: string): string =>
   env
     .split("\n")
-    .find((l) => l.startsWith("BETTER_AUTH_SECRET="))
-    ?.slice("BETTER_AUTH_SECRET=".length) ?? ""
+    .find((l) => l.startsWith(`${key}=`))
+    ?.slice(`${key}=`.length) ?? ""
+
+const secretOf = (env: string): string => valueOf(env, "BETTER_AUTH_SECRET")
 
 test("seedEnv copies .env.example and fills BETTER_AUTH_SECRET", () => {
   writeFileSync(join(dir, ".env.example"), "NODE_ENV=local\nBETTER_AUTH_SECRET=\nPOSTGRES_URL=\n")
@@ -27,6 +29,21 @@ test("seedEnv copies .env.example and fills BETTER_AUTH_SECRET", () => {
   const env = readFileSync(join(dir, ".env"), "utf8")
   expect(env).toContain("NODE_ENV=local")
   expect(secretOf(env).length).toBeGreaterThan(20)
+})
+
+test("seedEnv fills AGENT_AUTH_SECRET with its own value", () => {
+  writeFileSync(join(dir, ".env.example"), "BETTER_AUTH_SECRET=\nAGENT_AUTH_SECRET=\n")
+  seedEnv(dir)
+  const env = readFileSync(join(dir, ".env"), "utf8")
+  const agent = valueOf(env, "AGENT_AUTH_SECRET")
+  expect(agent.length).toBeGreaterThan(20)
+  expect(agent).not.toBe(secretOf(env))
+})
+
+test("seedEnv does not overwrite a pre-set AGENT_AUTH_SECRET", () => {
+  writeFileSync(join(dir, ".env"), "BETTER_AUTH_SECRET=preset\nAGENT_AUTH_SECRET=agentpreset\n")
+  seedEnv(dir)
+  expect(valueOf(readFileSync(join(dir, ".env"), "utf8"), "AGENT_AUTH_SECRET")).toBe("agentpreset")
 })
 
 test("seedEnv is idempotent and keeps the existing secret", () => {

--- a/packages/env/src/api-hono.ts
+++ b/packages/env/src/api-hono.ts
@@ -8,6 +8,8 @@ import { polyfillServer } from "@/lib/polyfill"
 export const env = createEnv({
   server: {
     NODE_ENV,
+    // Gates the local-only agent sign-in route. Unset by default; a fork sets it deliberately in dev to enable agent login, and must leave it unset everywhere else. No polyfill: it is optional, so a build passes without it, and the route stays unmounted.
+    AGENT_AUTH_SECRET: z.string().min(1).optional(),
     HONO_APP_URL: z.url(),
     HONO_PORT: z.coerce.number().default(4000),
     HONO_RATE_LIMIT: z.coerce.number().default(60),
@@ -19,6 +21,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
+    AGENT_AUTH_SECRET: process.env.AGENT_AUTH_SECRET,
     HONO_APP_URL: polyfillServer(process.env.HONO_APP_URL, "https://polyfill.url"),
     HONO_PORT: process.env.HONO_PORT,
     HONO_RATE_LIMIT: process.env.HONO_RATE_LIMIT,

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -59,7 +59,7 @@ Turborepo starts both apps together:
 
 ## Sign in
 
-A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. To get past auth immediately, use the dev-only **Login (agents)** button (or one `curl`). It mints a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
+A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. To get past auth immediately, set `AGENT_AUTH_SECRET` in `.env` (it gates the route, unset by default) and use the dev-only **Login (agents)** button (or one `curl`). It mints a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
 
 When you're ready for real users, wire up GitHub or Google in [Authentication](/docs/manage/authentication); each button appears only once its credentials are set.
 

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -59,7 +59,7 @@ Turborepo starts both apps together:
 
 ## Sign in
 
-A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. To get past auth immediately, set `AGENT_AUTH_SECRET` in `.env` (it gates the route, unset by default) and use the dev-only **Login (agents)** button (or one `curl`). It mints a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
+A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. To get past auth immediately, set `AGENT_AUTH_SECRET` in `.env` (it gates the route, unset by default); the dev-only **Login (agents)** button then appears in the sign-in dialog. Click it (or use one `curl`) to mint a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
 
 When you're ready for real users, wire up GitHub or Google in [Authentication](/docs/manage/authentication); each button appears only once its credentials are set.
 

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -28,7 +28,7 @@ The rest of this page is what those commands do, and the one thing to check if t
 - sets your [feature flags](/docs/manage/features) (docs, blog, API reference, internal docs, waitlist), from an interactive checklist or `--<flag>`/`--no-<flag>` flags,
 - installs dependencies with Bun from the shipped `bun.lock`, so the first install resolves from locked versions instead of a slow cold resolve (progress streams live),
 - provisions a local Postgres in Docker (via [pglaunch](https://github.com/nrjdalal/pglaunch)), reusing an already-running one when you re-run `init`, and applies the migrations,
-- writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET`.
+- writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET`, and an `AGENT_AUTH_SECRET` that enables the local **Login (agents)** sign-in out of the box.
 
 Everything else has a working default, so the scaffold runs as-is. The feature checklist is pre-checked to the defaults (all on except the waitlist), and any feature can be flipped later in config. The database step defaults to yes when Docker is running; pass `--db` to provision it without the prompt.
 
@@ -59,7 +59,7 @@ Turborepo starts both apps together:
 
 ## Sign in
 
-A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. To get past auth immediately, set `AGENT_AUTH_SECRET` in `.env` (it gates the route, unset by default); the dev-only **Login (agents)** button then appears in the sign-in dialog. Click it (or use one `curl`) to mint a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
+A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. `init` already seeded `AGENT_AUTH_SECRET` in your local `.env`, so the dev-only **Login (agents)** button is ready in the sign-in dialog: click it (or use one `curl`) to mint a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
 
 When you're ready for real users, wire up GitHub or Google in [Authentication](/docs/manage/authentication); each button appears only once its credentials are set.
 

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -26,7 +26,7 @@ The full cycle an agent runs, start to finish:
 ```bash
 # 1: scaffold a product, enable the local sign-in, then start the stack
 bunx zerostarter init
-echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # enables Login (agents)
+grep -q '^AGENT_AUTH_SECRET=.\+' .env || echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # enables Login (agents)
 bun run dev
 
 # 2: sign in locally (drive the real UI, or the curl below)
@@ -54,7 +54,7 @@ See [AI Skills](/docs/resources/ai-skills) for the full catalog and how to write
 Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. Enable it once by setting `AGENT_AUTH_SECRET` in `.env` (it is unset by default, so the route stays unmounted until you opt in):
 
 ```bash
-echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # once, to enable the route
+grep -q '^AGENT_AUTH_SECRET=.\+' .env || echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # once, to enable the route
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" \
   http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user   # now authenticated

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -24,8 +24,9 @@ This is about AI agents that _build on_ the codebase: coding assistants. ZeroSta
 The full cycle an agent runs, start to finish:
 
 ```bash
-# 1: scaffold a product, then start the stack
+# 1: scaffold a product, enable the local sign-in, then start the stack
 bunx zerostarter init
+echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # enables Login (agents)
 bun run dev
 
 # 2: sign in locally (drive the real UI, or the curl below)
@@ -59,11 +60,11 @@ curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" \
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user   # now authenticated
 ```
 
-It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable), and sets the session cookie. In the browser, the dev-only **Login (agents)** button does the same thing (once the secret is set).
+It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable), and sets the session cookie. In the browser, the dev-only **Login (agents)** button does the same thing; it appears in the sign-in dialog only once the secret is set, so it always matches whether the route is actually mounted.
 
 <Callout type="warn" title="Local only, by construction">
 
-The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. Because the secret is unset by default, a fresh clone and any deployed default env expose no admin-minting route: it returns `404`, and you opt in deliberately in local dev. The trusted-`Origin` check still guards each request.
+The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. Because the secret is unset by default, a fresh clone and any deployed default env expose no admin-minting route: it returns `404`, and you opt in deliberately in local dev. The **Login (agents)** button is gated on the same condition (it appears only when the API advertises the route), so it never posts to a route that would 404. The trusted-`Origin` check still guards each request.
 
 </Callout>
 

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -50,19 +50,20 @@ See [AI Skills](/docs/resources/ai-skills) for the full catalog and how to write
 
 ## Local sign-in
 
-Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request:
+Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. Enable it once by setting `AGENT_AUTH_SECRET` in `.env` (it is unset by default, so the route stays unmounted until you opt in):
 
 ```bash
+echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # once, to enable the route
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" \
   http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user   # now authenticated
 ```
 
-It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable), and sets the session cookie. In the browser, the dev-only **Login (agents)** button does the same thing.
+It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable), and sets the session cookie. In the browser, the dev-only **Login (agents)** button does the same thing (once the secret is set).
 
 <Callout type="warn" title="Local only, by construction">
 
-The route is gated to a local `NODE_ENV` and requires a trusted `Origin`. It returns `404` anywhere else, so it can never mint a session in production.
+The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. Because the secret is unset by default, a fresh clone and any deployed default env expose no admin-minting route: it returns `404`, and you opt in deliberately in local dev. The trusted-`Origin` check still guards each request.
 
 </Callout>
 

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -24,9 +24,8 @@ This is about AI agents that _build on_ the codebase: coding assistants. ZeroSta
 The full cycle an agent runs, start to finish:
 
 ```bash
-# 1: scaffold a product, enable the local sign-in, then start the stack
+# 1: scaffold a product (init seeds AGENT_AUTH_SECRET, enabling Login (agents)), then start the stack
 bunx zerostarter init
-grep -q '^AGENT_AUTH_SECRET=.\+' .env || echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # enables Login (agents)
 bun run dev
 
 # 2: sign in locally (drive the real UI, or the curl below)
@@ -51,10 +50,10 @@ See [AI Skills](/docs/resources/ai-skills) for the full catalog and how to write
 
 ## Local sign-in
 
-Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. Enable it once by setting `AGENT_AUTH_SECRET` in `.env` (it is unset by default, so the route stays unmounted until you opt in):
+Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. `bunx zerostarter init` seeds `AGENT_AUTH_SECRET` for you, so the route is already live; if you cloned the repo instead, enable it once with the first line below (it is unset in `.env.example`, so the route stays unmounted until you opt in):
 
 ```bash
-grep -q '^AGENT_AUTH_SECRET=.\+' .env || echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # once, to enable the route
+grep -q '^AGENT_AUTH_SECRET=.\+' .env || echo "AGENT_AUTH_SECRET=$(openssl rand -base64 32)" >> .env   # only if you cloned; init already seeded it
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" \
   http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user   # now authenticated
@@ -64,7 +63,7 @@ It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable
 
 <Callout type="warn" title="Local only, by construction">
 
-The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. Because the secret is unset by default, a fresh clone and any deployed default env expose no admin-minting route: it returns `404`, and you opt in deliberately in local dev. The **Login (agents)** button is gated on the same condition (it appears only when the API advertises the route), so it never posts to a route that would 404. The trusted-`Origin` check still guards each request.
+The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. It ships blank in `.env.example`, so a fresh clone and any deployed default env expose no admin-minting route: it returns `404`. `bunx zerostarter init` seeds the secret only into your local (gitignored) `.env`, so agent login works in local dev without touching a deploy, where `NODE_ENV` is not `local` and the route stays down regardless. The **Login (agents)** button is gated on the same condition (it appears only when the API advertises the route), so it never posts to a route that would 404. The trusted-`Origin` check still guards each request.
 
 </Callout>
 

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -63,7 +63,7 @@ It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable
 
 <Callout type="warn" title="Local only, by construction">
 
-The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. It ships blank in `.env.example`, so a fresh clone and any deployed default env expose no admin-minting route: it returns `404`. `bunx zerostarter init` seeds the secret only into your local (gitignored) `.env`, so agent login works in local dev without touching a deploy, where `NODE_ENV` is not `local` and the route stays down regardless. The **Login (agents)** button is gated on the same condition (it appears only when the API advertises the route), so it never posts to a route that would 404. The trusted-`Origin` check still guards each request.
+The route mounts only when `NODE_ENV` is `local` **and** `AGENT_AUTH_SECRET` is set. It ships blank in `.env.example`, so a fresh clone and any deployed default env expose no admin-minting route: it returns `404`. `bunx zerostarter init` seeds the secret only into your local (gitignored) `.env`, so agent login works in local dev without touching a deploy, where `NODE_ENV` is not `local` and the route stays down regardless. The **Login (agents)** button appears only in a dev build when the API advertises the route, so it never posts to a route that would 404. The trusted-`Origin` check still guards each request.
 
 </Callout>
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -19,7 +19,7 @@ The sign-in dialog renders itself from whatever is configured. It fetches `GET /
 
 **Magic link is off by default.** The client plugin is registered but the server `magicLink` plugin is not, so the email field stays hidden rather than showing a dead control. To enable it, add `magicLink({ sendMagicLink })` to the `plugins` array in `packages/auth/src/index.ts` and implement `sendMagicLink` to deliver the email.
 
-**Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, gated to the `local` environment and a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
+**Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, mounted only when `NODE_ENV` is `local` and `AGENT_AUTH_SECRET` is set (unset by default), and guarded by a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
 
 <Callout type="warn" title="Configure at least one method before shipping">
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -19,7 +19,7 @@ The sign-in dialog renders itself from whatever is configured. It fetches the en
 
 **Magic link is off by default.** The client plugin is registered but the server `magicLink` plugin is not, so the email field stays hidden rather than showing a dead control. To enable it, add `magicLink({ sendMagicLink })` to the `plugins` array in `packages/auth/src/index.ts` and implement `sendMagicLink` to deliver the email.
 
-**Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, mounted only when `NODE_ENV` is `local` and `AGENT_AUTH_SECRET` is set (unset by default), and guarded by a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
+**Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, mounted only when `NODE_ENV` is `local` and `AGENT_AUTH_SECRET` is set (blank in `.env.example`, so deploys expose nothing; `zerostarter init` seeds it into your local `.env`), and guarded by a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
 
 <Callout type="warn" title="Configure at least one method before shipping">
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -8,7 +8,7 @@ description: Better Auth with OAuth, organizations, teams, and the role gate beh
 
 ## Sign-in methods
 
-The sign-in dialog renders itself from whatever is configured. It fetches `GET /api/auth/providers`, which returns `enabledProviders`, and draws only those buttons, so turning a method on or off is usually an env change, not a UI change.
+The sign-in dialog renders itself from whatever is configured. It fetches the enabled methods from `GET /api/auth/providers` (the configured OAuth and magic-link providers, plus agent sign-in when its local-only route is mounted) and draws only those buttons, so turning a method on or off is usually an env change, not a UI change.
 
 **OAuth (GitHub and Google) is optional.** A provider registers only when _both_ halves of its credential pair are set, so a fork can ship with GitHub, Google, both, or neither:
 

--- a/web/next/content/docs/manage/environment.mdx
+++ b/web/next/content/docs/manage/environment.mdx
@@ -20,7 +20,7 @@ env.HONO_PORT // number, validated, defaults to 4000
 
 The four slices, each a Zod schema that validates only what that consumer needs:
 
-- **`@packages/env/api-hono`**: `HONO_APP_URL`, `HONO_PORT`, the rate-limit knobs, `HONO_TRUSTED_ORIGINS`
+- **`@packages/env/api-hono`**: `HONO_APP_URL`, `HONO_PORT`, the rate-limit knobs, `HONO_TRUSTED_ORIGINS`, and the optional `AGENT_AUTH_SECRET` (gates the local agent sign-in)
 - **`@packages/env/auth`**: `BETTER_AUTH_SECRET`, `HONO_APP_URL`, `HONO_TRUSTED_ORIGINS`, and the optional OAuth pairs
 - **`@packages/env/db`**: `POSTGRES_URL`
 - **`@packages/env/web-next`**: the server-only `INTERNAL_API_URL` plus the client `NEXT_PUBLIC_*` vars

--- a/web/next/src/components/common/access.tsx
+++ b/web/next/src/components/common/access.tsx
@@ -46,10 +46,12 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
       return data
     },
   })
+  // The agent button posts to a route that only mounts locally with AGENT_AUTH_SECRET set, so gate it on what the API advertises (never in production, where isDev is false and this is dead code).
+  const agentEnabled = isDev && (data?.providers.includes("agent") ?? false)
   const githubEnabled = data?.providers.includes("github") ?? false
   const googleEnabled = data?.providers.includes("google") ?? false
   const magicLinkEnabled = data?.providers.includes("magic-link") ?? false
-  const hasAlternatives = isDev || githubEnabled || googleEnabled
+  const hasAlternatives = agentEnabled || githubEnabled || googleEnabled
   const hasNoProviders = !magicLinkEnabled && !hasAlternatives
 
   useEffect(() => {
@@ -157,7 +159,7 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
           )}
           {hasAlternatives && (
             <div className="grid gap-4">
-              {isDev && (
+              {agentEnabled && (
                 <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
                   <Button type="submit" variant="outline" className="w-full">
                     Login (agents)
@@ -225,6 +227,7 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
             ) : (
               <p className="text-muted-foreground text-center text-sm">
                 No sign-in options are configured yet.
+                {isDev && " Set AGENT_AUTH_SECRET in .env to enable local agent login."}
               </p>
             ))}
         </div>


### PR DESCRIPTION
Tighten the local-only agent sign-in so it is opted into deliberately, one of the [hardening refactors](https://github.com/nrjdalal/zerostarter/blob/canary/.github/notes/plans/hardening-refactors.md) from the external [evaluation](https://github.com/nrjdalal/saas-starter-evals).

## Background
`/api/agents/sign-in-as` mints an admin session for local AI-agent testing (a real DX differentiator, kept). It was gated on `isLocal(NODE_ENV)` alone, and `.env.example` ships `NODE_ENV=local`, so a default self-host could keep the route reachable. Tighten the gate.

## Change
- Add `AGENT_AUTH_SECRET` (optional, no polyfill) to `packages/env` + `.env.example` (empty).
- Mount the router only when `isLocal(NODE_ENV) && env.AGENT_AUTH_SECRET`. The Origin check still guards each request.
- The secret is **unset by default** and the CLI seed doesn't fill it, so a fresh clone and any deployed default env mount no admin route. A dev opts into agent login by setting it once (`openssl rand -base64 32`).
- Docs synced: `AGENTS.md`, the `dev` skill, and `working-with-agents` / `setup` / `authentication`.

## Verified (runtime, both ways)
| | secret unset | secret set |
| --- | --- | --- |
| `POST /api/agents/sign-in-as` (`NODE_ENV=local`) | **404** | **302** + `role: admin` session |
| untrusted Origin (secret set) | - | rejected |

The automated route test is deferred to the product-test harness (`bun test` auto-loads `.env`, so it would false-pass locally); the gate is runtime-verified above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dev-only **agent sign-in** capability gated by `AGENT_AUTH_SECRET` in local `.env`.
  * **Login (agents)** is now driven by server-provided sign-in options and only appears when the agent method is enabled.
* **Bug Fixes**
  * Sign-in option availability is now consistent with the enabled authentication methods returned by the server.
* **Documentation**
  * Updated setup and agent workflow docs to include `AGENT_AUTH_SECRET` preconditions and the local-only gating behavior (returns 404 when not enabled).
  * Updated auth documentation to reflect how providers are discovered.
* **Tests**
  * Added coverage for `AGENT_AUTH_SECRET` seeding and non-overwrite behavior.
* **Chores**
  * Updated environment seeding guidance for local scaffolds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->