### PR TITLE
ci: gate the PR build on oxfmt formatting

### DIFF
--- a/.github/workflows/auto-check-build.yml
+++ b/.github/workflows/auto-check-build.yml
@@ -27,9 +27,10 @@ jobs:
       - name: Install dependencies
         run: bun install --ignore-scripts
 
-      - name: Audit, Lint, Check-types, Test, and Build
+      - name: Audit, Format, Lint, Check-types, Test, and Build
         run: |
           bun audit --audit-level high
+          bun run format:check
           bun run lint
           bun run check-types
           bun run test

--- a/packages/cli/src/templates.ts
+++ b/packages/cli/src/templates.ts
@@ -19,7 +19,9 @@ export const DEFAULT_FEATURES: FeatureFlags = {
   waitlist: false,
 }
 
-const featuresBlock = (features: FeatureFlags): string => `// Optional surfaces a fork enables or disables. Typed boolean (not \`as const\`) so a fork can flip them and the runtime gates are not dead code. Off means the routes 404 and the links, nav, sitemap, llms, and search drop the surface. waitlist off makes the home a plain landing page.
+const featuresBlock = (
+  features: FeatureFlags,
+): string => `// Optional surfaces a fork enables or disables. Typed boolean (not \`as const\`) so a fork can flip them and the runtime gates are not dead code. Off means the routes 404 and the links, nav, sitemap, llms, and search drop the surface. waitlist off makes the home a plain landing page.
 export const features = {
   apiDocs: ${features.apiDocs},
   blog: ${features.blog},

--- a/packages/cli/test/convert.test.ts
+++ b/packages/cli/test/convert.test.ts
@@ -158,13 +158,17 @@ describe("convertRepo (in-place)", () => {
 
   test("writes the chosen feature flags into site.ts", () => {
     scaffold()
-    convertRepo(dir, { name: "acme" }, {
-      apiDocs: true,
-      blog: false,
-      docs: true,
-      internalDocs: true,
-      waitlist: true,
-    })
+    convertRepo(
+      dir,
+      { name: "acme" },
+      {
+        apiDocs: true,
+        blog: false,
+        docs: true,
+        internalDocs: true,
+        waitlist: true,
+      },
+    )
     const site = read(join(dir, "packages/config/src/site.ts"))
     expect(site).toContain("export const features")
     expect(site).toContain("blog: false")

--- a/packages/cli/test/templates.test.ts
+++ b/packages/cli/test/templates.test.ts
@@ -44,7 +44,7 @@ test("siteTemplate honors an explicit feature set", () => {
 test("homeTemplate branches between the waitlist and a plain landing", () => {
   const out = homeTemplate()
   expect(out).toContain('from "next/navigation"')
-  expect(out).toContain("if (features.waitlist) redirect(\"/waitlist\")")
+  expect(out).toContain('if (features.waitlist) redirect("/waitlist")')
   expect(out).toContain("{site.name}")
   expect(out).not.toContain("zerostarter")
 })

--- a/web/next/content/docs/contributing.mdx
+++ b/web/next/content/docs/contributing.mdx
@@ -16,10 +16,11 @@ Branch off `canary` with a descriptive name (`feat/...`, `fix/...`), then run th
 
 ```bash
 bun audit --audit-level high   # the first CI gate
-bun run build
-bun run check-types
 bun run format
 bun run lint
+bun run check-types
+bun run test
+bun run build
 ```
 
 Two rules from `AGENTS.md` are non-negotiable:

--- a/web/next/content/docs/getting-started/scripts.mdx
+++ b/web/next/content/docs/getting-started/scripts.mdx
@@ -30,7 +30,7 @@ Each of these builds `@packages/env` first, then runs Drizzle Kit against `packa
 
 - `bun run lint`: Oxlint over the whole tree (also what CI runs).
 - `bun run format`: Oxfmt, writing fixes.
-- `bun run format:check`: Oxfmt, report only.
+- `bun run format:check`: Oxfmt, report only (also what CI runs).
 - `bun run check-types`: type-check every workspace, then the repo scripts (`check-types:scripts`, `tsgo` over `.github/scripts`).
 - `bun run test`: run every workspace's tests through Turbo (the `packages/cli` suite today). PR CI runs this and `check-types` too, so a failing test or type error blocks the merge.
 

--- a/web/next/content/docs/manage/code-quality.mdx
+++ b/web/next/content/docs/manage/code-quality.mdx
@@ -35,7 +35,7 @@ Run either across the tree yourself:
 ```bash
 bun run lint          # oxlint over everything (this is what CI runs)
 bun run format        # oxfmt, writing fixes
-bun run format:check  # oxfmt, report only
+bun run format:check  # oxfmt, report only (also what CI runs)
 ```
 
 ## The git hooks
@@ -74,7 +74,7 @@ pre-push:
 
 **pre-push**: `bun audit --audit-level high` runs, but only from `canary` (`only: ref: canary`), so a vulnerable dependency is caught before the branch leaves your machine without blocking your offline commits. `ensure-remote-branches.ts` seeds the release branches (default `main`) that drive the release PR (see [Releases](/docs/manage/release)).
 
-**On a pull request**, the `auto-check-build` workflow re-runs the full gate on GitHub: `bun audit`, `bun run lint`, `bun run check-types`, `bun run test`, and `bun run build`. A failing type error or test blocks the merge, so the checks that are cheap to skip locally (the pre-commit build tolerates type errors that `tsc` would reject) still cannot reach `canary`.
+**On a pull request**, the `auto-check-build` workflow re-runs the full gate on GitHub: `bun audit`, `bun run format:check`, `bun run lint`, `bun run check-types`, `bun run test`, and `bun run build`. A failing type error or test blocks the merge, so the checks that are cheap to skip locally (the pre-commit build tolerates type errors that `tsc` would reject) still cannot reach `canary`.
 
 <Callout type="warn" title="The local build sees your real .env">
 

--- a/web/next/content/docs/manage/environment.mdx
+++ b/web/next/content/docs/manage/environment.mdx
@@ -57,12 +57,12 @@ A variable declared in the schema but missing from the `runtimeEnv` map is silen
 
 ## Skipping validation
 
-Two flags fall missing required variables back to shape-valid dummies so a build without real secrets still passes. Validation still runs otherwise, so a present-but-invalid value always fails:
+Two flags let a build pass without real secrets: missing required variables fall back to shape-valid dummies, except `BETTER_AUTH_SECRET`, which is made optional and stays `undefined` rather than a predictable dummy. Validation still runs otherwise, so a present-but-invalid value always fails:
 
 - `SKIP_ENV_VALIDATION=true` covers **every** variable, server and client. This is the CI/Docker escape hatch, used before any real secrets exist.
 - `SKIP_ENV_VALIDATION_SERVER=true` covers only the **server-only** variables (`POSTGRES_URL`, `BETTER_AUTH_SECRET`, `HONO_APP_URL`, `HONO_TRUSTED_ORIGINS`); the public `NEXT_PUBLIC_*` client vars stay **required and validated**. The web build sets this: it compiles the server packages for their types without their secrets, but must still guarantee the client vars it inlines and ships.
 
-Never set either for a running app: the server would then start against dummy secrets instead of real ones.
+Never set either for a running app: the server would then start against dummy URLs and an undefined `BETTER_AUTH_SECRET` instead of real values.
 
 ## Next
 

--- a/web/next/content/docs/manage/features.mdx
+++ b/web/next/content/docs/manage/features.mdx
@@ -20,13 +20,13 @@ export const features = {
 }
 ```
 
-| Flag           | Surface                                        | Off means                                                                                     |
-| -------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `apiDocs`      | `/api/docs` Scalar reference UI + the `/api/openapi.json` spec | both 404 and the navbar "API Docs" link is hidden                            |
-| `blog`         | `/blog` and its posts                          | `/blog` 404s, the navbar link, `/og/blog`, sitemap, and `llms.txt` blog entries all drop      |
-| `docs`         | `/docs`                                        | `/docs` 404s, the navbar link, `/og/docs`, search (`/api/search`), sitemap, and `llms.txt` docs entries all drop |
-| `internalDocs` | `/console/docs` (admin-gated internal docs)    | the console docs render the not-found page and their search (`/api/console/search`) 404s        |
-| `waitlist`     | `/waitlist` page and its API                   | `/waitlist` and `/api/waitlist` 404, and a fresh fork's home becomes a plain landing page      |
+| Flag           | Surface                                                        | Off means                                                                                                        |
+| -------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `apiDocs`      | `/api/docs` Scalar reference UI + the `/api/openapi.json` spec | both 404 and the navbar "API Docs" link is hidden                                                                |
+| `blog`         | `/blog` and its posts                                          | `/blog` 404s, the navbar link, `/og/blog`, sitemap, and `llms.txt` blog entries all drop                         |
+| `docs`         | `/docs`                                                        | `/docs` 404s, the navbar link, `/og/docs`, search (`/api/search`), sitemap, and `llms.txt` docs entries all drop |
+| `internalDocs` | `/console/docs` (admin-gated internal docs)                    | the console docs render the not-found page and their search (`/api/console/search`) 404s                         |
+| `waitlist`     | `/waitlist` page and its API                                   | `/waitlist` and `/api/waitlist` 404, and a fresh fork's home becomes a plain landing page                        |
 
 "Off" is not a stub: the route returns a real 404, the links and navigation entries disappear, and the surface is dropped from the sitemap, `llms.txt`, and search, so nothing points at a page that no longer exists.
 

--- a/web/next/src/app/sitemap.ts
+++ b/web/next/src/app/sitemap.ts
@@ -24,14 +24,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]
 
   // Docs pages (empty when the docs feature is off)
-  const docsRoutes: MetadataRoute.Sitemap = docs
-    .pages()
-    .map((page) => ({
-      url: `${baseUrl}${page.url}`,
-      lastModified: new Date(),
-      changeFrequency: "weekly" as const,
-      priority: 0.9,
-    }))
+  const docsRoutes: MetadataRoute.Sitemap = docs.pages().map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.9,
+  }))
 
   // Blog pages: gate on the seam's `enabled`, but read through getPublishedBlogPosts() (not pages()) for its narrowed `publishedAt: string`, which lastModified needs. Empty when the blog feature is off.
   const blogRoutes: MetadataRoute.Sitemap = blog.enabled

--- a/web/next/src/components/console/sidebar.tsx
+++ b/web/next/src/components/console/sidebar.tsx
@@ -18,7 +18,13 @@ import type { NavGroup } from "@/lib/docs"
 import { isActive } from "@/lib/utils"
 
 const mainItems = [
-  { title: "Documentation", url: "/console/docs", icon: RiBookLine, exact: false, feature: "internalDocs" },
+  {
+    title: "Documentation",
+    url: "/console/docs",
+    icon: RiBookLine,
+    exact: false,
+    feature: "internalDocs",
+  },
 ] as const
 
 // Sidebar-header slot: the console home ("Dashboard") link, plus the docs search inside /console/docs (matching public /docs).

--- a/web/next/src/lib/content.ts
+++ b/web/next/src/lib/content.ts
@@ -79,5 +79,16 @@ export function contentSource<K extends ContentKind>(kind: K): ContentSource<K> 
     return createRelativeLink(docsSource, page as PageOf<"docs">)
   }
 
-  return { kind, baseUrl: entry.baseUrl, enabled, og: entry.og, source, getPageOr404, pages, params, tree, relativeLink }
+  return {
+    kind,
+    baseUrl: entry.baseUrl,
+    enabled,
+    og: entry.og,
+    source,
+    getPageOr404,
+    pages,
+    params,
+    tree,
+    relativeLink,
+  }
 }


### PR DESCRIPTION
Started as a doc-sync follow-up to #696 (the `BETTER_AUTH_SECRET` fail-closed change), which surfaced pre-existing oxfmt formatting drift on `canary` — which in turn revealed that CI has no formatting gate at all. This PR closes that gap end to end.

## Commits

- **`docs(env)`** — sync `environment.mdx` with #696: `BETTER_AUTH_SECRET` is now made optional under a skip flag (resolves to `undefined`), never a shape-valid dummy; the closing "Skipping validation" warning matches.
- **`style`** — `bun run format` over the 7 files carrying pre-existing oxfmt drift (untouched since an oxfmt change, so the per-commit hook never reflowed them). Pure formatting, no behavior change.
- **`ci`** — add `bun run format:check` to `auto-check-build` (after `audit`, before `lint`; fail-fast) so formatting drift can't silently reach `canary` again. Sync the CI-gate order across the `contributing`, `code-quality`, and `scripts` docs (contributing keeps `bun run format`, the local fixer, in the same position).

## Notes

- CI order is `audit → format:check → lint → check-types → test → build`. `build` stays last (fullest step + `build-sizes` report); `test`/`check-types` depend on `^build` (upstream packages only), so they don't subsume it.
- The job name `Audit, Lint, and Build` (the required-check identifier) is unchanged; only the descriptive step name gained "Format".
- `format:check` passes clean on this branch, so the PR both adds the gate and satisfies it.

Docs + CI + formatting only; no runtime behavior change.
