### PR TITLE
refactor(env): read the auth secret directly instead of polyfilling it

### DIFF
--- a/packages/env/src/auth.ts
+++ b/packages/env/src/auth.ts
@@ -3,12 +3,12 @@ import { z } from "zod"
 
 import "@/lib/utils"
 import { NODE_ENV } from "@/lib/constants"
-import { polyfillServer } from "@/lib/polyfill"
+import { polyfillServer, serverSecret } from "@/lib/polyfill"
 
 export const env = createEnv({
   server: {
     NODE_ENV,
-    BETTER_AUTH_SECRET: z.string().min(1),
+    BETTER_AUTH_SECRET: serverSecret(z.string().min(1)),
     GITHUB_CLIENT_ID: z.string().min(1).optional(),
     GITHUB_CLIENT_SECRET: z.string().min(1).optional(),
     GOOGLE_CLIENT_ID: z.string().min(1).optional(),
@@ -21,7 +21,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
-    BETTER_AUTH_SECRET: polyfillServer(process.env.BETTER_AUTH_SECRET, "polyfill"),
+    BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
     GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID,
     GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET,
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,

--- a/packages/env/src/lib/polyfill.ts
+++ b/packages/env/src/lib/polyfill.ts
@@ -1,3 +1,5 @@
+import { z } from "zod"
+
 const base = process.env.SKIP_ENV_VALIDATION === "true"
 const skipServer = base || process.env.SKIP_ENV_VALIDATION_SERVER === "true"
 
@@ -7,3 +9,7 @@ export const polyfillServer = (value: string | undefined, dummy: string) =>
 
 export const polyfillClient = (value: string | undefined, dummy: string) =>
   value || (base ? dummy : value)
+
+// A security-critical server secret, never substituted with a dummy (unlike polyfillServer). Under a server skip flag its schema becomes optional so a tooling build passes without the secret; otherwise it stays required, so a missing secret fails closed at runtime instead of silently using a predictable constant. Pair with a raw `process.env` value in runtimeEnv (no polyfill).
+export const serverSecret = <T extends z.ZodTypeAny>(schema: T) =>
+  skipServer ? schema.optional() : schema


### PR DESCRIPTION
Read the auth secret directly and fail closed when it is required, one of the [hardening refactors](https://github.com/nrjdalal/zerostarter/blob/canary/.github/notes/plans/hardening-refactors.md) from the external [evaluation](https://github.com/nrjdalal/saas-starter-evals).

## Background
Under `SKIP_ENV_VALIDATION`, a missing `BETTER_AUTH_SECRET` was substituted with a placeholder in the validated env. Nothing reads `env.BETTER_AUTH_SECRET` today (better-auth reads `process.env` directly), so this is defensive hardening, not a live issue, but a security secret should never resolve to a constant.

## Change
- Add a reusable `serverSecret(schema)` helper in `packages/env`: under a server skip flag it makes the schema `.optional()` (a tooling build passes with `undefined`); otherwise the schema stays required, failing closed at runtime.
- `BETTER_AUTH_SECRET` uses `serverSecret(z.string().min(1))` and a raw `process.env` value (no substitution). The harmless URL polyfills are unchanged.

## Verified
| scenario | result |
| --- | --- |
| skip + no secret (build) | `undefined` (no placeholder); `@packages/auth` still constructs |
| no skip + no secret (runtime) | throws `Invalid environment variables` (fail-closed) |

The automated fail-closed test is deferred to the product-test harness (`bun test` auto-loads `.env`, so it would false-pass locally).