### PR TITLE
feat(auth): derive cookie config from a build-generated tldts breakdown (@packages/scripts)

### DIFF
--- a/.agents/skills/add-package/SKILL.md
+++ b/.agents/skills/add-package/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: add-package
+description: Add a new shared workspace package under packages/*. Use when creating a new @packages/<name>, whether a bundled library other workspaces import or a build-only script package that runs during a build.
+---
+
+# Add a Package
+
+Workspaces are globbed as `api/*`, `packages/*`, `web/*` (root `package.json`). A new shared package lives at `packages/<name>/` and is named `@packages/<name>`. Every package shares one shape; copy an existing sibling, do not invent a new layout.
+
+## Pick the shape
+
+- **Library** (`env`, `db`, `auth`, `config`): built with tsdown to `dist/`, imported by other workspaces via an `exports` map. Use when code is consumed at runtime.
+- **Build-only script** (`scripts`): never bundled, never imported at runtime. Its `.ts` files run via `bun src/<x>.ts` during another package's build (e.g. `@packages/auth`'s `build` runs `bun ../scripts/src/generate-tldts.ts` first). Use for build-time codegen. Keep CI/repo tooling in `.github/scripts` instead; `packages/scripts` is for app-build tooling that needs workspace deps.
+
+## Common skeleton (both shapes)
+
+```
+packages/<name>/
+├── package.json
+├── tsconfig.json
+└── src/
+    └── index.ts        # source under src/, imported via @/ (a build-only script names its entry by function, e.g. generate-tldts.ts, not index.ts)
+```
+
+`package.json` fields shared by every package:
+
+```jsonc
+{
+  "name": "@packages/<name>",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@packages/config": "workspace:*",
+    "@types/bun": "catalog:",
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}
+```
+
+`@packages/config` MUST be a devDependency: `tsconfig.json` extends it, and without the dep the `extends` cannot resolve. Keep deps and `exports` alphabetical (A→Z); catalog-versioned deps use `"catalog:"`, workspace deps use `"workspace:*"`.
+
+`tsconfig.json` (identical to `env`/`db`/`auth`):
+
+```json
+{
+  "extends": "@packages/config/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+## Library shape (adds to the skeleton)
+
+```jsonc
+{
+  // ...skeleton...
+  "files": ["dist"],
+  "exports": {
+    ".": { "types": "./dist/index.d.mts", "default": "./dist/index.mjs" }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": { /* runtime deps */ },
+  "devDependencies": {
+    "@packages/config": "workspace:*",
+    "@types/bun": "catalog:",
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
+  }
+}
+```
+
+Add one export entry per `entry` file. `tsdown.config.ts` uses the shared helper (validates env in `build:prepare`, emits tsgo dts, minifies):
+
+```ts
+import { definePackageConfig } from "@packages/config/tsdown"
+import { getSafeEnv } from "@packages/env"
+import { env } from "@packages/env/<name>"
+
+export default definePackageConfig({
+  name: "@packages/<name>",
+  env,
+  getSafeEnv,
+})
+```
+
+A package with no env of its own can pass another package's `env`/`getSafeEnv`, or (like `env` itself) call `defineConfig` from tsdown directly. `turbo.json`'s `build.outputs` already lists `dist/**`, so no turbo edit is needed.
+
+## Build-only script shape (adds to the skeleton)
+
+No `build`, no `exports`, no `files`, no `tsdown`. Add only the script's own tool deps (e.g. `tldts`) as devDependencies. Because the entry is a Bun script using `Bun.*` / `import.meta.dir` / `node:*`, the native tsc preview (tsgo) does not auto-include `@types/*` for it, so pin `types: ["bun"]` exactly as `packages/cli` (the repo's other Bun package) and `.github/scripts/tsconfig.json` do:
+
+```json
+{
+  "extends": "@packages/config/tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}
+```
+
+`types: ["bun"]` is the only line that differs from a library's tsconfig; `bun-types` pulls in the node references, so `@types/node` stays a devDep but needs no separate `types` entry. The consumer runs it in its own `build`, e.g. `"build": "bun ../<name>/src/<script>.ts && tsdown"` (a `bun <path>` sibling-script call, the same pattern `web/next` and `api/hono` use for `.github/scripts/*.ts`), and declares `"@packages/<name>": "workspace:*"` as a devDependency so `turbo prune` keeps it in the Docker build. Invoke it from the consumer's directory (the `bun ../<name>/...` form), not the repo root: a script that reads env via `@packages/env` inherits its cwd-relative `.env` load (`cwd/../../.env`), so running it from root silently misses `.env`.
+
+Write any generated artifact to the repo-root `.generated/` dir (gitignored, dockerignored, and removed by `bun run clean`), not inside a package. `.generated/` is the one centralized home for generated-but-disposable files the build consumes; keep individual packages free of committed-or-not `*.generated.*` files. When you add a new generated artifact type, add it to `.gitignore`/`.dockerignore` and `.github/scripts/clean.sh` together.
+
+## Wire it up
+
+1. `bun install` from the repo root to link the new workspace (fresh worktrees also need this before the pre-commit build; set `NODE_ENV=production SKIP_ENV_VALIDATION=true`).
+2. In each consumer, add `"@packages/<name>": "workspace:*"` (a runtime `dependency` for a library, a `devDependency` for a build-only package) and import via `@packages/<name>` (or a subpath export).
+3. Runtime code follows the `runtime-apis` skill: Bun-native APIs where they exist, else `node:`-prefixed built-ins.
+4. Verify: `bunx turbo run check-types build test` is green and the new package appears in the run.
+
+## Keep docs in sync
+
+Adding a package touches the map. In the same change, update: the `packages/*` list in `AGENTS.md`/`CLAUDE.md`; both structure trees, `README.md` (`## Monorepo Structure`) and `web/next/content/docs/getting-started/project-structure.mdx` (its frontmatter/intro package count, the tree, and the "The packages" list); the `codebase-map` skill; and any skill whose globs name package paths (e.g. `runtime-apis`). A fork keeps build-only packages like `scripts` (unlike `cli`, which `init` strips), so they belong in the user-facing trees too. See the `doc-sync` skill.
+
+## Gotchas
+
+- Missing `@packages/config` devDep → `tsconfig extends` fails to resolve. It is a dep, not just a base file.
+- A Bun-script package without `types: ["bun"]` fails `check-types` with `Cannot find name 'Bun'` / `'node:...'` under tsgo, even though the identical library config auto-includes fine. Pin `types` for script packages only.
+- Keep `exports`, `entry`, and dependency lists alphabetical so they match their docs (`order-lists-alphabetically`).

--- a/.agents/skills/codebase-map/SKILL.md
+++ b/.agents/skills/codebase-map/SKILL.md
@@ -8,12 +8,14 @@ description: Orient in this repo: which file to edit for a change, how a change 
 One Bun + Turborepo monorepo: two deployable apps over shared packages. Imports use `@api/hono`, `@packages/*`, and the `@/` alias, never deep relative paths.
 
 ```
+.generated/       # repo-root home for build-time generated assets (gitignored)
 api/hono/         # backend (Hono): routers, middlewares, the AppType export
 web/next/         # frontend (Next.js App Router): app/, components/, lib/, content/
 packages/auth/    # Better Auth instance
 packages/db/      # Drizzle schema + client
 packages/env/     # type-safe env, one validated entry per consumer
 packages/config/  # TS base, tsdown factory, and site.ts (brand identity)
+packages/scripts/ # build-only bun tooling (e.g. generate-tldts); never bundled
 packages/cli/     # the zerostarter scaffolding CLI (canonical repo only; init strips it)
 ```
 

--- a/.agents/skills/runtime-apis/SKILL.md
+++ b/.agents/skills/runtime-apis/SKILL.md
@@ -23,7 +23,7 @@ The prefix is mandatory even in Bun-only code: it marks the import as a built-in
 | `packages/env/**` | Node + Bun | `node:` only. Imported by both web (Node) and api (Bun); stays portable. |
 | `.github/workflows/*` (`actions/github-script`) | Node | `require("node:...")`. |
 
-Bun-first applies to Bun-only files: `.github/scripts/*.ts` (`bun x.ts`). The CLI test files run under `bun test` but mirror the CLI's `node:` style on purpose.
+Bun-first applies to Bun-only files: `.github/scripts/*.ts` and `packages/scripts/src/*.ts` (`bun x.ts`). The CLI test files run under `bun test` but mirror the CLI's `node:` style on purpose.
 
 ## Bun equivalents
 

--- a/.agents/skills/runtime-apis/index.md
+++ b/.agents/skills/runtime-apis/index.md
@@ -1,7 +1,7 @@
 # Node API index
 
 Per-file inventory of every Node built-in used in the repo, for the [`runtime-apis`](SKILL.md) skill.
-Snapshot: 2026-07-11. Regenerate with the `rg "node:..."` command in `SKILL.md`.
+Snapshot: 2026-07-17. Regenerate with the `rg "node:..."` command in `SKILL.md`.
 
 The `Runtime` column drives the rule: **Node** and **Both** files stay on `node:` (no `Bun.*`);
 **Bun** files may move a call to a `Bun.*` equivalent where one exists.
@@ -13,6 +13,7 @@ The `Runtime` column drives the rule: **Node** and **Both** files stay on `node:
 | `.github/scripts/ensure-remote-branches.ts` | Bun | `node:child_process` (execFileSync) |
 | `.github/scripts/shadcn-customize.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (readFileSync, writeFileSync) |
 | `.github/workflows/auto-labeler.yml` | Node | `node:fs`, `node:path` (via `require`, `actions/github-script`) |
+| `packages/auth/tsdown.config.ts` | Build | `node:fs` (existsSync, readFileSync); `node:path` (resolve) |
 | `packages/cli/bin/commands/_args.ts` | Node | `node:util` (parseArgs, ParseArgsConfig) |
 | `packages/cli/bin/commands/_bun.ts` | Node | `node:os` (homedir); `node:path` (delimiter, join) |
 | `packages/cli/bin/commands/_prompt.ts` | Node | `node:readline/promises` (createInterface) |
@@ -30,6 +31,7 @@ The `Runtime` column drives the rule: **Node** and **Both** files stay on `node:
 | `packages/cli/test/io.test.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (mkdirSync, mkdtempSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
 | `packages/env/src/lib/utils.ts` | Both | `node:path` (path) |
 | `packages/env/tsdown.config.ts` | Build | `node:child_process` (execSync) |
+| `packages/scripts/src/generate-tldts.ts` | Bun | `node:path` (resolve) |
 | `web/next/src/app/layout.tsx` | Node | `node:fs` (existsSync); `node:path` (join) |
 
 ## Convertible to `Bun.*` (optional, Bun-only files)

--- a/.dockerignore
+++ b/.dockerignore
@@ -41,6 +41,7 @@ yarn-error.log*
 next-env.d.ts
 
 # custom directories
+.generated/
 .playwright-cli/
 .source/
 .turbo/

--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -10,6 +10,7 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 
 - [TanStack Start migration](tanstack-start-migration.md) - complete and verified locally, blocked on the Vercel Bun-runtime deploy (#650).
 - [Hardening refactors from the external evaluation](hardening-refactors.md) - gate the agent sign-in behind an explicit secret, read the auth secret directly, and gate tests + check-types in PR CI.
+- [Auth cookie derivation from a build-generated tldts breakdown](env-derived-tldts.md) - a `@packages/scripts` build step writes the parse to a gitignored JSON, auth bakes it via tsdown `define` (tldts stays out of the runtime bundle) and reconciles `{ cookieDomain, cookiePrefix, isPrivate }` via one `cookieConfig` (`feat/tldts-cookie-domain`, PR #723).
 
 ## Planned
 

--- a/.github/notes/plans/env-derived-tldts.md
+++ b/.github/notes/plans/env-derived-tldts.md
@@ -1,0 +1,70 @@
+# Auth cookie derivation from a build-generated tldts breakdown
+
+**Status:** in progress on `feat/tldts-cookie-domain` (PR #723).
+
+**Scope:** canary only. Independent of the `feat/split-deploy-auth` branch; the `isPrivate` signal is computed from tldts's PSL, not that branch's curated set.
+
+**Not split-deploy:** `SameSite=None` on a hosting suffix only sets cookie attributes. Safari blocks third-party cookies, so a `*.vercel.app` deploy of this branch alone still cannot complete cross-origin OAuth without that branch's nonce handoff (`skipStateCookieCheck`). `isPrivate` mode is not "split-deploy solved".
+
+## Problem
+
+On canary the auth cookie values come from two functions in `packages/auth/src/lib/utils.ts` that hand-roll `split(".")` index math on `HONO_APP_URL`. That misses multi-level public suffixes (`co.uk`, `com.au`) and private hosting suffixes (`vercel.app`), which genuinely need the Public Suffix List. Bundling tldts to parse one host at boot, however, adds ~125 KB (its full PSL) to the api server bundle.
+
+## Approach
+
+Run tldts **once at build time in a dedicated scripts package**, write the small result, and bake only that into auth.
+
+- **`@packages/scripts`** is a new private workspace package for app-build tooling. Nothing imports it at runtime, so it never ships. It follows the same shape as the other `packages/*` (source under `src/`, `tsconfig.json` extends `@packages/config/tsconfig.json`, `check-types` runs `tsc --noEmit`), and owns `src/generate-tldts.ts` plus its `@packages/config` + `@packages/env` + `tldts` devDependencies. The script reads `env.HONO_APP_URL` from `@packages/env` (reusing its env loading, no separate dotenv), runs `parse(url, { allowPrivateDomains: true })`, and writes the repo-root `.generated/tldts.json` (gitignored). `.github/scripts` stays for CI/repo tooling only.
+- **`@packages/auth` build runs it first:** `"build": "bun ../scripts/src/generate-tldts.ts && tsdown"`, and declares `@packages/scripts` as a devDependency so `turbo prune` keeps it in the Docker build.
+- **`@packages/auth/tsdown.config.ts`** reads that JSON and injects it via tsdown `define` as `__DERIVED_TLDTS__`. `definePackageConfig` gained an optional `define` passthrough for this (harmless to db/api).
+- **`@packages/auth/src/index.ts`** reads the ambient constant directly and runs one `cookieConfig(tldts)` → `{ cookieDomain, cookiePrefix, isPrivate }`; the `advanced` block switches cookie mode on `isPrivate`.
+
+`@packages/env` stays plain: just `createEnv(...)`, no `derived` pass-through. The runtime carries only the ~200-byte parse result, and `co.uk`/`vercel.app` are fully correct because the real PSL runs in the script (e.g. `api.example.co.uk` → `cookieDomain: ".example.co.uk"`, `cookiePrefix: undefined`).
+
+### Why a scripts package (not the tsdown config, not env, not .github/scripts)
+
+- Loading env inside a build config is a bad smell, and the tsdown config loader can't cleanly import the runtime's loader.
+- The generated value has one consumer (auth), so it belongs in auth, not routed through an `env.derived` export.
+- A repo-level `.github/scripts` file can't resolve workspace-scoped deps cleanly and mixes CI tooling with app-build tooling. A workspace package resolves `@packages/env` + `tldts`, is never bundled, and keeps build-only deps off the root.
+
+### Build-time env + trade-off
+
+`generate-tldts.ts` reads `HONO_APP_URL` from `@packages/env`, which loads it the same dual way at build: `process.env` on Vercel (build env), or the `.env` the Docker build mounts as a required secret (env's own dotenv). Cache-invalidation covers both sources: `turbo.json` lists `HONO_APP_URL` in `globalEnv` (catches the process-env case) plus `.env*` in `globalDependencies`, so a changed URL, whether in `.env` or an `.env.<mode>` override (the env package loads `.env.${NODE_ENV}` with `override: true`), re-hashes the build even when it lives only in a file (local/Docker). It stays global rather than scoped to `@packages/auth#build` because `.env` also feeds web's baked `NEXT_PUBLIC_*`; a repo-wide re-hash on the rare `.env` edit is simpler and can't silently miss a future env-baking build. A generator change is already caught by turbo's workspace graph (auth depends on `@packages/scripts`, so its source feeds auth's build hash), verified with a cache-miss test, so it needs no global entry. Docker's own layer cache is separate: BuildKit excludes the mounted `.env` secret from its cache key, so a `.env` change needs `docker compose build --no-cache` (called out in the Docker guide). Trade-off: the artifact's cookie config is baked to the build-time `HONO_APP_URL`, as the web already bakes `NEXT_PUBLIC_*`; the standard flows match (Vercel per-deploy, docker-compose shares one `.env`).
+
+### Where generated assets live: `.generated/`
+
+The breakdown is written to a single repo-root `.generated/tldts.json`, not to a file inside `@packages/auth`. Generated, disposable artifacts that the build consumes but that are not final build outputs get one centralized, gitignored home rather than scattering `*.generated.*` files across packages.
+
+Name choice, against common web/monorepo conventions:
+
+- **Dot-prefixed** to match the repo's existing tool-managed, gitignored dirs (`.next`, `.source`, `.turbo`), signalling "generated, not hand-edited, safe to delete."
+- **`generated` over `.cache`** because the contents are a required build input regenerated on every build, not a performance cache that is safe to blow away for only a speed cost. Calling it a cache would mislead.
+- A no-dot **`generated/`** was rejected: that convention usually denotes _committed_ codegen, the opposite of a gitignored throwaway.
+
+`.generated/` is gitignored and dockerignored as a directory, and `bun run clean` (`.github/scripts/clean.sh`) removes it. The script now covers the build-generated set (was missing `.generated`, `vercel-bundle`, `coverage`, `.playwright-cli`, the generated `meta.json`, and `.d.ts`) and leaves user config and secrets alone (`.env*`, `.npmrc`, `.vercel`, and unused `out/`/`build/`).
+
+## Changes
+
+Relative to `canary`:
+
+- **New** `packages/scripts/` (`package.json`, `tsconfig.json`, `src/generate-tldts.ts`), a build-only workspace package that mirrors the standard `packages/*` shape (extends the shared `@packages/config/tsconfig.json`, `src/` layout), with `types: ["bun"]` pinned for the Bun-script entry, matching `packages/cli` (the repo's other Bun package) and `.github/scripts/tsconfig.json`.
+- `tldts` added to the root catalog and to `@packages/scripts` devDependencies (alongside `@packages/config`, `@packages/env`, `@types/bun`, `@types/node`, `typescript`); `dotenv` is unchanged (an existing `@packages/env` dependency the script reuses through the env package).
+- `packages/config/tsdown.ts`: `definePackageConfig` gains an optional `define`.
+- `turbo.json`: `.env*` added to `globalDependencies` so the auth (and web `NEXT_PUBLIC_*`) build cache invalidates on any env-file change including `.env.<mode>` overrides (`globalEnv` alone only sees `process.env`; a generator change is already caught via the `@packages/scripts` workspace dependency).
+- `@packages/auth`: build runs `generate-tldts` first (with `@packages/scripts` as a devDep); `tsdown.config.ts` inlines the JSON via `define`; `index.ts` reads the ambient `ParsedHost`; the hand-rolled `getCookieDomain`/`getCookiePrefix` collapse into one `cookieConfig` plus the `isPrivate` cookie-mode switch.
+- `@packages/env` is untouched (plain `createEnv`).
+- Generated output centralized at repo-root `.generated/tldts.json`; `.generated/` added to `.gitignore`, `.dockerignore`, and `.github/scripts/clean.sh` (which is also brought up to date with the rest of the generated set).
+
+## Behavior
+
+Custom-domain and `.localhost` hosts unchanged. Hosting suffixes (`vercel.app`, `pages.dev`, `github.io`) → `cookieDomain: undefined` (host-only) + `SameSite=None`, where canary emitted the browser-rejected `.vercel.app`. ccTLD apex → host-only; IP literals → host-only. A host with no shareable parent (apex API URL, bare `localhost`, IP) keeps the `cookieDomain &&` guard, so Better Auth stays host-only rather than widening to `Domain=<hostname>`.
+
+## Verification
+
+- Full turbo build (all 8 packages) + `check-types` (incl. `@packages/scripts`) green; `bun test` in `@packages/auth` passes (cookieConfig). `@packages/env/dist/auth.mjs` clean (no `derived`, no tldts); `@packages/auth/dist/index.mjs` carries only the baked breakdown; api bundle **1.43 MB** (canary size, no PSL).
+- Script sourcing verified: with `HONO_APP_URL` only in a `.env` file (shell var unset), the script wrote the correct `api.zerostarter.dev` breakdown and it baked into `auth/dist`.
+- `packages/auth/test/utils.test.ts` covers `cookieConfig` across production subdomains, `.localhost` (main + worktree), ccTLD apex/subdomain, hosting suffixes, IPs, and the null-host fallback.
+
+## Doc-sync
+
+- `.env.example` unchanged: `HONO_APP_URL` already documented; the breakdown is generated from it.

--- a/.github/scripts/clean.sh
+++ b/.github/scripts/clean.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
 
+# Remove generated, disposable artifacts (build outputs, caches, codegen) tracked in .gitignore so `bun run clean` gives a fresh tree; user config and secrets stay.
 bunx rimraf --glob \
+  "**/*.tsbuildinfo" \
+  "**/.generated" \
   "**/.next" \
+  "**/.playwright-cli" \
   "**/.source" \
   "**/.turbo" \
   "**/bundle" \
+  "**/coverage" \
   "**/dist" \
-  "**/node_modules" \
   "**/next-env.d.ts" \
-  "**/tsconfig.tsbuildinfo"
+  "**/node_modules" \
+  "**/vercel-bundle" \
+  ".github/scripts/*.d.ts" \
+  "web/next/content/blog/meta.json" \
+  "web/next/content/console/docs/meta.json" \
+  "web/next/content/docs/meta.json"

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ yarn-error.log*
 next-env.d.ts
 
 # custom directories
