### PR TITLE
feat(dev): serve the worktree api at api.&lt;branch&gt; to match api.&lt;env&gt;

### DIFF
--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -70,7 +70,7 @@ export const exampleRouter = new Hono().post(
 `bun --hot` will NOT see a new file: restart the stack (see the `dev` skill), then:
 
 ```bash
-WEB=$(bunx portless get zerostarter); API=$(bunx portless get api.zerostarter)
+WEB=$(bunx portless get zerostarter); API=$(echo "$WEB" | sed 's#://#://api.#')
 curl -sS -X POST -H "Content-Type: application/json" -H "Origin: $WEB" \
   -d '{"email":"you@example.com"}' "$API/api/<name>"
 ```

--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -13,7 +13,7 @@ description: Start, restart, and verify the ZeroStarter dev stack. `bun run dev`
 (bun run dev --ui stream > /tmp/zerostarter-dev.log 2>&1 &)
 # Resolve this worktree's URLs (branch-prefixed); the proxy needs a moment, so retry
 for i in $(seq 1 60); do WEB=$(bunx portless get zerostarter 2>/dev/null); [ -n "$WEB" ] && break; sleep 1; done
-API=$(bunx portless get api.zerostarter)
+API=$(echo "$WEB" | sed 's#://#://api.#')         # api-first sibling of the web host
 curl -sf --retry 60 --retry-delay 1 --retry-connrefused "$API/api/health" > /dev/null
 curl -sS "$API/api/health"                        # {"data":{"message":"ok",...}}
 curl -sS -o /dev/null -w "%{http_code}" "$WEB/"   # 200
@@ -21,7 +21,7 @@ curl -sS -o /dev/null -w "%{http_code}" "$WEB/"   # 200
 
 Ready when the health curl prints `"message":"ok"` and `/` returns `200`. `bunx portless list` shows every active route.
 
-- Web / API base URLs: `bunx portless get zerostarter` / `bunx portless get api.zerostarter`
+- Web / API base URLs: `bunx portless get zerostarter` and its `api.` sibling (`echo "$WEB" | sed 's#://#://api.#'`)
 - Scalar API docs: `$API/api/docs`
 - Logs: `tail -f /tmp/zerostarter-dev.log`
 
@@ -35,7 +35,7 @@ The API dev task runs `bun --hot src/index.ts`, and **`--hot` does not pick up n
 pkill -f "turbo run dev" 2>/dev/null
 sleep 2
 (bun run dev --ui stream > /tmp/zerostarter-dev.log 2>&1 &)
-API=$(bunx portless get api.zerostarter)
+API=$(bunx portless get zerostarter | sed 's#://#://api.#')
 curl -sf --retry 60 --retry-delay 1 --retry-connrefused "$API/api/health" > /dev/null
 ```
 
@@ -48,7 +48,7 @@ Restart the same way after changing `@packages/*` exports the API consumes; they
 Sign in as `LocalAgent` (local only, trusted Origin required). The route is gated on `AGENT_SIGNIN_ENABLED`: set it to `true` in `.env` first, or the route 404s. It is off by default, so a fresh clone and any deploy expose no admin-minting route.
 
 ```bash
-WEB=$(bunx portless get zerostarter); API=$(bunx portless get api.zerostarter)
+WEB=$(bunx portless get zerostarter); API=$(echo "$WEB" | sed 's#://#://api.#')
 curl -sS -c cookies.txt -X POST -H "Origin: $WEB" "$API/api/agents/sign-in-as"
 curl -sS -b cookies.txt "$API/api/v1/user"
 ```

--- a/.agents/skills/ui-verify/SKILL.md
+++ b/.agents/skills/ui-verify/SKILL.md
@@ -11,7 +11,7 @@ A green type-check and clean lint prove the code compiles, not that the page ren
 
 ### 1. Run the stack
 
-Start the dev servers (`dev` skill). Under the default portless dev the base URLs are named and branch-prefixed, so resolve them once: `WEB=$(bunx portless get zerostarter)` and `API=$(bunx portless get api.zerostarter)` (or `PORTLESS=0 bun run dev` for fixed `http://localhost:3000` / `http://localhost:4000`). Done when `$WEB/` returns 200 and `$API/api/health` responds ok.
+Start the dev servers (`dev` skill). Under the default portless dev the base URLs are named and branch-prefixed, so resolve them once: `WEB=$(bunx portless get zerostarter)` and `API=$(echo "$WEB" | sed 's#://#://api.#')` (its api-first sibling; or `PORTLESS=0 bun run dev` for fixed `http://localhost:3000` / `http://localhost:4000`). Done when `$WEB/` returns 200 and `$API/api/health` responds ok.
 
 ### 2. Drive the affected route
 

--- a/.github/scripts/portless-api.ts
+++ b/.github/scripts/portless-api.ts
@@ -4,6 +4,8 @@
 // app's already-prefixed host from `portless get` (which uses portless's own worktree
 // sanitization) and prepend `api.`. PORTLESS=0 skips all of this (fixed ports, no proxy).
 
+export {} // makes this a module so the top-level await type-checks
+
 const cmd = process.argv.slice(2)
 if (cmd.length === 0) {
   console.error("portless-api: no command given")

--- a/.github/scripts/portless-api.ts
+++ b/.github/scripts/portless-api.ts
@@ -1,0 +1,38 @@
+// Launches the api under an explicit, api-first portless name so a worktree resolves at
+// api.<branch>.<web>.localhost, matching the deployed api.<env> layout. portless's explicit-name
+// mode (`portless <name> <cmd>`) does not apply the worktree branch prefix, so we take the web
+// app's already-prefixed host from `portless get` (which uses portless's own worktree
+// sanitization) and prepend `api.`. PORTLESS=0 skips all of this (fixed ports, no proxy).
+
+const cmd = process.argv.slice(2)
+if (cmd.length === 0) {
+  console.error("portless-api: no command given")
+  process.exit(1)
+}
+
+const run = (args: string[]) => {
+  const proc = Bun.spawn(args, { env: process.env, stdio: ["inherit", "inherit", "inherit"] })
+  const stop = () => proc.kill()
+  process.on("SIGINT", stop)
+  process.on("SIGTERM", stop)
+  return proc
+}
+
+if (process.env.PORTLESS === "0") {
+  process.exit((await run(cmd).exited) ?? 1)
+}
+
+// api.<web> -> <web>; convert.ts rebrands `portless.name` for forks, so this stays in sync.
+const { portless } = await Bun.file("package.json").json()
+const webName = String(portless?.name ?? "api").replace(/^api\./, "")
+
+const got = Bun.spawnSync(["portless", "get", webName], { env: process.env, stdout: "pipe" })
+const webUrl = new TextDecoder().decode(got.stdout).trim()
+if (!webUrl) {
+  console.error(`portless-api: could not resolve the web URL via \`portless get ${webName}\``)
+  process.exit(1)
+}
+const nameLabels = new URL(webUrl).hostname.split(".").slice(0, -1)
+const apiName = ["api", ...nameLabels].join(".")
+
+process.exit((await run(["portless", apiName, ...cmd]).exited) ?? 1)

--- a/.github/scripts/portless.ts
+++ b/.github/scripts/portless.ts
@@ -1,12 +1,11 @@
 // Derives each app's public URLs from portless's PORTLESS_URL (worktree branch included) and injects them before spawning the real dev command; a transparent pass-through when PORTLESS_URL is unset (PORTLESS=0, CI).
 
-// Toggle the adjacent `api.` label (it sits just before the two base labels) to get the sibling app's host. Assumes the two-app `<name>` / `api.<name>` naming from the package.json `portless.name`s (convert.ts keeps forks in sync) and a single-label worktree prefix; a branch literally named `api` would be misread as the api host. Update this if that scheme changes.
+// The api host is the web host with a leftmost `api.` label (api-first, the `api.<env>` layout), so the api is a child of each env's web host. Strip or prepend that leftmost label to get the sibling. A branch literally named `api` would be misread as the api host; update this if the naming scheme changes.
 export function deriveUrls(portlessUrl: string): { web: string; api: string } {
   const labels = new URL(portlessUrl).hostname.split(".")
-  const apiIdx = labels.length - 3
-  const isApi = apiIdx >= 0 && labels[apiIdx] === "api"
-  const webLabels = isApi ? labels.toSpliced(apiIdx, 1) : labels
-  const apiLabels = isApi ? labels : labels.toSpliced(labels.length - 2, 0, "api")
+  const isApi = labels[0] === "api"
+  const webLabels = isApi ? labels.slice(1) : labels
+  const apiLabels = isApi ? labels : ["api", ...labels]
   const toOrigin = (host: string[]) => {
     const url = new URL(portlessUrl)
     url.hostname = host.join(".")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Guidance for AI coding agents working in this repository, a Bun monorepo: the `p
 Signs in as `LocalAgent` (`agent@local.host`). The route is gated: set `AGENT_SIGNIN_ENABLED=true` in `.env` first (it is off by default, so the route 404s without it and a deployed default env never exposes it). Then click **Login (agents)** in the dev UI, or use curl:
 
 ```bash
-WEB=$(bunx portless get zerostarter); API=$(bunx portless get api.zerostarter)
+WEB=$(bunx portless get zerostarter); API=$(echo "$WEB" | sed 's#://#://api.#')
 curl -sS -c cookies.txt -X POST -H "Origin: $WEB" "$API/api/agents/sign-in-as"
 curl -sS -b cookies.txt "$API/api/v1/user"
 ```

--- a/api/hono/package.json
+++ b/api/hono/package.json
@@ -12,7 +12,7 @@
     "build": "tsdown && bun build dist/index.mjs --outfile bundle/index.mjs --target bun --minify",
     "build:vercel": "tsdown && bun build dist/index.mjs --outfile vercel-bundle/index.mjs --target bun --minify --external hono",
     "check-types": "tsc --noEmit",
-    "dev": "portless",
+    "dev": "bun ../../.github/scripts/portless-api.ts bun run dev:app",
     "dev:app": "concurrently \"tsdown --watch\" \"bun ../../.github/scripts/portless.ts bun --hot src/index.ts\"",
     "start": "bun bundle/index.mjs"
   },

--- a/packages/auth/src/lib/utils.ts
+++ b/packages/auth/src/lib/utils.ts
@@ -6,7 +6,7 @@
  * getCookieDomain("https://api.canary.example.com")      // ".canary.example.com"
  * getCookieDomain("https://api.dev.example.com")         // ".dev.example.com"
  * getCookieDomain("http://api.zerostarter.localhost")    // ".zerostarter.localhost" (portless dev)
- * getCookieDomain("http://feat.api.zerostarter.localhost") // ".zerostarter.localhost" (portless worktree)
+ * getCookieDomain("http://api.feat.zerostarter.localhost") // ".zerostarter.localhost" (portless worktree)
  * getCookieDomain("http://localhost:4000")               // undefined
  */
 export function getCookieDomain(url: string): string | undefined {
@@ -33,7 +33,7 @@ export function getCookieDomain(url: string): string | undefined {
  * getCookiePrefix("https://api.example.com")             // undefined (production, uses default)
  * getCookiePrefix("https://api.canary.example.com")      // "canary"
  * getCookiePrefix("https://api.dev.example.com")         // "dev"
- * getCookiePrefix("http://feat.api.zerostarter.localhost") // undefined (local dev, no prefix)
+ * getCookiePrefix("http://api.feat.zerostarter.localhost") // undefined (local dev, no prefix)
  * getCookiePrefix("http://localhost:4000")               // undefined
  */
 export function getCookiePrefix(url: string): string | undefined {

--- a/packages/cli/test/portless.test.ts
+++ b/packages/cli/test/portless.test.ts
@@ -17,17 +17,17 @@ test("deriveUrls toggles the api label from the api host (main checkout)", () =>
   })
 })
 
-// Worktree: the branch name prefixes each host as the leftmost label.
+// Worktree (api-first): web `feat.zerostarter.localhost`, api `api.feat.zerostarter.localhost`.
 test("deriveUrls handles the branch-prefixed web host (worktree)", () => {
   expect(deriveUrls("http://feat.zerostarter.localhost:1355")).toEqual({
     web: "http://feat.zerostarter.localhost:1355",
-    api: "http://feat.api.zerostarter.localhost:1355",
+    api: "http://api.feat.zerostarter.localhost:1355",
   })
 })
 
 test("deriveUrls handles the branch-prefixed api host (worktree)", () => {
-  expect(deriveUrls("http://feat.api.zerostarter.localhost:1355")).toEqual({
+  expect(deriveUrls("http://api.feat.zerostarter.localhost:1355")).toEqual({
     web: "http://feat.zerostarter.localhost:1355",
-    api: "http://feat.api.zerostarter.localhost:1355",
+    api: "http://api.feat.zerostarter.localhost:1355",
   })
 })

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -53,7 +53,7 @@ See [AI Skills](/docs/resources/ai-skills) for the full catalog and how to write
 Testing anything behind auth normally means an OAuth round-trip an agent can't complete. ZeroStarter ships a **local-only** sign-in that returns a real session in one request. `bunx zerostarter init` sets `AGENT_SIGNIN_ENABLED=true` for you, so the route is already live; if you cloned the repo instead, set `AGENT_SIGNIN_ENABLED=true` in `.env` first (it is off by default, so the route stays unmounted until you opt in):
 
 ```bash
-WEB=$(bunx portless get zerostarter); API=$(bunx portless get api.zerostarter)
+WEB=$(bunx portless get zerostarter); API=$(echo "$WEB" | sed 's#://#://api.#')
 curl -sS -c cookies.txt -X POST -H "Origin: $WEB" "$API/api/agents/sign-in-as"
 curl -sS -b cookies.txt "$API/api/v1/user"   # now authenticated
 ```


### PR DESCRIPTION
Flips the **worktree** portless api URL from env-first (`<branch>.api.<web>.localhost`) to **api-first** (`api.<branch>.<web>.localhost`), so local dev mirrors the deployed `api.<env>` layout (e.g. `api.canary.zerostarter.dev`) canary just reverted to. In both, the api is a child of each env's web host and the env-scoped cross-subdomain cookie isolates cleanly.

## What changed

**Mechanism**
- `deriveUrls` (`.github/scripts/portless.ts`): the api host is the web host with a leftmost `api.` label (was a trailing `.api` insert).
- `.github/scripts/portless-api.ts` (new): launches the api under an explicit api-first portless name. portless's explicit-name mode skips the worktree branch prefix, so it takes the web app's already-prefixed `portless get` host and prepends `api.`. `PORTLESS=0` passes straight through to fixed ports.
- `api/hono` dev runs through that wrapper. `convert.ts` needs no change: it rebrands `portless.name` to `api.<slug>`, which the wrapper strips back to `<slug>` to resolve the web host.

**Docs** — the blocker was that `bunx portless get api.zerostarter` computes the config-name URL (`<branch>.api.<web>`), which is **not** where the api is served. Every agent-login / endpoint-test snippet now derives the api from the web URL instead:

```bash
WEB=$(bunx portless get zerostarter); API=$(echo "$WEB" | sed 's#://#://api.#')
```

Updated across `AGENTS.md`, the `dev` / `api-endpoint` / `ui-verify` skills, and `working-with-agents.mdx`; refreshed the `getCookieDomain` / `getCookiePrefix` worktree examples to the api-first host. `setup.mdx` already used `api.<name>` and needed nothing.

## Verification (branch `feat/portless-api-env`)

- `portless list`: api served at `http://api.portless-api-env.zerostarter.localhost:1355` → `/api/health` returns 200.
- The doc-form derivation resolves to that exact served host; the old `portless get api.zerostarter` returned the unserved `portless-api-env.api.zerostarter.localhost`.
- **Auth e2e** over the api-first URL: sign-in sets the session cookie on the shared `.zerostarter.localhost` domain, and `$API/api/v1/user` returns `LocalAgent` (role admin).
- `bun test packages/cli/test/portless.test.ts`: 4 pass. `check-types`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API-first local development support with automatic API host resolution and graceful process shutdown.
  * Added a direct execution fallback when proxying is disabled.

* **Bug Fixes**
  * Updated local worktree URL handling to consistently use the `api.<branch>` hostname format.

* **Documentation**
  * Updated agent sign-in instructions and authentication examples to use the revised API URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->