### PR TITLE
docs: add CLI, Organizations & Teams, and Rate Limiting pages (overhaul phase 1)

### DIFF
--- a/web/next/content/docs/deployment/docker.mdx
+++ b/web/next/content/docs/deployment/docker.mdx
@@ -36,6 +36,12 @@ base → prepare → builder → runner
 - The **web** image uses Next.js `output: "standalone"`: the builder copies `.next/static` and `public` into the standalone bundle, and the runner starts `bun server.js`.
 - The **api** image copies its `bundle/` output and runs `bun bundle/index.mjs`.
 
+<Callout type="info" title="Why the images stay small and self-contained">
+
+The api runner ships only its bundle: no `node_modules`, so it resolves every import from the bundle and starts with no network. The web build prunes the native binaries it will never run: `next.config.ts` detects the image's libc (alpine is musl) and drops the other-libc `sharp` and `@takumi-rs` binaries from output tracing, keeping only the takumi core `/og` needs. That keeps a single libc stack in the standalone output instead of both.
+
+</Callout>
+
 ## The .env build secret
 
 Both builds validate the full env, so they need `.env` at build time, but never bake it into a layer. It's passed as a **BuildKit secret**, mounted only for the build step:

--- a/web/next/content/docs/deployment/vercel.mdx
+++ b/web/next/content/docs/deployment/vercel.mdx
@@ -101,7 +101,7 @@ A custom domain (where web and api share a parent) switches back automatically, 
 
 </Callout>
 
-The api infers that web origin from `HONO_TRUSTED_ORIGINS`; if you trust more than one origin (say a preview URL), set `HONO_WEB_URL` on the api project to name it explicitly.
+The api infers that web origin from `HONO_TRUSTED_ORIGINS`, taking the first trusted origin that isn't the api itself. Set `HONO_WEB_URL` on the api project to name it explicitly when that inference won't do: either because you trust more than one origin (say a preview URL) and don't want it to guess, or because no trusted origin differs from the api at all, in which case sign-in cannot complete until you set it.
 
 ## WebSockets
 

