### PR TITLE
feat: gate the local agent sign-in behind an AGENT_SIGNIN_ENABLED toggle

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -39,11 +39,12 @@ Restart the same way after changing `@packages/*` exports the API consumes; they
 
 ## Agent login
 
-Sign in as `LocalAgent` (local only, trusted Origin required):
+Sign in as `LocalAgent` (local only, trusted Origin required). The route is gated on `AGENT_SIGNIN_ENABLED`: set it to `true` in `.env` first, or the route 404s. It is off by default, so a fresh clone and any deploy expose no admin-minting route.
 
 ```bash
+grep -q '^AGENT_SIGNIN_ENABLED=true' .env || echo "AGENT_SIGNIN_ENABLED=true" >> .env   # once, to enable
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```
 
-In the browser: click **Login** in the top navbar (hidden on `/console` and `/dashboard`), then **Login (agents)** in the dialog (development only).
+In the browser: click **Login** in the top navbar (hidden on `/console` and `/dashboard`), then **Login (agents)** in the dialog (development only, with `AGENT_SIGNIN_ENABLED=true`).

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -42,7 +42,6 @@ Restart the same way after changing `@packages/*` exports the API consumes; they
 Sign in as `LocalAgent` (local only, trusted Origin required). The route is gated on `AGENT_SIGNIN_ENABLED`: set it to `true` in `.env` first, or the route 404s. It is off by default, so a fresh clone and any deploy expose no admin-minting route.
 
 ```bash
-grep -q '^AGENT_SIGNIN_ENABLED=true' .env || echo "AGENT_SIGNIN_ENABLED=true" >> .env   # once, to enable
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```

--- a/.agents/skills/ui-verify/SKILL.md
+++ b/.agents/skills/ui-verify/SKILL.md
@@ -22,7 +22,7 @@ agent-browser open http://localhost:3000/<route>
 agent-browser snapshot   # read the page, then click/type/verify
 ```
 
-Behind auth: sign in first with the **Login (agents)** button, or the local sign-in (`dev` skill). For an end-to-end change, or whenever asked, drive the whole flow, not just the screen you touched. Done when you have observed the change render and behave, not merely that the route loaded.
+Behind auth: sign in first with the **Login (agents)** button (shown once `AGENT_SIGNIN_ENABLED=true`) or the local sign-in (`dev` skill). For an end-to-end change, or whenever asked, drive the whole flow, not just the screen you touched. Done when you have observed the change render and behave, not merely that the route loaded.
 
 ### 3. Check it holds up
 

--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ HONO_RATE_LIMIT_WINDOW_MS=60000 # 1 minute (default)
 # Generate using `openssl rand -base64 32`
 BETTER_AUTH_SECRET=
 
+# Optional (local dev only): set to `true` to enable the agent sign-in route (`/api/agents/sign-in-as`), which mints an admin session for AI-agent testing. Leave blank (or `false`) everywhere else, including production; the route stays unmounted.
+AGENT_SIGNIN_ENABLED=
+
 # Optional: GitHub OAuth (`https://github.com/settings/developers`). Leave blank to hide the button.
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=

--- a/.github/notes/plans/hardening-refactors.md
+++ b/.github/notes/plans/hardening-refactors.md
@@ -13,9 +13,11 @@ The PR gate (`auto-check-build.yml`) ran `audit + lint + build` only, so a type 
 
 `packages/env/src/auth.ts` substituted a placeholder for a missing `BETTER_AUTH_SECRET` under `SKIP_ENV_VALIDATION`. A security secret should never resolve to a constant. Add a `serverSecret()` helper: under the skip flag the schema is optional (a tooling build passes with `undefined`), otherwise it stays required, failing closed at runtime. Read the raw `process.env` value.
 
-## Gate the agent sign-in route behind an explicit secret
+## Gate the agent sign-in route behind an explicit toggle
 