+.generated/
 .playwright-cli/
 .source/
 .turbo/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in this repository, a Bun monorepo: the `packages/cli` npm binary, the `web/next` app, the `api/hono` service, and shared `packages/*` (auth, config, db, env). Start each task with the `codebase-map` skill to orient, then load the task skill that fits (see [Skills](#skills)).
+Guidance for AI coding agents working in this repository, a Bun monorepo: the `packages/cli` npm binary, the `web/next` app, the `api/hono` service, and shared `packages/*` (auth, config, db, env), with build-only tooling in `packages/scripts`. Start each task with the `codebase-map` skill to orient, then load the task skill that fits (see [Skills](#skills)).
 
 ## Workflow
 
@@ -52,6 +52,7 @@ Skills live in `.agents/skills` (symlinked to `.claude/skills` and `.github/skil
 
 | Skill          | Description                                                                                                              |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `add-package`  | Add a shared workspace package under `packages/*` (library or build-only script), matching the standard shape.           |
 | `api-endpoint` | Add a typed Hono API endpoint or WebSocket route: router, OpenAPI docs, validation envelope, and RPC client wiring.      |
 | `audit`        | Run the dependency security audit and maintain `.github/notes/dependencies.md`.                                          |
 | `codebase-map` | Orient in this repo: which file to edit for a change, how a change ripples across the stack, and how to search the code. |

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ Every item below is wired and working out of the box, not just a dependency in `
     ├── auth/      # Better Auth instance (OAuth, organizations, teams, admin)
     ├── db/        # Drizzle ORM schema and PostgreSQL client
     ├── env/       # Type-safe environment variables (t3-oss/env + Zod)
-    └── config/    # Shared config: TS/tsdown bases and the `site` brand identity
+    ├── config/    # Shared config: TS/tsdown bases and the `site` brand identity
+    └── scripts/   # Build-only tooling (e.g. tldts generation); never bundled
 ```
 
-Two deployable apps (`api/hono` and `web/next`) and four shared packages. Brand identity lives in one place, `@packages/config/site`, so a fork rebrands by editing a single file.
+Two deployable apps (`api/hono` and `web/next`) and shared `packages/*` (auth, config, db, env, scripts). Brand identity lives in one place, `@packages/config/site`, so a fork rebrands by editing a single file.
 
 📖 **[Full project structure →](https://zerostarter.dev/docs/getting-started/project-structure)**
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
       },
       "devDependencies": {
         "@packages/config": "workspace:*",
+        "@packages/scripts": "workspace:*",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "tsdown": "catalog:",
@@ -123,6 +124,18 @@
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
         "tsdown": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
+    "packages/scripts": {
+      "name": "@packages/scripts",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@packages/config": "workspace:*",
+        "@packages/env": "workspace:*",
+        "@types/bun": "catalog:",
+        "@types/node": "catalog:",
+        "tldts": "catalog:",
         "typescript": "catalog:",
       },
     },
@@ -272,6 +285,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.2",
     "takumi-js": "^2.0.2",
+    "tldts": "^7.4.9",
     "ts-morph": "^28.0.0",
     "tsdown": "^0.22.4",
     "turbo": "^2.10.4",
@@ -703,6 +717,8 @@
     "@packages/db": ["@packages/db@workspace:packages/db"],
 
     "@packages/env": ["@packages/env@workspace:packages/env"],
+
+    "@packages/scripts": ["@packages/scripts@workspace:packages/scripts"],
 
     "@posthog/core": ["@posthog/core@1.40.1", "", { "dependencies": { "@posthog/types": "^1.393.0" } }, "sha512-jXuMtZCwA7AMpYlo1wjm6GlC58YBlz/ZxpDIsF9hroUfqYoPPDmQbsQb4iiZAS43+o/kwloxdKJIlE0IiwQ5HQ=="],
 
@@ -2173,6 +2189,10 @@
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "tldts": ["tldts@7.4.9", "", { "dependencies": { "tldts-core": "^7.4.9" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA=="],
+
+    "tldts-core": ["tldts-core@7.4.9", "", {}, "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.2",
     "takumi-js": "^2.0.2",
+    "tldts": "^7.4.9",
     "ts-morph": "^28.0.0",
     "tsdown": "^0.22.4",
     "turbo": "^2.10.4",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -9,7 +9,7 @@
   "types": "./dist/index.d.mts",
   "exports": "./dist/index.mjs",
   "scripts": {
-    "build": "tsdown",
+    "build": "bun ../scripts/src/generate-tldts.ts && tsdown",
     "check-types": "tsc --noEmit",
     "test": "bun test"
   },
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@packages/config": "workspace:*",
+    "@packages/scripts": "workspace:*",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
     "tsdown": "catalog:",

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -19,10 +19,11 @@ import {
   organization as organizationPlugin,
 } from "better-auth/plugins"
 
-import { getCookieDomain, getCookiePrefix } from "@/lib/utils"
+import { cookieConfig, type ParsedHost } from "@/lib/utils"
 
-const cookieDomain = getCookieDomain(env.HONO_APP_URL)
-const cookiePrefix = getCookiePrefix(env.HONO_APP_URL)
+// The app host's tldts breakdown, inlined at build by @packages/scripts/src/generate-tldts.ts (see tsdown.config.ts define), so no Public Suffix List ships at runtime.
+declare const __DERIVED_TLDTS__: ParsedHost
+const { cookieDomain, cookiePrefix, isPrivate } = cookieConfig(__DERIVED_TLDTS__)
 
 export type SocialProvider = "github" | "google"
 export type AuthProvider = SocialProvider | "magic-link"
@@ -75,13 +76,24 @@ export const auth = betterAuth({
       : {}),
   },
   advanced: {
+    // The environment name-prefix isolates cookie names across envs; it applies independent of the cookie-mode switch below (a private-suffix env would still want it).
     ...(cookiePrefix && { cookiePrefix }),
-    ...(cookieDomain && {
-      crossSubDomainCookies: {
-        enabled: true,
-        domain: cookieDomain,
-      },
-    }),
+    // On a hosting suffix (tldts isPrivate) sibling origins cannot share a Domain cookie, so send SameSite=None; otherwise scope a cross-subdomain cookie to the derived domain when there is one. A host with no shareable parent (apex, bare localhost, IP) stays host-only rather than letting Better Auth widen to Domain=<hostname>.
+    ...(isPrivate
+      ? {
+          defaultCookieAttributes: {
+            sameSite: "none" as const,
+            secure: true,
+          },
+        }
+      : cookieDomain
+        ? {
+            crossSubDomainCookies: {
+              enabled: true,
+              domain: cookieDomain,
+            },
+          }
+        : {}),
   },
 })
 

--- a/packages/auth/src/lib/utils.ts
+++ b/packages/auth/src/lib/utils.ts
@@ -1,52 +1,32 @@
-/**
- * Extracts the cookie domain from a URL for cross-subdomain cookie sharing.
- *
- * @example
- * getCookieDomain("https://api.example.com")             // ".example.com"
- * getCookieDomain("https://api.canary.example.com")      // ".canary.example.com"
- * getCookieDomain("https://api.dev.example.com")         // ".dev.example.com"
- * getCookieDomain("http://api.zerostarter.localhost")    // ".zerostarter.localhost" (portless dev)
- * getCookieDomain("http://feat.api.zerostarter.localhost") // ".zerostarter.localhost" (portless worktree)
- * getCookieDomain("http://localhost:4000")               // undefined
- */
-export function getCookieDomain(url: string): string | undefined {
-  try {
-    const { hostname } = new URL(url)
-    if (hostname === "localhost" || hostname === "127.0.0.1") return undefined
-    const parts = hostname.split(".")
-    // Local dev (portless *.localhost): share the cookie across the base `<name>.localhost` so the web and api subdomains, branch-prefixed in a worktree, both receive it.
-    if (parts.at(-1) === "localhost") {
-      return parts.length >= 2 ? `.${parts.slice(-2).join(".")}` : undefined
-    }
-    if (parts.length <= 2) return undefined
-    return `.${parts.slice(1).join(".")}`
-  } catch {
-    return undefined
-  }
+// The tldts fields (parsed with allowPrivateDomains) auth reads to shape session cookies; a structural subset of tldts's result, baked into the bundle so @packages/auth carries no tldts dependency of its own.
+export type ParsedHost = {
+  domain: string | null
+  isIp: boolean
+  isPrivate: boolean | null
+  publicSuffix: string | null
+  subdomain: string | null
 }
 
-/**
- * Extracts the cookie prefix from a URL for environment-specific cookie isolation.
- * Returns undefined for production (uses Better Auth default prefix).
- *
- * @example
- * getCookiePrefix("https://api.example.com")             // undefined (production, uses default)
- * getCookiePrefix("https://api.canary.example.com")      // "canary"
- * getCookiePrefix("https://api.dev.example.com")         // "dev"
- * getCookiePrefix("http://feat.api.zerostarter.localhost") // undefined (local dev, no prefix)
- * getCookiePrefix("http://localhost:4000")               // undefined
- */
-export function getCookiePrefix(url: string): string | undefined {
-  try {
-    const { hostname } = new URL(url)
-    if (hostname === "localhost" || hostname === "127.0.0.1") return undefined
-    const parts = hostname.split(".")
-    // Local dev (portless *.localhost): no env prefix; branches share one cookie under `<name>.localhost` and there is no cross-branch boundary to isolate.
-    if (parts.at(-1) === "localhost") return undefined
-    // 4+ parts means environment subdomain: api.canary.example.com
-    if (parts.length >= 4) return parts[1]
-    return undefined
-  } catch {
-    return undefined
+// Reconcile the app host's tldts breakdown into the session cookie config, plus tldts's own isPrivate flag passed through.
+export function cookieConfig({ domain, isIp, isPrivate, publicSuffix, subdomain }: ParsedHost): {
+  cookieDomain?: string
+  cookiePrefix?: string
+  isPrivate: boolean | null
+} {
+  // Cross-subdomain cookie domain: a portless *.localhost base shares under its own domain, otherwise drop the api leaf label and scope to the rest. None for an IP, or a bare or apex host with nothing to share under.
+  let cookieDomain: string | undefined
+  if (!isIp && domain) {
+    if (publicSuffix === "localhost") cookieDomain = `.${domain}`
+    else if (subdomain) cookieDomain = `.${[...subdomain.split(".").slice(1), domain].join(".")}`
   }
+
+  // Environment isolation prefix: the label beneath the api leaf (api.canary.example.com yields canary). None for local .localhost dev and single-label subdomains.
+  let cookiePrefix: string | undefined
+  if (publicSuffix !== "localhost" && subdomain) {
+    const labels = subdomain.split(".")
+    if (labels.length >= 2) cookiePrefix = labels[1]
+  }
+
+  // isPrivate is tldts's own flag, passed through: true when the app sits on a PSL private-section hosting suffix (vercel.app, pages.dev, github.io), where sibling deployments cannot share a cross-subdomain cookie. Null for an IP.
+  return { cookieDomain, cookiePrefix, isPrivate }
 }

--- a/packages/auth/test/utils.test.ts
+++ b/packages/auth/test/utils.test.ts
@@ -1,40 +1,129 @@
 import { expect, test } from "bun:test"
 
-import { getCookieDomain, getCookiePrefix } from "@/lib/utils"
+import { cookieConfig, type ParsedHost } from "@/lib/utils"
 
-test("getCookieDomain scopes the cookie to the environment subdomain in production", () => {
-  expect(getCookieDomain("https://api.example.com")).toBe(".example.com")
-  expect(getCookieDomain("https://api.canary.example.com")).toBe(".canary.example.com")
-  expect(getCookieDomain("https://api.dev.example.com")).toBe(".dev.example.com")
+// A real tldts parse result (allowPrivateDomains), narrowed to the fields cookieConfig reads.
+const host = (h: Partial<ParsedHost>): ParsedHost => ({
+  domain: null,
+  isIp: false,
+  isPrivate: false,
+  publicSuffix: null,
+  subdomain: null,
+  ...h,
 })
 
-test("getCookieDomain returns undefined for bare localhost / IP / apex", () => {
-  expect(getCookieDomain("http://localhost:4000")).toBeUndefined()
-  expect(getCookieDomain("http://127.0.0.1:4000")).toBeUndefined()
-  expect(getCookieDomain("https://example.com")).toBeUndefined()
-  expect(getCookieDomain("not a url")).toBeUndefined()
+test("cookieConfig scopes the cookie to the environment subdomain in production", () => {
+  expect(
+    cookieConfig(host({ subdomain: "api", domain: "example.com", publicSuffix: "com" })),
+  ).toEqual({
+    cookieDomain: ".example.com",
+    cookiePrefix: undefined,
+    isPrivate: false,
+  })
+  expect(
+    cookieConfig(host({ subdomain: "api.canary", domain: "example.com", publicSuffix: "com" })),
+  ).toEqual({ cookieDomain: ".canary.example.com", cookiePrefix: "canary", isPrivate: false })
+  expect(
+    cookieConfig(host({ subdomain: "api.dev", domain: "example.com", publicSuffix: "com" })),
+  ).toEqual({ cookieDomain: ".dev.example.com", cookiePrefix: "dev", isPrivate: false })
 })
 
-test("getCookieDomain shares the cookie across web + api under portless (.localhost)", () => {
-  // Main checkout: web zerostarter.localhost, api api.zerostarter.localhost.
-  expect(getCookieDomain("http://zerostarter.localhost:1355")).toBe(".zerostarter.localhost")
-  expect(getCookieDomain("http://api.zerostarter.localhost:1355")).toBe(".zerostarter.localhost")
-  // Worktree (branch-prefixed): web feat.zerostarter.localhost, api feat.api.zerostarter.localhost.
-  expect(getCookieDomain("http://feat.zerostarter.localhost:1355")).toBe(".zerostarter.localhost")
-  expect(getCookieDomain("http://feat.api.zerostarter.localhost:1355")).toBe(
-    ".zerostarter.localhost",
+test("cookieConfig is host-only for an apex, a bare host, an IP, and the null-host fallback", () => {
+  expect(cookieConfig(host({ subdomain: "", domain: "example.com", publicSuffix: "com" }))).toEqual(
+    {
+      cookieDomain: undefined,
+      cookiePrefix: undefined,
+      isPrivate: false,
+    },
   )
+  // Bare localhost: tldts leaves domain null.
+  expect(cookieConfig(host({ publicSuffix: "localhost" }))).toEqual({
+    cookieDomain: undefined,
+    cookiePrefix: undefined,
+    isPrivate: false,
+  })
+  // IP: tldts passes isPrivate through as null.
+  expect(cookieConfig(host({ isIp: true, isPrivate: null }))).toEqual({
+    cookieDomain: undefined,
+    cookiePrefix: undefined,
+    isPrivate: null,
+  })
+  // The build config's null-host fallback (a bare tsdown run without the generate step).
+  expect(cookieConfig(host({ isPrivate: null }))).toEqual({
+    cookieDomain: undefined,
+    cookiePrefix: undefined,
+    isPrivate: null,
+  })
 })
 
-test("getCookiePrefix isolates by environment subdomain in production", () => {
-  expect(getCookiePrefix("https://api.example.com")).toBeUndefined()
-  expect(getCookiePrefix("https://api.canary.example.com")).toBe("canary")
-  expect(getCookiePrefix("https://api.dev.example.com")).toBe("dev")
+test("cookieConfig shares the cookie across web + api under portless (.localhost)", () => {
+  for (const subdomain of ["", "api", "feat.api"]) {
+    expect(
+      cookieConfig(host({ subdomain, domain: "zerostarter.localhost", publicSuffix: "localhost" })),
+    ).toEqual({ cookieDomain: ".zerostarter.localhost", cookiePrefix: undefined, isPrivate: false })
+  }
 })
 
-test("getCookiePrefix returns no prefix for local dev (.localhost) so web + api match", () => {
-  expect(getCookiePrefix("http://localhost:4000")).toBeUndefined()
-  expect(getCookiePrefix("http://api.zerostarter.localhost:1355")).toBeUndefined()
-  expect(getCookiePrefix("http://feat.api.zerostarter.localhost:1355")).toBeUndefined()
-  expect(getCookiePrefix("http://feat.zerostarter.localhost:1355")).toBeUndefined()
+test("cookieConfig treats a multi-level public suffix as an apex, not a shareable parent", () => {
+  expect(
+    cookieConfig(host({ subdomain: "", domain: "example.co.uk", publicSuffix: "co.uk" })),
+  ).toEqual({
+    cookieDomain: undefined,
+    cookiePrefix: undefined,
+    isPrivate: false,
+  })
+  expect(
+    cookieConfig(host({ subdomain: "api", domain: "example.co.uk", publicSuffix: "co.uk" })),
+  ).toEqual({ cookieDomain: ".example.co.uk", cookiePrefix: undefined, isPrivate: false })
+  // "example" is the registrable name on a ccTLD, not an environment prefix.
+  expect(
+    cookieConfig(host({ subdomain: "api.canary", domain: "example.co.uk", publicSuffix: "co.uk" })),
+  ).toEqual({ cookieDomain: ".canary.example.co.uk", cookiePrefix: "canary", isPrivate: false })
+})
+
+test("cookieConfig passes isPrivate through for a public hosting suffix and stays host-only", () => {
+  expect(
+    cookieConfig(
+      host({
+        subdomain: "",
+        domain: "myapp-api.vercel.app",
+        isPrivate: true,
+        publicSuffix: "vercel.app",
+      }),
+    ),
+  ).toEqual({ cookieDomain: undefined, cookiePrefix: undefined, isPrivate: true })
+  expect(
+    cookieConfig(
+      host({
+        subdomain: "",
+        domain: "myapp.pages.dev",
+        isPrivate: true,
+        publicSuffix: "pages.dev",
+      }),
+    ),
+  ).toEqual({ cookieDomain: undefined, cookiePrefix: undefined, isPrivate: true })
+  expect(
+    cookieConfig(
+      host({
+        subdomain: "",
+        domain: "myuser.github.io",
+        isPrivate: true,
+        publicSuffix: "github.io",
+      }),
+    ),
+  ).toEqual({ cookieDomain: undefined, cookiePrefix: undefined, isPrivate: true })
+})
+
+test("cookieConfig still computes a domain under a private suffix with a subdomain; isPrivate wins in index.ts", () => {
+  // Unreachable on Vercel/Pages in practice; documents that index.ts's isPrivate branch overrides the computed cross-subdomain domain rather than sharing it.
+  expect(
+    cookieConfig(
+      host({
+        subdomain: "api",
+        domain: "myapp.vercel.app",
+        isPrivate: true,
+        publicSuffix: "vercel.app",
+      }),
+    ),
+  ).toEqual({ cookieDomain: ".myapp.vercel.app", cookiePrefix: undefined, isPrivate: true })
 })

--- a/packages/auth/tsdown.config.ts
+++ b/packages/auth/tsdown.config.ts
@@ -1,5 +1,37 @@
+import { existsSync, readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
 import { definePackageConfig } from "@packages/config/tsdown"
 import { getSafeEnv } from "@packages/env"
 import { env } from "@packages/env/auth"
 
-export default definePackageConfig({ name: "@packages/auth", env, getSafeEnv })
+import type { ParsedHost } from "@/lib/utils"
+
+// The build-time tldts breakdown that generate-tldts writes to repo-root .generated/, parsed and spread over a null-host fallback (a renamed tldts field falls back to null), then inlined via define so no Public Suffix List ships. Anchored to this file, not cwd, so a stray tsdown run still resolves it.
+const generatedPath = resolve(import.meta.dirname, "../../.generated/tldts.json")
+const fallback: ParsedHost = {
+  domain: null,
+  isIp: false,
+  isPrivate: null,
+  publicSuffix: null,
+  subdomain: null,
+}
+
+let breakdown: ParsedHost = fallback
+if (existsSync(generatedPath)) {
+  breakdown = { ...fallback, ...JSON.parse(readFileSync(generatedPath, "utf-8")) }
+} else if (process.env.SKIP_ENV_VALIDATION === "true") {
+  // Only the skip-validation flow (worktree pre-commit, bare tsdown) tolerates a missing artifact; it bakes host-only cookies.
+  console.warn(`@packages/auth: ${generatedPath} missing; baking the host-only fallback.`)
+} else {
+  throw new Error(
+    `@packages/auth: ${generatedPath} missing; run generate-tldts before tsdown (or set SKIP_ENV_VALIDATION).`,
+  )
+}
+
+export default definePackageConfig({
+  name: "@packages/auth",
+  env,
+  getSafeEnv,
+  define: { __DERIVED_TLDTS__: JSON.stringify(breakdown) },
+})

--- a/packages/config/tsdown.ts
+++ b/packages/config/tsdown.ts
@@ -10,12 +10,14 @@ export function definePackageConfig(options: {
   name: string
   env: Record<string, unknown>
   getSafeEnv: (env: Record<string, unknown>, name?: string) => unknown
+  define?: Record<string, string>
   deps?: BundleDeps
 }) {
-  const { name, env, getSafeEnv, deps } = options
+  const { name, env, getSafeEnv, define, deps } = options
 
   return [
     defineConfig({
+      ...(define ? { define } : {}),
       ...(deps ? { deps } : {}),
       dts: { tsgo: true },
       entry: ["src/index.ts"],

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@packages/scripts",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@packages/config": "workspace:*",
+    "@packages/env": "workspace:*",
+    "@types/bun": "catalog:",
+    "@types/node": "catalog:",
+    "tldts": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/scripts/src/generate-tldts.ts
+++ b/packages/scripts/src/generate-tldts.ts
@@ -1,0 +1,26 @@
+import { resolve } from "node:path"
+
+import { env } from "@packages/env/auth"
+import { parse } from "tldts"
+
+// Write the app host's tldts breakdown to the repo-root .generated/ dir at build time so its Public Suffix List never ships; @packages/auth's tsdown bakes this JSON via define. Only the fields cookieConfig reads (the ParsedHost shape) are kept.
+const { domain, hostname, isIp, isPrivate, publicSuffix, subdomain } = parse(env.HONO_APP_URL, {
+  allowPrivateDomains: true,
+})
+// Fail loud on tldts drift: a multi-label registrable host resolves to a full breakdown, so a null/undefined field (a renamed/moved field that would otherwise bake host-only cookies silently) is a build error. IPs, localhost, and single-label hosts legitimately carry null fields and are exempt.
+const nullish = (value: unknown) => value === null || value === undefined
+if (
+  !isIp &&
+  publicSuffix !== "localhost" &&
+  typeof hostname === "string" &&
+  hostname.includes(".") &&
+  [domain, publicSuffix, subdomain, isPrivate].some(nullish)
+) {
+  throw new Error(
+    `generate-tldts: "${env.HONO_APP_URL}" did not fully resolve (tldts drift, or an unparseable host?)`,
+  )
+}
+await Bun.write(
+  resolve(import.meta.dir, "../../../.generated/tldts.json"),
+  JSON.stringify({ domain, isIp, isPrivate, publicSuffix, subdomain }),
+)

--- a/packages/scripts/tsconfig.json
+++ b/packages/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@packages/config/tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,7 @@
       "dependsOn": ["^build"]
     }
   },
+  "globalDependencies": [".env*"],
   "globalEnv": [
     // CI variables
     "SKIP_ENV_VALIDATION",

--- a/web/next/content/docs/deployment/docker.mdx
+++ b/web/next/content/docs/deployment/docker.mdx
@@ -48,7 +48,7 @@ Compose wires this from `secrets: dotenv` (sourced from `./.env`); a plain `dock
 
 <Callout type="warn" title="Rebuild with --no-cache after editing .env">
 
-Secret contents aren't part of BuildKit's cache key. Edit `.env` and a plain rebuild can reuse the cached build step, silently shipping stale values, including web's `NEXT_PUBLIC_*`, which Next inlines into the bundle at build time. After any env change, run `docker compose build --no-cache`.
+Secret contents aren't part of BuildKit's cache key. Edit `.env` and a plain rebuild can reuse the cached build step, silently shipping stale values, including web's `NEXT_PUBLIC_*` and the auth session-cookie scope derived from `HONO_APP_URL`, both baked into the bundle at build time. After any env change, run `docker compose build --no-cache`.
 
 </Callout>
 

--- a/web/next/content/docs/getting-started/project-structure.mdx
+++ b/web/next/content/docs/getting-started/project-structure.mdx
@@ -1,14 +1,14 @@
 ---
 slug: /docs/getting-started/project-structure
 title: Project Structure
-description: "How the monorepo fits together: two apps, four packages, one import graph."
+description: "How the monorepo fits together: two apps, their packages, one import graph."
 ---
 
-The whole repo is one mental model: two deployable apps, four shared packages, and a single import graph that ties them together.
+The whole repo is one mental model: two deployable apps, their packages, and a single import graph that ties them together.
 
 - **`web/next`**: the Next.js frontend (App Router, React 19).
 - **`api/hono`**: the Hono backend that owns every route and talks to the database.
-- **`packages/*`**, the code both apps share: the auth instance, the Drizzle schema, validated env, and the brand config.
+- **`packages/*`**, the shared code plus build tooling: the auth instance, the Drizzle schema, validated env, the brand config, and a build-only scripts package.
 
 Three import aliases wire it together: `@api/hono` gives the frontend its API types, `@packages/*` pulls in a shared package, and `@/` is the local-to-this-app alias. Imports only point _down_ that list: apps depend on packages, never the reverse.
 
@@ -20,7 +20,8 @@ Three import aliases wire it together: `@api/hono` gives the frontend its API ty
    ├─ auth/       # Better Auth instance + session types
    ├─ db/         # Drizzle schema + migrations
    ├─ env/        # type-safe, validated environment variables
-   └─ config/     # TS base, tsdown factory, and site.ts (the brand)
+   ├─ config/     # TS base, tsdown factory, and site.ts (the brand)
+   └─ scripts/    # build-only tooling (tldts generation); never bundled
 ```
 
 ## `api/hono`
@@ -49,6 +50,7 @@ The `(marketing)/` route group under `src/app/` holds the marketing surfaces: th
 - **`db`**: Drizzle schema under `src/schema/` (`auth.ts`, `waitlist.ts`) and generated migrations under `drizzle/`.
 - **`env`**: every environment variable, validated with [@t3-oss/env-core](https://env.t3.gg) and split per surface (`api-hono.ts`, `auth.ts`, `db.ts`, `web-next.ts`).
 - **`config`**: the TypeScript base every package extends, the `tsdown` factory, and `src/site.ts`, the single file a fork edits to rebrand.
+- **`scripts`**: build-only Bun tooling (e.g. the tldts breakdown baked into `auth`). It runs during a build and writes to the gitignored repo-root `.generated/`, never bundled or imported at runtime.
 
 ## Bun catalog
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -64,7 +64,7 @@ await authClient.organization.setActive({ organizationId: "..." })
 
 ## Sessions and cookies
 
-Sessions live in the `session` table and travel as a secure cookie; the active `organizationId` and `teamId` ride along on the row. Cross-subdomain cookies switch on automatically when `HONO_APP_URL` is a subdomain. Better Auth caches the session in a cookie for `maxAge: 300` (~5 minutes), so a role change made elsewhere can lag by that much unless the session is revoked.
+Sessions live in the `session` table and travel as a secure cookie; the active `organizationId` and `teamId` ride along on the row. The cookie scope is derived at build time from `HONO_APP_URL`'s public-suffix breakdown: a subdomain of a shareable parent gets a cross-subdomain `Domain` cookie, a public hosting suffix (`*.vercel.app` and the like) where siblings cannot share falls back to `SameSite=None`, and a bare or apex host stays host-only. Better Auth caches the session in a cookie for `maxAge: 300` (~5 minutes), so a role change made elsewhere can lag by that much unless the session is revoked.
 
 Reading the session is one call on either side:
 

--- a/web/next/content/docs/resources/ai-skills.mdx
+++ b/web/next/content/docs/resources/ai-skills.mdx
@@ -28,6 +28,7 @@ The skills, arranged as the arc of a real task, **Navigate** to find your way, *
 | Stage    | Skill           | What it does                                                                                                                  |
 | -------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | Navigate | `codebase-map`  | Orient fast: the "where do I edit for X" table and how a change ripples across the stack. Start here in unfamiliar territory. |
+| Build    | `add-package`   | Add a shared workspace package the repo's way: skeleton, `types: ["bun"]` for Bun scripts, gitignored `.generated/` output.   |
 | Build    | `api-endpoint`  | Add a typed Hono route the repo's way: router, validation envelope, OpenAPI, RPC wiring, and the restart-and-`curl` test.     |
 | Build    | `db-migration`  | Change the Drizzle schema and apply it: `db:generate`, then `db:migrate`.                                                     |
 | Build    | `design`        | The canonical UI conventions: spacing, color, cursor, typography, tokens. Follow it for any component work.                   |

--- a/web/next/docs.config.ts
+++ b/web/next/docs.config.ts
@@ -29,7 +29,8 @@ const docsConfig = {
       {
         "/docs/getting-started/project-structure": {
           title: "Project Structure",
-          description: "How the monorepo fits together: two apps, four packages, one import graph.",
+          description:
+            "How the monorepo fits together: two apps, their packages, one import graph.",
         },
       },
     ],


### PR DESCRIPTION
## What

Derive the session-cookie configuration from a real tldts parse of the app host, run **at build time in a dedicated scripts package** so its Public Suffix List never ships in the runtime bundle.

- **`@packages/scripts`** — a new private workspace package for app-build tooling (never imported at runtime, so never bundled). It mirrors the standard `packages/*` shape: source under `src/`, `tsconfig.json` extends `@packages/config/tsconfig.json`, and its build-only deps are devDependencies (`@packages/config`, `@packages/env`, `tldts`, off the root). `src/generate-tldts.ts` reads `env.HONO_APP_URL` from `@packages/env` (reusing its env loading, no separate dotenv), runs `parse(url, { allowPrivateDomains: true })`, and writes the repo-root `.generated/tldts.json` (gitignored). Generated assets get one centralized `.generated/` home (dot-prefixed like `.next`/`.source`/`.turbo`; "generated" not `.cache` since it's a required build input, not a perf cache), which `.gitignore`/`.dockerignore` and `bun run clean` all cover. `.github/scripts` stays for CI/repo tooling.
- **`@packages/auth` build runs it first** (`"build": "bun ../scripts/src/generate-tldts.ts && tsdown"`, with `@packages/scripts` as a devDep so `turbo prune` keeps it in Docker). `tsdown.config.ts` reads the JSON and bakes it via `define` (`definePackageConfig` gained an optional `define` passthrough). `index.ts` reads the ambient constant and runs one `cookieConfig(tldts)` → `{ cookieDomain, cookiePrefix, isPrivate }`, switching cookie mode on `isPrivate`.
- **`@packages/env` stays plain `createEnv(...)`** — the earlier `derived` pass-through is gone, since auth is the only consumer.

## Why the full PSL, at build

`co.uk`, `com.au`, `s3.amazonaws.com`, `vercel.app` and friends can't be handled by a small hand-rolled list — correct public-suffix boundaries need the PSL. Running it at build gets that correctness (e.g. `api.example.co.uk` → `cookieDomain: ".example.co.uk"`, `cookiePrefix: undefined`, not a bogus `"example"`) while shipping only the ~200-byte result. Tree-shaking can't help: the PSL is data a called `parse()` consumes, not dead code.

## Cookie mode

`index.ts` `advanced` branches on `isPrivate` (tldts's own field, passed through):

- **hosting suffix** (`vercel.app`, `pages.dev`, `github.io` → `true`): sibling origins can't share a Domain cookie → `defaultCookieAttributes: { sameSite: "none", secure: true }`.
- **otherwise**: `crossSubDomainCookies` scoped to the derived `cookieDomain`.

## Behavior

Custom-domain and `.localhost` hosts unchanged. Hosting suffixes → host-only + `SameSite=None` (canary emitted the browser-rejected `.vercel.app`). ccTLD apex → host-only; any IP literal → host-only. A host with no shareable parent (apex API URL, bare `localhost`, IP) keeps the `cookieDomain &&` guard, staying host-only rather than widening to `Domain=<hostname>`.

## Build size

PSL is build-only, so the runtime bundle is essentially unchanged from canary:

| Artifact | canary | this PR |
|---|---|---|
| `@packages/env/dist/auth.mjs` | ~1.0 KB | ~1.0 KB (unchanged) |
| `@packages/auth/dist/index.mjs` | ~1.8 KB | ~2.0 KB (baked breakdown) |
| `@api/hono` deployed bundle | 1.43 MB | 1.43 MB |
| `@web/next` | — | unchanged |

## Build-time trade-off

The cookie config is baked to the **build-time** `HONO_APP_URL`, the same way the web bakes `NEXT_PUBLIC_*`. The script sources it as the runtime does (`process.env` on Vercel, the mounted `.env` on Docker), and `turbo.json` re-hashes the build on a URL change via `globalEnv` (`HONO_APP_URL` from `process.env`) plus `.env*` in `globalDependencies` (for the `.env`/`.env.<mode>` file case that `globalEnv` can't see). Docker layer caching is separate: BuildKit excludes the mounted `.env` secret, so a `.env` change needs `docker compose build --no-cache` (documented in the Docker guide). Running one image against a *different* runtime `HONO_APP_URL` would update `baseURL` but not the baked cookie config; the standard flows (Vercel per-deploy, docker-compose sharing one `.env`) match.

## Verification

- Full turbo build (all 8 packages) + `check-types` (incl. `@packages/scripts`) green; tldts absent from every `dist` and the api bundle.
- Script sourcing verified: with `HONO_APP_URL` only in a `.env` file (shell var unset), the script wrote the correct `api.zerostarter.dev` breakdown and it baked into `auth/dist`.
- `packages/auth/test/utils.test.ts` covers `cookieConfig` across production subdomains, `.localhost` (main + worktree), ccTLD apex/subdomain, hosting suffixes, IPs, and the null-host fallback (`bun test` green).
- Since this adds a workspace package, `@packages/scripts` conforms to the standard `packages/*` shape (`src/` layout, `tsconfig.json` extends `@packages/config/tsconfig.json`), and a new `add-package` skill (`.agents/skills/add-package`, registered in the AGENTS.md table) captures that shape for the next one.
- Working notes: `.github/notes/plans/env-derived-tldts.md`.

## Scope

canary only. Independent of the `feat/split-deploy-auth` branch — the `isPrivate` signal is computed straight from tldts's PSL, not that branch's curated set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication cookie domain and prefix handling across localhost, IP addresses, subdomains, and multi-level domains.
  * Improved environment-specific cookie isolation while preserving correct behavior for production domains.

* **Tests**
  * Expanded coverage for cookie configuration across public suffixes, localhost, IP addresses, and nested subdomains.

* **Documentation**
  * Added planning notes describing the updated authentication cookie handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
