### PR TITLE
refactor: alphabetize enumerable lists across the site

### DIFF
--- a/packages/config/src/site.ts
+++ b/packages/config/src/site.ts
@@ -5,9 +5,9 @@ export const site = {
     "Modern, type-safe/RPC starter monorepo with foundations for building scalable SaaS products with clean architecture, automation, and great developer experience.",
   tagline: "Production-ready SaaS infrastructure with world-class human and agent DX",
   social: {
+    discord: "https://discord.gg/38FeAUmHSZ",
     github: "https://github.com/nrjdalal/zerostarter",
     x: "https://x.com/nrjdalal",
-    discord: "https://discord.gg/38FeAUmHSZ",
   },
   // Local-only dev agent identity (api/hono agents router).
   agent: {

--- a/web/next/content/docs/getting-started/roadmap.mdx
+++ b/web/next/content/docs/getting-started/roadmap.mdx
@@ -39,14 +39,14 @@ Nothing in this table ships today. Do not assume any of it is available; if you 
 | [SendGrid](https://sendgrid.com)              | Email                |
 | [i18next](https://www.i18next.com)            | Internationalization |
 | [next-intl](https://next-intl.dev)            | Internationalization |
-| [Stripe](https://stripe.com)                  | Payments             |
-| [Lemon Squeezy](https://www.lemonsqueezy.com) | Payments             |
-| [Paddle](https://www.paddle.com)              | Payments             |
-| [Razorpay](https://razorpay.com)              | Payments             |
-| [Polar](https://polar.sh)                     | Payments             |
 | [Autumn](https://useautumn.com)               | Payments             |
 | [Creem](https://www.creem.io)                 | Payments             |
 | [Dodo](https://dodopayments.com)              | Payments             |
+| [Lemon Squeezy](https://www.lemonsqueezy.com) | Payments             |
+| [Paddle](https://www.paddle.com)              | Payments             |
+| [Polar](https://polar.sh)                     | Payments             |
+| [Razorpay](https://razorpay.com)              | Payments             |
+| [Stripe](https://stripe.com)                  | Payments             |
 
 ## Next
 

--- a/web/next/content/docs/resources/ai-skills.mdx
+++ b/web/next/content/docs/resources/ai-skills.mdx
@@ -30,17 +30,17 @@ The skills, arranged as the arc of a real task, **Navigate** to find your way, *
 | Navigate | `codebase-map`  | Orient fast: the "where do I edit for X" table and how a change ripples across the stack. Start here in unfamiliar territory. |
 | Build    | `api-endpoint`  | Add a typed Hono route the repo's way: router, validation envelope, OpenAPI, RPC wiring, and the restart-and-`curl` test.     |
 | Build    | `db-migration`  | Change the Drizzle schema and apply it: `db:generate`, then `db:migrate`.                                                     |
+| Build    | `design`        | The canonical UI conventions: spacing, color, cursor, typography, tokens. Follow it for any component work.                   |
 | Build    | `dev`           | Start, restart, and verify the dev stack; fixes the `bun --hot` trap where new files return `NOT_FOUND`.                      |
 | Build    | `portless`      | Set up and use portless for stable named `.localhost` dev URLs instead of `localhost:PORT`.                                   |
-| Build    | `design`        | The canonical UI conventions: spacing, color, cursor, typography, tokens. Follow it for any component work.                   |
 | Build    | `runtime-apis`  | Prefer Bun-native APIs; fall back to Node built-ins with the required `node:` prefix.                                         |
 | Operate  | `agent-browser` | Drive the running app like a user: navigate, click, and snapshot the accessibility tree.                                      |
-| Operate  | `docker-test`   | Build and smoke-test the Docker images with `docker compose`.                                                                 |
 | Operate  | `audit`         | Run the dependency security audit and maintain `.github/notes/dependencies.md`; unblocks the pre-push audit hook.             |
+| Operate  | `docker-test`   | Build and smoke-test the Docker images with `docker compose`.                                                                 |
 | Operate  | `ui-verify`     | Verify a frontend change in a real browser with agent-browser, then attach screenshots to the PR.                             |
-| Maintain | `shadcn-sync`   | Run `bun run shadcn:update` and reconcile it so a sync never silently drops your customizations.                              |
 | Maintain | `fonts`         | Add or swap web fonts: fetch latin variable woff2 from Fontsource, localize through `next/font/local`.                        |
 | Maintain | `ignore-sync`   | Keep `.dockerignore` in step with `.gitignore`.                                                                               |
+| Maintain | `shadcn-sync`   | Run `bun run shadcn:update` and reconcile it so a sync never silently drops your customizations.                              |
 | Ship     | `doc-sync`      | Sync docs and skills so a change never ships drift: the surface map, a grep sweep, and the strict docs build.                 |
 | Ship     | `gh-commit`     | Atomic commits in conventional-commit format.                                                                                 |
 

--- a/web/next/src/components/common/navbar.tsx
+++ b/web/next/src/components/common/navbar.tsx
@@ -23,11 +23,6 @@ import { cn, isActive } from "@/lib/utils"
 
 const socialLinks = [
   {
-    href: site.social.x,
-    icon: RiTwitterXFill,
-    label: "X",
-  },
-  {
     href: site.social.discord,
     icon: RiDiscordFill,
     label: "Discord",
@@ -36,6 +31,11 @@ const socialLinks = [
     href: site.social.github,
     icon: RiGithubFill,
     label: "GitHub",
+  },
+  {
+    href: site.social.x,
+    icon: RiTwitterXFill,
+    label: "X",
   },
 ]
 


### PR DESCRIPTION
Applies the list-ordering convention (documented in `AGENTS.md` via #709) to the website's arbitrary-set lists. Relevance/flow-ordered lists were left as-is.

A read-only inventory pass across the docs, marketing, and nav config confirmed most sets are already meticulously A→Z (`techStack`, `features`, env slices, the error-code and features tables), which made the exceptions genuine defects rather than noise. Fixed:

- **`roadmap.mdx`** — the Payments row group → A→Z (`Autumn, Creem, Dodo, Lemon Squeezy, Paddle, Polar, Razorpay, Stripe`). Every other Area group in that table was already alphabetical; Payments was the lone unsorted block.
- **`packages/config/src/site.ts` `social`** and **`navbar.tsx` `socialLinks`** → A→Z (`discord, github, x`). The two lists previously disagreed with each other and neither documented a priority, so alphabetical makes them consistent.
- **`ai-skills.mdx`** — alphabetize skills within each stage, keeping the deliberate stage arc (Navigate → Build → Operate → Maintain → Ship). `design`, `audit`, and the Maintain group were out of order.

**Left as-is (legitimately relevance/flow/design-ordered):** the docs nav/`## Next` reading-flow sequences, marketing bento/narrative cards, the deploy/agent chips, the portfolio `hire`/`resume` sections (prominence/chronology), blog post order, and the size-variant progression.

`check-types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)