-`api/hono/src/routers/agents.ts` `/api/agents/sign-in-as` (the local-only agent login) was gated on `NODE_ENV=local`, which is the `.env.example` default, so it could stay reachable in a default self-host. Add an `AGENT_AUTH_SECRET` (unset by default) and mount the route only when it is set, so agent login is opted into deliberately in dev and a default env never exposes it. Thread it through `packages/env`, `.env.example`, `AGENTS.md`, and the `dev`/docs. The deferred route test lands with the product-test harness below.
+`api/hono/src/routers/agents.ts` `/api/agents/sign-in-as` (the local-only agent login) was gated on `NODE_ENV=local`, which is the `.env.example` default, so it could stay reachable in a default self-host. Add an `AGENT_SIGNIN_ENABLED` toggle (off by default) and mount the route only when it is true, so agent login is opted into deliberately in dev and a default env never exposes it. Thread it through `packages/env`, `.env.example`, `AGENTS.md`, and the `dev`/docs. The deferred route test lands with the product-test harness below.
+
+To keep the agent-DX differentiator intact, `packages/cli` `seedEnv` also sets `AGENT_SIGNIN_ENABLED=true` in the scaffolded project's `.env` alongside a generated `BETTER_AUTH_SECRET`, so `bunx zerostarter init` yields working agent login out of the box. This only touches the gitignored `.env`, never the committed `.env.example`, so clone/deploy defaults stay off and the `isLocal(NODE_ENV)` gate keeps the toggle inert on a real deploy.
 
 ## Larger, tracked separately
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,14 +33,14 @@ Guidance for AI coding agents working in this repository, a Bun monorepo: the `p
 
 ## Logging in (agents)
 
-Signs in as `LocalAgent` (`agent@local.host`). Click **Login (agents)** in the dev UI, or use curl:
+Signs in as `LocalAgent` (`agent@local.host`). The route is gated: set `AGENT_SIGNIN_ENABLED=true` in `.env` first (it is off by default, so the route 404s without it and a deployed default env never exposes it). Then click **Login (agents)** in the dev UI, or use curl:
 
 ```bash
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user
 ```
 
-Local-only and requires a trusted `Origin` header. See `api/hono/src/routers/agents.ts` if needed.
+Local-only (needs `NODE_ENV=local` and `AGENT_SIGNIN_ENABLED=true`) and requires a trusted `Origin` header. See `api/hono/src/routers/agents.ts` if needed.
 
 ## Skills
 

--- a/api/hono/src/lib/agent-signin.ts
+++ b/api/hono/src/lib/agent-signin.ts
@@ -1,0 +1,5 @@
+import { isLocal } from "@packages/env"
+import { env } from "@packages/env/api-hono"
+
+// True when the local-only agent sign-in is enabled: a local env with AGENT_SIGNIN_ENABLED turned on (off by default, so a clone or a deploy mounts no admin-minting route). The route mount (agents.ts) and the /providers advertisement (auth.ts) share this predicate, so a shown button never posts to an unmounted route.
+export const agentSignInEnabled = (): boolean => isLocal(env.NODE_ENV) && env.AGENT_SIGNIN_ENABLED

--- a/api/hono/src/lib/agent-signin.ts
+++ b/api/hono/src/lib/agent-signin.ts
@@ -1,5 +1,5 @@
 import { isLocal } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 
-// True when the local-only agent sign-in is enabled: a local env with AGENT_SIGNIN_ENABLED turned on (off by default, so a clone or a deploy mounts no admin-minting route). The route mount (agents.ts) and the /providers advertisement (auth.ts) share this predicate, so a shown button never posts to an unmounted route.
+// One source of truth for the route mount (agents.ts) and the /providers advertisement (auth.ts).
 export const agentSignInEnabled = (): boolean => isLocal(env.NODE_ENV) && env.AGENT_SIGNIN_ENABLED

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -1,20 +1,21 @@
 import { auth } from "@packages/auth"
 import { site } from "@packages/config/site"
 import { db, user as userTable } from "@packages/db"
-import { isLocal } from "@packages/env"
 import { env } from "@packages/env/api-hono"
 import { makeSignature } from "better-auth/crypto"
 import { eq } from "drizzle-orm"
 import { Hono } from "hono"
 import { setCookie } from "hono/cookie"
 
+import { agentSignInEnabled } from "@/lib/agent-signin"
 import { ApiError } from "@/lib/error"
 
 const AGENT_EMAIL = site.agent.email
 const AGENT_NAME = site.agent.name
 
 export const agentsRouter = new Hono()
-  .use(async (c, next) => (isLocal(env.NODE_ENV) ? next() : c.notFound()))
+  // Mount only when agent sign-in is enabled (see agentSignInEnabled). The Origin check below still guards each request.
+  .use(async (c, next) => (agentSignInEnabled() ? next() : c.notFound()))
   .post("/sign-in-as", async (c) => {
     const fail = (message: string): never => {
       throw new ApiError(500, "AGENT_LOGIN_FAILED", message)

--- a/api/hono/src/routers/agents.ts
+++ b/api/hono/src/routers/agents.ts
@@ -14,7 +14,6 @@ const AGENT_EMAIL = site.agent.email
 const AGENT_NAME = site.agent.name
 
 export const agentsRouter = new Hono()
-  // Mount only when agent sign-in is enabled (see agentSignInEnabled). The Origin check below still guards each request.
   .use(async (c, next) => (agentSignInEnabled() ? next() : c.notFound()))
   .post("/sign-in-as", async (c) => {
     const fail = (message: string): never => {

--- a/api/hono/src/routers/auth.ts
+++ b/api/hono/src/routers/auth.ts
@@ -1,7 +1,15 @@
 import { auth, enabledProviders } from "@packages/auth"
 import { Hono } from "hono"
 
+import { agentSignInEnabled } from "@/lib/agent-signin"
+
 export const authRouter = new Hono()
   .get("/get-session", (c) => auth.handler(c.req.raw))
-  .get("/providers", (c) => c.json({ data: { providers: enabledProviders } }))
+  .get("/providers", (c) =>
+    c.json({
+      data: {
+        providers: [...enabledProviders, ...(agentSignInEnabled() ? ["agent" as const] : [])],
+      },
+    }),
+  )
   .on(["GET", "POST"], "/*", (c) => auth.handler(c.req.raw))

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -42,11 +42,14 @@ const setEnvVar = (envPath: string, key: string, value: string): void => {
   write(envPath, lines.join("\n"))
 }
 
-// Create .env from .env.example and fill a generated BETTER_AUTH_SECRET when it is empty.
+// Create .env from .env.example, filling a generated BETTER_AUTH_SECRET and enabling the local agent sign-in (AGENT_SIGNIN_ENABLED=true) when each is empty. Both land only in the gitignored .env, never the committed .env.example, so a clone or deploy still ships them blank (agent sign-in off).
 export const seedEnv = (dir: string): void => {
   const envPath = ensureEnv(dir)
   if (!getEnvVar(envPath, "BETTER_AUTH_SECRET")) {
     setEnvVar(envPath, "BETTER_AUTH_SECRET", randomBytes(32).toString("base64"))
+  }
+  if (!getEnvVar(envPath, "AGENT_SIGNIN_ENABLED")) {
+    setEnvVar(envPath, "AGENT_SIGNIN_ENABLED", "true")
   }
 }
 

--- a/packages/cli/src/db.ts
+++ b/packages/cli/src/db.ts
@@ -42,7 +42,7 @@ const setEnvVar = (envPath: string, key: string, value: string): void => {
   write(envPath, lines.join("\n"))
 }
 
-// Create .env from .env.example, filling a generated BETTER_AUTH_SECRET and enabling the local agent sign-in (AGENT_SIGNIN_ENABLED=true) when each is empty. Both land only in the gitignored .env, never the committed .env.example, so a clone or deploy still ships them blank (agent sign-in off).
+// Create .env from .env.example, filling a generated BETTER_AUTH_SECRET and enabling agent sign-in (AGENT_SIGNIN_ENABLED=true) when each is empty.
 export const seedEnv = (dir: string): void => {
   const envPath = ensureEnv(dir)
   if (!getEnvVar(envPath, "BETTER_AUTH_SECRET")) {

--- a/packages/cli/test/db.test.ts
+++ b/packages/cli/test/db.test.ts
@@ -15,11 +15,13 @@ afterEach(() => {
   rmSync(dir, { force: true, recursive: true })
 })
 
-const secretOf = (env: string): string =>
+const valueOf = (env: string, key: string): string =>
   env
     .split("\n")
-    .find((l) => l.startsWith("BETTER_AUTH_SECRET="))
-    ?.slice("BETTER_AUTH_SECRET=".length) ?? ""
+    .find((l) => l.startsWith(`${key}=`))
+    ?.slice(`${key}=`.length) ?? ""
+
+const secretOf = (env: string): string => valueOf(env, "BETTER_AUTH_SECRET")
 
 test("seedEnv copies .env.example and fills BETTER_AUTH_SECRET", () => {
   writeFileSync(join(dir, ".env.example"), "NODE_ENV=local\nBETTER_AUTH_SECRET=\nPOSTGRES_URL=\n")
@@ -27,6 +29,19 @@ test("seedEnv copies .env.example and fills BETTER_AUTH_SECRET", () => {
   const env = readFileSync(join(dir, ".env"), "utf8")
   expect(env).toContain("NODE_ENV=local")
   expect(secretOf(env).length).toBeGreaterThan(20)
+})
+
+test("seedEnv enables AGENT_SIGNIN_ENABLED", () => {
+  writeFileSync(join(dir, ".env.example"), "BETTER_AUTH_SECRET=\nAGENT_SIGNIN_ENABLED=\n")
+  seedEnv(dir)
+  const env = readFileSync(join(dir, ".env"), "utf8")
+  expect(valueOf(env, "AGENT_SIGNIN_ENABLED")).toBe("true")
+})
+
+test("seedEnv does not overwrite a pre-set AGENT_SIGNIN_ENABLED", () => {
+  writeFileSync(join(dir, ".env"), "BETTER_AUTH_SECRET=preset\nAGENT_SIGNIN_ENABLED=false\n")
+  seedEnv(dir)
+  expect(valueOf(readFileSync(join(dir, ".env"), "utf8"), "AGENT_SIGNIN_ENABLED")).toBe("false")
 })
 
 test("seedEnv is idempotent and keeps the existing secret", () => {

--- a/packages/env/src/api-hono.ts
+++ b/packages/env/src/api-hono.ts
@@ -8,7 +8,6 @@ import { polyfillServer } from "@/lib/polyfill"
 export const env = createEnv({
   server: {
     NODE_ENV,
-    // Toggles the local-only agent sign-in route. Off by default; a fork sets it to true in dev to enable agent login, and leaves it off everywhere else. Parsed as a boolean and defaulted to false, so a build passes without it and the route stays unmounted.
     AGENT_SIGNIN_ENABLED: z.stringbool().default(false),
     HONO_APP_URL: z.url(),
     HONO_PORT: z.coerce.number().default(4000),

--- a/packages/env/src/api-hono.ts
+++ b/packages/env/src/api-hono.ts
@@ -8,6 +8,8 @@ import { polyfillServer } from "@/lib/polyfill"
 export const env = createEnv({
   server: {
     NODE_ENV,
+    // Toggles the local-only agent sign-in route. Off by default; a fork sets it to true in dev to enable agent login, and leaves it off everywhere else. Parsed as a boolean and defaulted to false, so a build passes without it and the route stays unmounted.
+    AGENT_SIGNIN_ENABLED: z.stringbool().default(false),
     HONO_APP_URL: z.url(),
     HONO_PORT: z.coerce.number().default(4000),
     HONO_RATE_LIMIT: z.coerce.number().default(60),
@@ -19,6 +21,7 @@ export const env = createEnv({
   },
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
+    AGENT_SIGNIN_ENABLED: process.env.AGENT_SIGNIN_ENABLED,
     HONO_APP_URL: polyfillServer(process.env.HONO_APP_URL, "https://polyfill.url"),
     HONO_PORT: process.env.HONO_PORT,
     HONO_RATE_LIMIT: process.env.HONO_RATE_LIMIT,

--- a/web/next/content/docs/getting-started/setup.mdx
+++ b/web/next/content/docs/getting-started/setup.mdx
@@ -28,7 +28,7 @@ The rest of this page is what those commands do, and the one thing to check if t
 - sets your [feature flags](/docs/manage/features) (docs, blog, API reference, internal docs, waitlist), from an interactive checklist or `--<flag>`/`--no-<flag>` flags,
 - installs dependencies with Bun from the shipped `bun.lock`, so the first install resolves from locked versions instead of a slow cold resolve (progress streams live),
 - provisions a local Postgres in Docker (via [pglaunch](https://github.com/nrjdalal/pglaunch)), reusing an already-running one when you re-run `init`, and applies the migrations,
-- writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET`.
+- writes `.env` from `.env.example` with a freshly generated `BETTER_AUTH_SECRET` and `AGENT_SIGNIN_ENABLED=true`, which enables the local **Login (agents)** sign-in out of the box.
 
 Everything else has a working default, so the scaffold runs as-is. The feature checklist is pre-checked to the defaults (all on except the waitlist), and any feature can be flipped later in config. The database step defaults to yes when Docker is running; pass `--db` to provision it without the prompt.
 