--- a/web/next/content/docs/getting-started/cli.mdx
+++ b/web/next/content/docs/getting-started/cli.mdx
@@ -1,0 +1,83 @@
+---
+slug: /docs/getting-started/cli
+title: CLI
+description: "Scaffold, re-scaffold, and re-baseline a fork: the init, reinit, and sync commands."
+---
+
+The `zerostarter` CLI is how you start a project and keep it current. `init` scaffolds a fresh product, `reinit` re-scaffolds a repo you already have, and `sync` re-baselines a fork on the latest starter without discarding your work. All three run under Bun (`bunx`), fetch the starter with [gitpick](https://github.com/nrjdalal/gitpick) as a subtree (no upstream git history rides along), and rebrand everything to your project.
+
+## `init`: scaffold a fresh product
+
+```bash
+bunx zerostarter init [dir]
+```
+
+Fetches the latest starter into `dir` (default `.`), rebrands it to the directory name, seeds `.env`, installs dependencies, and makes the first commits on a `canary` branch with `main` seeded behind it. It can also provision a local Postgres and run migrations.
+
+When the terminal is interactive it asks three things, each skippable with `--yes`: a project name (only when the target directory is non-empty and not already a starter), which optional surfaces to ship, and whether to provision a local database.
+
+| Flag                             | Default   | Effect                                                                                                 |
+| -------------------------------- | --------- | ------------------------------------------------------------------------------------------------------ |
+| `--yes`, `-y`                    | off       | Skip every prompt and take defaults; provisions Postgres if Docker is running.                         |
+| `--canary`                       | `main`    | Scaffold from the `canary` branch instead of `main`.                                                   |
+| `--db`                           | off       | Force-provision a local Postgres and migrate (needs Docker); ignored if `POSTGRES_URL` is already set. |
+| `--dry-run`                      | off       | Print the plan and write nothing.                                                                      |
+| `--<feature>` / `--no-<feature>` | see below | Turn an optional surface on or off instead of the picker.                                              |
+| `--help`, `-h`                   | -         | Print usage.                                                                                           |
+
+The feature flags are `--api-docs`, `--blog`, `--docs`, `--internal-docs`, and `--waitlist`. All are on by default except `waitlist`; each gates a surface that a fork can drop (see [Features](/docs/manage/features)). Passing any feature flag skips the interactive picker.
+
+<Callout type="info" title="The directory name becomes the project name">
+
+Scaffolding into an empty `.` (or a fresh directory) names the project after that directory. Point `init` at a non-empty directory and it prompts for a name and scaffolds into a subdirectory of that name instead. `--canary` applies only when fetching; converting an existing checkout in place ignores it.
+
+</Callout>
+
+## `reinit`: re-scaffold a repo you already have
+
+```bash
+bunx zerostarter reinit [dir]
+```
+
+Deletes every file except `.git` and any `.env*`, re-fetches the latest starter, rebrands to the directory name, installs, and commits on the current branch. It always uses `main` and the default features, so there is no picker and no `--canary` or `--db`. The only flag is `--yes` to skip the confirmation.
+
+The operation is atomic: any failure resets the working tree to your last commit. It also requires a clean repo up front.
+
+<Callout type="warn" title="reinit deletes files">
+
+`reinit` removes every tracked and untracked file except `.git` and `.env*`. Committed files are restored on rollback, but gitignored files that are not `.env*` are gone for good, so commit or stash anything you want to keep first.
+
+</Callout>
+
+## `sync`: re-baseline a fork on the latest starter
+
+```bash
+bunx zerostarter sync [dir]
+```
+
+Overlays the latest starter onto your fork, updating shared starter files while preserving everything your fork owns. Unlike `init` and `reinit`, it does not commit: it leaves the changes in your working tree so you review the diff and commit yourself. It requires a clean repo and rolls back on failure.
+
+What it preserves: your content, `public/`, marketing, `packages/config/src/site.ts` branding, `README.md`, your root package identity (name, version, author fields), and the `PRESERVE_ON_SYNC` paths (`bun.lock`, `packages/db/drizzle/`, `packages/db/src/schema/`, `web/next/docs.config.ts`, and the favicon). What it overwrites: every shared starter file, so local edits to those are replaced by the upstream version.
+
+```bash
+# review before committing
+git -C <dir> status
+```
+
+## The fork boundary
+
+All three commands fetch with gitpick, which reads the repo's root `.gitpickignore`. That one file declares the fork boundary in two parts: the paths a fork does not take from the starter (your `web/next/content/`, the `(marketing)` route group and marketing assets, `packages/cli/`, and author-only workflows), and a `PRESERVE_ON_SYNC` line naming the paths `sync` restores after an overlay (your applied database migrations and schema, `docs.config.ts`, the lockfile, and favicon). The boundary applies only to gitpick fetches; a plain `git clone` still gets the whole repository.
+
+## Rebrand: one edit, whole system
+
+`init` and `reinit` regenerate `packages/config/src/site.ts` from the project name (the name, plus placeholder description, tagline, and socials for you to fill in), rename the root package to a slug, rebrand the [portless](/docs/getting-started/setup) dev-URL names to `<slug>` and `api.<slug>`, and strip the demo `/hire` nav entry. Every surface reads its identity from `@packages/config/site`, so that one file is your brand. The rebrand fails loudly rather than half-applying if the starter's shape has drifted (a missing `portless` block, a leaked marketing font), which keeps a fork from shipping a broken identity.
+
+## Publishing a fork
+
+`init` seeds git on a `canary` working branch with `main` behind it. On your first `git push`, a pre-push hook publishes `canary` (GitHub makes it your default branch); push again and it seeds the release branches, so the canary-to-main release automation configures itself with no repository admin. Enable read-write workflow permissions when the hook prompts you. See [Releases](/docs/manage/release) for the flow it sets up.
+
+## Next
+
+- [Quickstart](/docs/getting-started/setup): the guided first run with `init`.
+- [Features](/docs/manage/features): the optional surfaces `init` writes into `site.ts`.
+- [Releases](/docs/manage/release): the canary-to-main flow the fork bootstrap wires up.

--- a/web/next/content/docs/getting-started/project-structure.mdx
+++ b/web/next/content/docs/getting-started/project-structure.mdx
@@ -44,6 +44,8 @@ The `(marketing)/` route group under `src/app/` holds the marketing surfaces: th
 
 </Callout>
 
+`src/components/` is grouped by domain the same way, one folder per area, so a component lives next to the surface it serves: `common/` (shared pieces like the navbar), `shell/` (the app frame: `PageShell`, `PageHeader`, and the `sidebar-*` parts), `dashboard/`, `console/`, `docs/`, `blog/`, `marketing/`, and `ui/`. `ui/` is the generated shadcn registry: don't hand-edit it (the sync rewrites it); customize through the post-sync script instead.
+
 ## The packages
 
 - **`auth`**, the Better Auth config: optional GitHub/Google OAuth, the organizations + teams plugin, and the `admin` plugin that gates `/console`. Exports session types.

--- a/web/next/content/docs/manage/api-conventions.mdx
+++ b/web/next/content/docs/manage/api-conventions.mdx
@@ -87,13 +87,7 @@ Every request passes the global middleware in order (from `api/hono/src/index.ts
 
 ### Rate limiting
 
-The limiter keys each request by the first available of: user id (if authenticated) → API key (a hash of the `Authorization` header) → IP (via [Arcjet](https://arcjet.com)) → a random UUID fallback. Limits come from `HONO_RATE_LIMIT` / `HONO_RATE_LIMIT_WINDOW_MS` (default 60 requests / 60s); authenticated users get 2× the limit, installed by the auth middleware. Exceeding it returns `429 TOO_MANY_REQUESTS`.
-
-<Callout type="warn" title="The API-key tier is unwired">
-
-No limiter passes `getApiKey`, so the API-key branch never fires; requests fall back to the user-id or IP tier. Wire `getApiKey` into a limiter to activate it.
-
-</Callout>
+The limiter keys each request by user id, then API key, then IP, and gives authenticated users a higher tier. Exceeding it returns `429 TOO_MANY_REQUESTS` in the same envelope. See [Rate Limiting](/docs/manage/rate-limiting) for the tiers, the environment variables, and the response headers.
 
 ### Auth
 

--- a/web/next/content/docs/manage/authentication.mdx
+++ b/web/next/content/docs/manage/authentication.mdx
@@ -81,7 +81,7 @@ The guard reads the session with the cookie cache disabled, so a grant or revoke
 
 ## Organizations and teams
 
-The [Organization plugin](https://www.better-auth.com/docs/plugins/organization) (with `teams` enabled) makes the app multi-tenant. Users create and switch organizations from the dashboard sidebar; the last active org is stored in a cookie and restored on next login. Members carry a `role` within an org (default `member`), invitations go out by email, and teams group members inside an org. The backing tables (`organization`, `member`, `team`, `teamMember`, `invitation`) live in [the schema](/docs/manage/database).
+The [Organization plugin](https://www.better-auth.com/docs/plugins/organization) (with `teams` enabled) makes the app multi-tenant. Users create and switch organizations from the dashboard sidebar; the last active org is stored in a cookie and restored on next login. Members carry a `role` within an org (default `member`), and the backing tables (`organization`, `member`, `team`, `teamMember`, `invitation`) live in [the schema](/docs/manage/database). Creating and switching organizations is wired; invitations, teams, and member management are available in the plugin but not yet built into the UI. See [Organizations & Teams](/docs/manage/organizations) for the full data model and what to build on top.
 
 Read the current context on the client:
 

--- a/web/next/content/docs/manage/organizations.mdx
+++ b/web/next/content/docs/manage/organizations.mdx
@@ -1,0 +1,79 @@
+---
+slug: /docs/manage/organizations
+label: Organizations
+title: Organizations & Teams
+description: "Multi-tenant from Better Auth: the org and team data model, roles, invitations, and active-org switching."
+---
+
+Multi-tenancy comes from the Better Auth [Organization plugin](https://www.better-auth.com/docs/plugins/organization), registered with `teams` enabled in `packages/auth/src/index.ts`. The plugin backs the whole surface (organizations, members, teams, invitations, and an active org per session) with tables in the same Drizzle schema as the rest of your data, so a tenant is just rows you already own, not a separate service.
+
+The starter wires the two flows a product needs on day one, creating an organization and switching between them, and leaves the rest of the plugin's capability (invitations, teams, member management) available but unwired, ready for your product logic.
+
+## The data model
+
+Five tables in `packages/db/src/schema/auth.ts` hold the tenancy, all cascading on delete:
+
+| Table          | Holds                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------- |
+| `organization` | The tenant: `name`, a unique `slug`, an optional `logo`, and free-form `metadata`.      |
+| `member`       | A user's membership in an org, carrying the org `role` (default `member`).              |
+| `team`         | A named group inside an org.                                                            |
+| `teamMember`   | A user's membership in a team (flat, no per-team role).                                 |
+| `invitation`   | A pending invite: `email`, target `role`, optional `teamId`, `status`, and `expiresAt`. |
+
+The active organization and team ride on the session row itself as `session.activeOrganizationId` and `session.activeTeamId`, so every request knows the current tenant without a second lookup.
+
+## Roles
+
+An org has three roles from Better Auth's defaults: `owner`, `admin`, and `member`. Whoever creates an org becomes its `owner`; everyone else joins as `member` unless an invitation names a different role. These live on `member.role` and are entirely separate from the user-level `role` column that gates [`/console`](/docs/manage/authentication#the-admin-role-and-console), which is a platform-admin flag, not an org role. Teams are flat: `teamMember` has no role column, so membership is the only distinction inside a team.
+
+## Reading the current context
+
+The client plugin (`web/next/src/lib/auth/client.ts`) exposes the org surface as hooks and methods on `authClient`. The starter's sidebar uses these:
+
+```ts
+import { authClient } from "@/lib/auth/client"
+
+const { data: orgs } = authClient.useListOrganizations()
+const { data: activeOrg } = authClient.useActiveOrganization()
+
+await authClient.organization.create({ name, slug })
+await authClient.organization.setActive({ organizationId })
+```
+
+The same plugin also provides everything the starter does not yet call: `organization.inviteMember`, `acceptInvitation`, `listInvitations`, `removeMember`, `updateMemberRole`, the team methods (`createTeam`, `setActiveTeam`, and friends, since teams are enabled), and permission checks (`hasPermission`). They work against the backend as soon as you build UI for them.
+
+## The active organization
+
+When a user switches orgs, the sidebar calls `setActive` and writes a per-user cookie, `last-active-org_<userId>`, so their choice survives a reload. On the next protected render, `web/next/src/app/(protected)/layout.tsx` reads that cookie and, if the session has no active org yet, POSTs to the org plugin's `set-active` endpoint to rehydrate it server-side. The result is that the active tenant is restored on login without a flash of the wrong org.
+
+<Callout type="info" title="The active-org cookie is client-set">
+
+`last-active-org_<userId>` is written with `document.cookie` (not `HttpOnly`), so it is a UI convenience, readable and writable in the browser, not a security boundary. The source of truth is `session.activeOrganizationId` on the row; the cookie only nominates which org to reactivate.
+
+</Callout>
+
+## What is wired, and what is not
+
+Working end to end in the app:
+
+- **Create an organization** from the dashboard sidebar (`organization.create`, slug derived from the name).
+- **Switch the active organization**, with the choice persisted and restored across sessions.
+
+Capable in the backend, but with no UI (and no email) yet:
+
+- **Invitations.** The `invitation` table and the plugin's invite/accept/reject endpoints exist, but no `sendInvitationEmail` is configured, so an invite creates a row without delivering a link. Wire delivery by adding `sendInvitationEmail` to the plugin in `packages/auth/src/index.ts`, then build the accept page around `organization.acceptInvitation`.
+- **Teams.** `teams.enabled` is on and the tables are there, but nothing reads or writes `activeTeamId` yet. Build team UI on the `createTeam` / `setActiveTeam` methods.
+- **Member management.** `removeMember`, `updateMemberRole`, and `leave` are all available to build against.
+
+<Callout type="warn" title="Role and org changes can lag ~5 minutes">
+
+Better Auth caches the session in a cookie for `maxAge: 300`, so a role or active-org change made elsewhere can take up to five minutes to appear unless the cache is bypassed. The console gate reads the session with the cache disabled for exactly this reason; the org switcher refetches its queries after each mutation so the UI stays current.
+
+</Callout>
+
+## Next
+
+- [Authentication](/docs/manage/authentication): sign-in methods, sessions, and the `/console` role gate.
+- [Database](/docs/manage/database): the org and team tables, and how to add your own.
+- [Dashboard](/docs/manage/dashboard): the protected shell where the org switcher lives.

--- a/web/next/content/docs/manage/rate-limiting.mdx
+++ b/web/next/content/docs/manage/rate-limiting.mdx
@@ -1,0 +1,61 @@
+---
+slug: /docs/manage/rate-limiting
+title: Rate Limiting
+description: Layered rate limits keyed by user, API key, or IP, with a higher tier for authenticated requests.
+---
+
+Every request to the API passes a rate limiter, built on [`hono-rate-limiter`](https://github.com/rhinobase/hono-rate-limiter) in `api/hono/src/middlewares/rate-limiter.ts`. It runs in two tiers from one factory: a global limit on every request keyed by client, and a higher per-user limit on the authenticated `/api/v1/*` routes. An authenticated request passes through both, so a signed-in user is bounded by their own budget and still counts against the shared IP budget.
+
+## How a request is keyed
+
+The limiter buckets each request by the first of these it can resolve:
+
+1. **User id**, when the request carries a session (`userid:<id>`).
+2. **API key**, hashed, when one is supplied (`apikey:<hash>`).
+3. **IP address**, detected from request headers with [`@arcjet/ip`](https://github.com/arcjet/arcjet-js) (`ip:<addr>`).
+4. A **random per-request id** if no IP can be found, which effectively leaves that request unbounded.
+
+The global limiter passes no user or key resolver, so it always falls to the IP (or random) tier. The auth middleware installs the per-user limiter that supplies the session's user id, so authenticated traffic is bucketed by account rather than by shared network address.
+
+## Limits and window
+
+Two environment variables set the budget, both read in `packages/env/src/api-hono.ts`:
+
+| Variable                    | Default | Controls                                  |
+| --------------------------- | ------- | ----------------------------------------- |
+| `HONO_RATE_LIMIT`           | `60`    | Requests allowed per window (anonymous).  |
+| `HONO_RATE_LIMIT_WINDOW_MS` | `60000` | Window length in milliseconds (1 minute). |
+
+Authenticated users get **twice** the base limit: the auth middleware constructs its per-user limiter with `HONO_RATE_LIMIT * 2`. So out of the box an anonymous caller gets 60 requests per minute per IP, and a signed-in user gets 120 per minute for their account.
+
+## What a throttled request sees
+
+Exceeding a limit returns `429` in the standard [error envelope](/docs/manage/api-conventions):
+
+```json
+{ "error": { "code": "TOO_MANY_REQUESTS", "message": "Too Many Requests" } }
+```
+
+Every response also carries the `draft-6` standard headers, `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset`, and a throttled one adds `Retry-After`, so a client can back off without guessing. The `429` is documented on every route in the OpenAPI spec, so it shows up in the [Scalar reference](/docs/getting-started/type-safe-api) too.
+
+<Callout type="info" title="Arcjet here is just IP detection">
+
+`@arcjet/ip` is a standalone header-parsing utility for finding a request's originating IP, not the Arcjet SaaS product. It needs no API key and no environment variable, and makes no network calls. It only reads forwarded/platform headers to resolve the address the IP tier keys on.
+
+</Callout>
+
+<Callout type="warn" title="The store is in-process">
+
+Each limiter uses an in-memory store scoped to one server instance, so limits are per-process, not shared across replicas. That is fine for a single instance or for local development; behind a load balancer or on serverless, back the limiter with a shared store (for example Redis) so the budget is enforced globally.
+
+</Callout>
+
+## The API-key tier is a stub
+
+The key resolver has an API-key branch, but nothing supplies it: no limiter passes a key resolver, and the starter has no API-key authentication at all. Auth is session-based (a cookie or session token resolved by Better Auth), so in practice requests key by user id or IP. To add API-key auth, validate the key in a middleware and pass a resolver into the limiter so the `apikey:` tier starts firing.
+
+## Next
+
+- [API Conventions](/docs/manage/api-conventions): the error envelope the `429` uses, and the rest of the middleware chain.
+- [Environment Variables](/docs/manage/environment): where `HONO_RATE_LIMIT` and its window are validated.
+- [Authentication](/docs/manage/authentication): the sessions the per-user tier keys on.

--- a/web/next/docs.config.ts
+++ b/web/next/docs.config.ts
@@ -33,6 +33,13 @@ const docsConfig = {
             "How the monorepo fits together: two apps, their packages, one import graph.",
         },
       },
+      {
+        "/docs/getting-started/cli": {
+          title: "CLI",
+          description:
+            "Scaffold, re-scaffold, and re-baseline a fork: the init, reinit, and sync commands.",
+        },
+      },
     ],
     "Core Concepts": [
       {
@@ -51,6 +58,13 @@ const docsConfig = {
         },
       },
       {
+        "/docs/manage/rate-limiting": {
+          title: "Rate Limiting",
+          description:
+            "Layered rate limits keyed by user, API key, or IP, with a higher tier for authenticated requests.",
+        },
+      },
+      {
         "/docs/manage/database": {
           title: "Database",
           description: "PostgreSQL with Drizzle: the schema, and the generate-then-migrate loop.",
@@ -61,6 +75,14 @@ const docsConfig = {
           title: "Auth & Organizations",
           description:
             "Better Auth with OAuth, organizations, teams, and the role gate behind /console.",
+        },
+      },
+      {
+        "/docs/manage/organizations": {
+          title: "Organizations & Teams",
+          description:
+            "Multi-tenant from Better Auth: the org and team data model, roles, invitations, and active-org switching.",
+          label: "Organizations",
         },
       },
       {


### PR DESCRIPTION
Phase 1 of the docs & landing overhaul ([audit + plan](https://claude.ai/code/artifact/8255273c-b630-417c-aa6e-71746828f72a)): fill the P0 documentation gaps. The docs were already current on recent behavior; what was missing was **depth** on the headline features and **discoverability** for the adoption on-ramp.

## New pages (each grounded in the code)

- **CLI** (`/docs/getting-started/cli`) — the whole `init` / `reinit` / `sync` surface with a flag table, the gitpick + `.gitpickignore` fork boundary, the one-`site.ts` rebrand, and the fork-first-push release bootstrap. This was the single biggest adopter gap: the CLI *is* the on-ramp and had no page.
- **Organizations & Teams** (`/docs/manage/organizations`) — the org/team data model, roles, active-org switching, and an honest **wired-vs-unwired** split: create/switch are wired; invitations, teams, and member management are available in the plugin but not yet built into the UI (and invitation email isn't configured). The headline multi-tenant feature had ~12 lines before.
- **Rate Limiting** (`/docs/manage/rate-limiting`) — the two tiers, the user → API-key → IP keying, the env vars and window, the `429` envelope + `RateLimit-*` headers, and the API-key-stub caveat. Was buried in API Conventions.

## Gap fills on existing pages

- **Project Structure** — enumerate the by-domain `components/` tree (`common`/`shell`/`console`/`dashboard`/`docs`/`blog`/`marketing`/`ui`) from the #654 regroup, which lived only in the internal design skill.
- **Docker** — note the single-libc pruning and the self-contained, `node_modules`-free api runner (why the images are small).
- **Vercel** — document the `HONO_WEB_URL` zero-origin case (sign-in can't complete until it's set), not just the multi-origin one.
- **API Conventions** — trim the rate-limit section to a pointer at the new page.
- **Authentication** — link to the new Organizations page and drop the stale "invitations go out by email" claim (email delivery isn't wired).

All three pages are wired into `docs.config.ts`; `docs.ts --strict` and the full web build pass (117 static pages), and the nav lands them in the right groups.

## Verified in-browser

| CLI | Organizations & Teams | Rate Limiting |
|---|---|---|
| ![CLI](https://litter.catbox.moe/o0zkrd.png) | ![Organizations](https://litter.catbox.moe/7avj4k.png) | ![Rate Limiting](https://litter.catbox.moe/ntu73k.png) |

## Next

Phase 2 (breadth: Realtime/WebSockets page, agent-DX/doc-sync, OG depth, magic-link example) and Phase 3 (the landing pass) follow as separate PRs, per the plan.