@@ -59,7 +59,7 @@ Turborepo starts both apps together:
 
 ## Sign in
 
-A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. To get past auth immediately, use the dev-only **Login (agents)** button (or one `curl`). It mints a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
+A fresh scaffold has no OAuth configured yet, so the home page shows no social buttons. `init` already set `AGENT_SIGNIN_ENABLED=true` in your local `.env`, so the dev-only **Login (agents)** button is ready in the sign-in dialog: click it (or use one `curl`) to mint a real, admin-role session locally with no OAuth round-trip. See [Working with Agents](/docs/getting-started/working-with-agents) for that flow.
 
 When you're ready for real users, wire up GitHub or Google in [Authentication](/docs/manage/authentication); each button appears only once its credentials are set.
 

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -50,10 +50,9 @@ See [AI Skills](/docs/resources/ai-skills) for the full catalog and how to write
 
 ## Local sign-in
 
-Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. `bunx zerostarter init` sets `AGENT_SIGNIN_ENABLED=true` for you, so the route is already live; if you cloned the repo instead, enable it once with the first line below (it is off by default, so the route stays unmounted until you opt in):
+Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. `bunx zerostarter init` sets `AGENT_SIGNIN_ENABLED=true` for you, so the route is already live; if you cloned the repo instead, set `AGENT_SIGNIN_ENABLED=true` in `.env` first (it is off by default, so the route stays unmounted until you opt in):
 
 ```bash
-grep -q '^AGENT_SIGNIN_ENABLED=true' .env || echo "AGENT_SIGNIN_ENABLED=true" >> .env   # only if you cloned; init already did this
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" \
   http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user   # now authenticated

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -24,7 +24,7 @@ This is about AI agents that _build on_ the codebase: coding assistants. ZeroSta
 The full cycle an agent runs, start to finish:
 
 ```bash
-# 1: scaffold a product, then start the stack
+# 1: scaffold a product (init sets AGENT_SIGNIN_ENABLED=true, enabling Login (agents)), then start the stack
 bunx zerostarter init
 bun run dev
 
@@ -50,19 +50,20 @@ See [AI Skills](/docs/resources/ai-skills) for the full catalog and how to write
 
 ## Local sign-in
 
-Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request:
+Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. `bunx zerostarter init` sets `AGENT_SIGNIN_ENABLED=true` for you, so the route is already live; if you cloned the repo instead, enable it once with the first line below (it is off by default, so the route stays unmounted until you opt in):
 
 ```bash
+grep -q '^AGENT_SIGNIN_ENABLED=true' .env || echo "AGENT_SIGNIN_ENABLED=true" >> .env   # only if you cloned; init already did this
 curl -sS -c cookies.txt -X POST -H "Origin: http://localhost:3000" \
   http://localhost:4000/api/agents/sign-in-as
 curl -sS -b cookies.txt http://localhost:4000/api/v1/user   # now authenticated
 ```
 
-It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable), and sets the session cookie. In the browser, the dev-only **Login (agents)** button does the same thing.
+It signs in as `LocalAgent`, grants the `admin` role (so `/console` is reachable), and sets the session cookie. In the browser, the dev-only **Login (agents)** button does the same thing; in a dev build it appears once `AGENT_SIGNIN_ENABLED` is true, so a visible button always has a live route behind it.
 
 <Callout type="warn" title="Local only, by construction">
 
-The route is gated to a local `NODE_ENV` and requires a trusted `Origin`. It returns `404` anywhere else, so it can never mint a session in production.
+The route mounts only when `NODE_ENV` is `local` **and** `AGENT_SIGNIN_ENABLED` is `true`. It ships off (blank) in `.env.example`, so a fresh clone and any deployed default env expose no admin-minting route: it returns `404`. `bunx zerostarter init` sets it only in your local (gitignored) `.env`, so agent login works in local dev without touching a deploy, where `NODE_ENV` is not `local` and the route stays down regardless. The **Login (agents)** button appears only in a dev build when the API advertises the route, so it never posts to a route that would 404. The trusted-`Origin` check still guards each request.
 
 </Callout>
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -8,7 +8,7 @@ description: Better Auth with OAuth, organizations, teams, and the role gate beh
 
 ## Sign-in methods
 
-The sign-in dialog renders itself from whatever is configured. It fetches `GET /api/auth/providers`, which returns `enabledProviders`, and draws only those buttons, so turning a method on or off is usually an env change, not a UI change.
+The sign-in dialog renders itself from whatever is configured. It fetches the enabled methods from `GET /api/auth/providers` (the configured OAuth and magic-link providers, plus agent sign-in when its local-only route is mounted) and draws only those buttons, so turning a method on or off is usually an env change, not a UI change.
 
 **OAuth (GitHub and Google) is optional.** A provider registers only when _both_ halves of its credential pair are set, so a fork can ship with GitHub, Google, both, or neither:
 
@@ -19,7 +19,7 @@ The sign-in dialog renders itself from whatever is configured. It fetches `GET /
 
 **Magic link is off by default.** The client plugin is registered but the server `magicLink` plugin is not, so the email field stays hidden rather than showing a dead control. To enable it, add `magicLink({ sendMagicLink })` to the `plugins` array in `packages/auth/src/index.ts` and implement `sendMagicLink` to deliver the email.
 
-**Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, gated to the `local` environment and a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
+**Agent sign-in** is a local-only shortcut: `POST /api/agents/sign-in-as` mints a real session as `LocalAgent` with the `admin` role, mounted only when `NODE_ENV` is `local` and `AGENT_SIGNIN_ENABLED` is `true` (off by default in `.env.example`, so deploys expose nothing; `zerostarter init` sets it in your local `.env`), and guarded by a trusted `Origin`. See [Working with Agents](/docs/getting-started/working-with-agents).
 
 <Callout type="warn" title="Configure at least one method before shipping">
 

--- a/web/next/content/docs/manage/environment.mdx
+++ b/web/next/content/docs/manage/environment.mdx
@@ -20,7 +20,7 @@ env.HONO_PORT // number, validated, defaults to 4000
 
 The four slices, each a Zod schema that validates only what that consumer needs:
 
-- **`@packages/env/api-hono`**: `HONO_APP_URL`, `HONO_PORT`, the rate-limit knobs, `HONO_TRUSTED_ORIGINS`
+- **`@packages/env/api-hono`**: `HONO_APP_URL`, `HONO_PORT`, the rate-limit knobs, `HONO_TRUSTED_ORIGINS`, and the optional `AGENT_SIGNIN_ENABLED` (gates the local agent sign-in)
 - **`@packages/env/auth`**: `BETTER_AUTH_SECRET`, `HONO_APP_URL`, `HONO_TRUSTED_ORIGINS`, and the optional OAuth pairs
 - **`@packages/env/db`**: `POSTGRES_URL`
 - **`@packages/env/web-next`**: the server-only `INTERNAL_API_URL` plus the client `NEXT_PUBLIC_*` vars

--- a/web/next/src/components/common/access.tsx
+++ b/web/next/src/components/common/access.tsx
@@ -46,7 +46,7 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
       return data
     },
   })
-  // The agent button posts to a route that only mounts locally with AGENT_SIGNIN_ENABLED=true, so gate it on what the API advertises (never in production, where isDev is false and this is dead code).
+  // The extra isDev keeps this dev-only admin control out of any production bundle.
   const agentEnabled = isDev && (data?.providers.includes("agent") ?? false)
   const githubEnabled = data?.providers.includes("github") ?? false
   const googleEnabled = data?.providers.includes("google") ?? false

--- a/web/next/src/components/common/access.tsx
+++ b/web/next/src/components/common/access.tsx
@@ -46,10 +46,12 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
       return data
     },
   })
+  // The agent button posts to a route that only mounts locally with AGENT_SIGNIN_ENABLED=true, so gate it on what the API advertises (never in production, where isDev is false and this is dead code).
+  const agentEnabled = isDev && (data?.providers.includes("agent") ?? false)
   const githubEnabled = data?.providers.includes("github") ?? false
   const googleEnabled = data?.providers.includes("google") ?? false
   const magicLinkEnabled = data?.providers.includes("magic-link") ?? false
-  const hasAlternatives = isDev || githubEnabled || googleEnabled
+  const hasAlternatives = agentEnabled || githubEnabled || googleEnabled
   const hasNoProviders = !magicLinkEnabled && !hasAlternatives
 
   useEffect(() => {
@@ -157,7 +159,7 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
           )}
           {hasAlternatives && (
             <div className="grid gap-4">
-              {isDev && (
+              {agentEnabled && (
                 <form action={`${config.api.url}/api/agents/sign-in-as`} method="POST">
                   <Button type="submit" variant="outline" className="w-full">
                     Login (agents)
@@ -225,6 +227,7 @@ export function Access({ labelClassName }: { labelClassName?: string }) {
             ) : (
               <p className="text-muted-foreground text-center text-sm">
                 No sign-in options are configured yet.
+                {isDev && " Set AGENT_SIGNIN_ENABLED=true in .env to enable local agent login."}
               </p>
             ))}
         </div>


### PR DESCRIPTION
## Summary

Rebuilds the agent sign-in hardening from scratch on `canary`, **superseding #695**. The local-only agent sign-in (`POST /api/agents/sign-in-as`, which mints a `LocalAgent` admin session) was gated on `NODE_ENV=local` alone, and since `.env.example` ships `NODE_ENV=local`, a default self-host could keep the admin-minting route reachable. This adds an explicit **`AGENT_SIGNIN_ENABLED`** toggle (a real boolean, off by default) as a second gate, and keeps the out-of-the-box agent DX by seeding it on `init`.

Named `AGENT_SIGNIN_ENABLED`, not `AGENT_AUTH_*`: it is a boolean toggle for one local dev shortcut, not an authentication mechanism and not a rotatable secret.

## What changed

- **env** (`packages/env`): `AGENT_SIGNIN_ENABLED: z.stringbool().default(false)`; blank / `false` / unset -> off. `.env.example` ships it blank.
- **api** (`api/hono`): one shared `agentSignInEnabled()` predicate (`isLocal(NODE_ENV) && env.AGENT_SIGNIN_ENABLED`) gates both the route mount (`agents.ts`) and the `/providers` advertisement (`auth.ts`), so the button can never drift from the route it posts to.
- **web**: the sign-in dialog renders **Login (agents)** only when the API advertises the `agent` provider, behind an extra `isDev` guard so a production bundle never renders a dev-only admin control; the empty state gains a dev-only hint.
- **cli**: `seedEnv` writes `AGENT_SIGNIN_ENABLED=true` into the scaffolded (gitignored) `.env`, so `bunx zerostarter init` yields a working button out of the box; it only fills empty keys and never touches the committed `.env.example`.
- **docs**: setup, working-with-agents, authentication, environment, `AGENTS.md`, the `dev` and `ui-verify` skills, and the hardening plan note.

## Security posture

The toggle ships **off** (blank) in the committed `.env.example`, so a `git clone` or any deploy exposes no admin-minting route. `init` writes `=true` only into the local gitignored `.env`. The `isLocal(NODE_ENV)` gate is an independent second lock, so a seeded toggle is inert on any real deploy. Exposure now requires two compound misconfigurations instead of one.

## Verification

- `bun run check-types` 12/12 (incl. `@web/next` RPC inference and `@api/hono`); `bun run lint` clean; CLI `bun test` 9/9.
- `z.stringbool().default(false)`: unset/blank -> `false`, `"false"` -> `false` (no truthy-string footgun), `"true"` -> `true`.
- `seedEnv` against the real `.env.example`: writes `AGENT_SIGNIN_ENABLED=true` on one line, in place.
- **Runtime, both directions** (booted the API):
  - `=true`: `/api/auth/providers` -> `{"providers":["agent"]}`; `POST /sign-in-as` -> `500` (route **mounted**).
  - `=false`: `/api/auth/providers` -> `{"providers":[]}`; `POST /sign-in-as` -> `404` (route **unmounted**).
- The **Login (agents)** button renders from that runtime-verified `/providers`; the client mapping is unchanged from #695 (browser-verified). A full browser screenshot pass can be run before merge if wanted.

## Supersedes

Replaces #695 (which used a presence-checked `AGENT_AUTH_SECRET`). Recommend closing #695 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional local-development setting to enable agent sign-in.
  * Local setup now enables agent sign-in automatically for development.
  * Sign-in options now display the agent login method only when enabled.
  * The “Login (agents)” option is hidden when unavailable, with guidance provided for enabling it.

* **Documentation**
  * Updated setup, authentication, environment, and agent workflow documentation with the new requirements and safeguards.

* **Bug Fixes**
  * Prevented agent sign-in controls from appearing when the sign-in route is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->