### PR TITLE
feat(cli): rebrand fork skills on sync, keep upstream refs + plain-text AGENTS.md links

### DIFF
--- a/.agents/skills/skills-manager/SKILL.md
+++ b/.agents/skills/skills-manager/SKILL.md
@@ -29,7 +29,7 @@ Each cell is the description's summary, the sentence before `Use ...`, so keep e
 
 ## How a fork syncs
 
-A fork inherits its skills from the scaffold, and the CLI marks each with `source: <upstream repo>` plus a `[!CAUTION]` note at the top. That note is the contract: `bunx zerostarter` updates a skill only while the note is intact and the body still matches upstream. Customize the skill or drop the note and the fork owns it. Check state with:
+A fork inherits its skills from the scaffold. On `init` and `sync` the CLI rebrands each skill's prose to the fork's project name (read from `package.json`) and marks it with `source: <upstream repo>` plus a `[!CAUTION]` note at the top. That note is the contract: `bunx zerostarter` updates a skill only while the note is intact and the body still matches upstream. Customize the skill or drop the note and the fork owns it. Check state with:
 
 ```bash
 bun .github/scripts/skills-manager.ts --outdated

--- a/.github/scripts/skills-manager.ts
+++ b/.github/scripts/skills-manager.ts
@@ -67,7 +67,7 @@ const table = (skills: Skill[]) =>
   [
     "| Skill | Description |",
     "| --- | --- |",
-    ...skills.map((s) => `| [\`${s.name}\`](.agents/skills/${s.dir}/SKILL.md) | ${s.summary} |`),
+    ...skills.map((s) => `| [${s.name}](.agents/skills/${s.dir}/SKILL.md) | ${s.summary} |`),
   ].join("\n")
 
 // Replace the body between `<!-- skills:<id> -->` and `<!-- /skills:<id> -->`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,26 +52,26 @@ Skills live in `.agents/skills` (symlinked to `.claude/skills` and `.github/skil
 
 <!-- skills:custom -->
 
-| Skill                                                      | Description                                                                                                                                                                         |
-| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`add-package`](.agents/skills/add-package/SKILL.md)       | Add a new shared workspace package under packages/*.                                                                                                                                |
-| [`api-endpoint`](.agents/skills/api-endpoint/SKILL.md)     | Add a typed Hono API endpoint or WebSocket route: router, OpenAPI docs, validation envelope, and RPC client wiring.                                                                 |
-| [`audit`](.agents/skills/audit/SKILL.md)                   | Run the dependency security audit and maintain .github/notes/dependencies.md.                                                                                                       |
-| [`codebase-map`](.agents/skills/codebase-map/SKILL.md)     | Orient in this repo: which file to edit for a change, how a change ripples across the stack, and how to search the code.                                                            |
-| [`db-migration`](.agents/skills/db-migration/SKILL.md)     | Create and apply a Drizzle schema change.                                                                                                                                           |
-| [`design`](.agents/skills/design/SKILL.md)                 | Follow and maintain the app's UI conventions.                                                                                                                                       |
-| [`dev`](.agents/skills/dev/SKILL.md)                       | Start, restart, and verify the ZeroStarter dev stack. `bun run dev` serves portless named `.localhost` URLs (branch-prefixed in a worktree); resolve them with `bunx portless get`. |
-| [`doc-sync`](.agents/skills/doc-sync/SKILL.md)             | Sync docs and skills so they never drift from the code.                                                                                                                             |
-| [`docker-test`](.agents/skills/docker-test/SKILL.md)       | Build and smoke-test the Docker images with docker compose.                                                                                                                         |
-| [`fonts`](.agents/skills/fonts/SKILL.md)                   | Add, swap, or remove a self-hosted web font (latin variable woff2 from fontsource, localized via next/font/local).                                                                  |
-| [`gh-commit`](.agents/skills/gh-commit/SKILL.md)           | Create atomic commits in the conventional format.                                                                                                                                   |
-| [`icebox`](.agents/skills/icebox/SKILL.md)                 | Icebox a raised-but-undecided concern instead of forcing a plan-or-dismiss call: record it with no verdict so the context survives.                                                 |
-| [`ignore-sync`](.agents/skills/ignore-sync/SKILL.md)       | Mirror .gitignore to .dockerignore.                                                                                                                                                 |
-| [`release`](.agents/skills/release/SKILL.md)               | Cut a production release by promoting canary to main.                                                                                                                               |
-| [`runtime-apis`](.agents/skills/runtime-apis/SKILL.md)     | Prefer Bun-native APIs, else Node built-ins with the node: prefix.                                                                                                                  |
-| [`shadcn-sync`](.agents/skills/shadcn-sync/SKILL.md)       | Run and reconcile the shadcn component sync (`bun run shadcn:update`).                                                                                                              |
-| [`skills-manager`](.agents/skills/skills-manager/SKILL.md) | Keep the AGENTS.md skills tables generated from skill descriptions, and understand how a fork syncs its skills from upstream.                                                       |
-| [`ui-verify`](.agents/skills/ui-verify/SKILL.md)           | Verify a frontend or UI change in a real browser.                                                                                                                                   |
+| Skill                                                    | Description                                                                                                                                                                         |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [add-package](.agents/skills/add-package/SKILL.md)       | Add a new shared workspace package under packages/*.                                                                                                                                |
+| [api-endpoint](.agents/skills/api-endpoint/SKILL.md)     | Add a typed Hono API endpoint or WebSocket route: router, OpenAPI docs, validation envelope, and RPC client wiring.                                                                 |
+| [audit](.agents/skills/audit/SKILL.md)                   | Run the dependency security audit and maintain .github/notes/dependencies.md.                                                                                                       |
+| [codebase-map](.agents/skills/codebase-map/SKILL.md)     | Orient in this repo: which file to edit for a change, how a change ripples across the stack, and how to search the code.                                                            |
+| [db-migration](.agents/skills/db-migration/SKILL.md)     | Create and apply a Drizzle schema change.                                                                                                                                           |
+| [design](.agents/skills/design/SKILL.md)                 | Follow and maintain the app's UI conventions.                                                                                                                                       |
+| [dev](.agents/skills/dev/SKILL.md)                       | Start, restart, and verify the ZeroStarter dev stack. `bun run dev` serves portless named `.localhost` URLs (branch-prefixed in a worktree); resolve them with `bunx portless get`. |
+| [doc-sync](.agents/skills/doc-sync/SKILL.md)             | Sync docs and skills so they never drift from the code.                                                                                                                             |
+| [docker-test](.agents/skills/docker-test/SKILL.md)       | Build and smoke-test the Docker images with docker compose.                                                                                                                         |
+| [fonts](.agents/skills/fonts/SKILL.md)                   | Add, swap, or remove a self-hosted web font (latin variable woff2 from fontsource, localized via next/font/local).                                                                  |
+| [gh-commit](.agents/skills/gh-commit/SKILL.md)           | Create atomic commits in the conventional format.                                                                                                                                   |
+| [icebox](.agents/skills/icebox/SKILL.md)                 | Icebox a raised-but-undecided concern instead of forcing a plan-or-dismiss call: record it with no verdict so the context survives.                                                 |
+| [ignore-sync](.agents/skills/ignore-sync/SKILL.md)       | Mirror .gitignore to .dockerignore.                                                                                                                                                 |
+| [release](.agents/skills/release/SKILL.md)               | Cut a production release by promoting canary to main.                                                                                                                               |
+| [runtime-apis](.agents/skills/runtime-apis/SKILL.md)     | Prefer Bun-native APIs, else Node built-ins with the node: prefix.                                                                                                                  |
+| [shadcn-sync](.agents/skills/shadcn-sync/SKILL.md)       | Run and reconcile the shadcn component sync (`bun run shadcn:update`).                                                                                                              |
+| [skills-manager](.agents/skills/skills-manager/SKILL.md) | Keep the AGENTS.md skills tables generated from skill descriptions, and understand how a fork syncs its skills from upstream.                                                       |
+| [ui-verify](.agents/skills/ui-verify/SKILL.md)           | Verify a frontend or UI change in a real browser.                                                                                                                                   |
 
 <!-- /skills:custom -->
 
@@ -79,9 +79,9 @@ Skills live in `.agents/skills` (symlinked to `.claude/skills` and `.github/skil
 
 <!-- skills:vendored -->
 
-| Skill                                                    | Description                                                                                                              |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| [`agent-browser`](.agents/skills/agent-browser/SKILL.md) | Browser automation CLI for AI agents.                                                                                    |
-| [`portless`](.agents/skills/portless/SKILL.md)           | Set up and use portless for named local dev server URLs (e.g. https://myapp.localhost instead of http://localhost:3000). |
+| Skill                                                  | Description                                                                                                              |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| [agent-browser](.agents/skills/agent-browser/SKILL.md) | Browser automation CLI for AI agents.                                                                                    |
+| [portless](.agents/skills/portless/SKILL.md)           | Set up and use portless for named local dev server URLs (e.g. https://myapp.localhost instead of http://localhost:3000). |
 
 <!-- /skills:vendored -->

--- a/packages/cli/bin/commands/sync.ts
+++ b/packages/cli/bin/commands/sync.ts
@@ -12,6 +12,7 @@ import {
 } from "@/git"
 import { exists, findPackageJsons, readJson, remove, writeJson } from "@/io"
 import { mergePkg, type Pkg } from "@/pkg"
+import { reconcileForkSkillsFromRoot } from "@/skills"
 
 import { parseArgsOrExit } from "./_args"
 import { ensureBun } from "./_bun"
@@ -78,6 +79,8 @@ export const sync = async (argv: string[]) => {
         if (!exists(path)) continue
         writeJson(path, mergePkg(forkPkg, readJson<Pkg>(path), path === rootPkg))
       }
+      // Rebrand the overlaid skills to the fork: the overlay re-added upstream SKILL.md files naming "zerostarter", so re-run init's reconcile, sourcing the fork name from the just-restored root package.json.
+      reconcileForkSkillsFromRoot(target)
       // Restore the fork-owned local files the .gitpickignore directive names (favicon, audit record).
       await gitRestore(target, preserve)
     },

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -14,9 +14,9 @@ export const slugify = (value: string): string =>
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "") || "app"
 
-// Rename the upstream identity to the fork's in prose only; the frontmatter source line is set separately and never rewritten, so it keeps pointing at the real upstream repo.
+// Rebrand the fork's own identity (display name, portless dev-URL names, docker image, log paths) while preserving upstream references: `bunx zerostarter` is the CLI a fork still runs to sync (it ships none of its own) and "zerostarter scaffolding CLI" names that upstream tool, so a lowercase "zerostarter" preceded by "bunx " or followed by " scaffolding CLI" is left alone. The frontmatter source line and sync note are stamped separately and never pass through here.
 const reconcile = (text: string, slug: string, name: string): string =>
-  text.replaceAll("ZeroStarter", name).replaceAll("zerostarter", slug)
+  text.replaceAll("ZeroStarter", name).replace(/(?<!bunx )zerostarter(?! scaffolding CLI)/g, slug)
 
 // The sync CAUTION stamped just below each fork skill's frontmatter; its presence is the contract, since bunx zerostarter updates a skill only while the note is intact and the body still matches upstream, and customizing the skill or dropping the note hands ownership to the fork.
 const syncNote = (): string =>

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from "node:fs"
 import { join } from "node:path"
 
-import { exists, read, write } from "@/io"
+import { exists, read, readJson, write } from "@/io"
 import type { Brand } from "@/templates"
 
 // A fork inherits its whole skill set from zerostarter (vendored skills included, received through zerostarter rather than the tool directly), so every scaffolded skill is marked as synced from here.
@@ -21,7 +21,7 @@ const reconcile = (text: string, slug: string, name: string): string =>
 // The sync CAUTION stamped just below each fork skill's frontmatter; its presence is the contract, since bunx zerostarter updates a skill only while the note is intact and the body still matches upstream, and customizing the skill or dropping the note hands ownership to the fork.
 const syncNote = (): string =>
   `> [!CAUTION]
-> Synced from ${UPSTREAM}. If you customize this skill or remove this note, it stops syncing and your fork owns it.`
+> Synced from ${UPSTREAM}. Customize this skill or remove this note to stop syncing.`
 
 // Reconcile every scaffolded skill to the fork: rename the upstream identity in prose, point source at the upstream repo, and stamp the sync note; a fork has no packages/cli of its own, so bunx zerostarter is how it later pulls skill updates.
 export const reconcileForkSkills = (root: string, brand: Brand): void => {
@@ -49,4 +49,10 @@ export const reconcileForkSkills = (root: string, brand: Brand): void => {
     const body = reconcile(lines.slice(close + 1).join("\n"), slug, brand.name).replace(/^\n+/, "")
     write(file, `---\n${fm.join("\n")}\n---\n\n${syncNote()}\n\n${body}`)
   }
+}
+
+// Rebrand a fork's overlaid skills from its own package.json name. A sync overlay re-adds upstream SKILL.md files that name "zerostarter" and there is no brand prompt, so source the fork identity from the preserved root package.json (mergePkg keeps `name` on sync). A missing name (never scaffolded) is a no-op.
+export const reconcileForkSkillsFromRoot = (root: string): void => {
+  const name = readJson<{ name?: string }>(join(root, "package.json")).name
+  if (name) reconcileForkSkills(root, { name })
 }

--- a/packages/cli/test/convert.test.ts
+++ b/packages/cli/test/convert.test.ts
@@ -274,4 +274,21 @@ describe("reconcileForkSkillsFromRoot (sync path)", () => {
     expect(() => reconcileForkSkillsFromRoot(dir)).not.toThrow()
     expect(read(join(dir, ".agents/skills/dev/SKILL.md"))).toContain("ZeroStarter")
   })
+
+  test("keeps upstream refs (bunx zerostarter, scaffolding CLI) but rebrands fork identity", () => {
+    write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
+    write(
+      join(dir, ".agents/skills/codebase-map/SKILL.md"),
+      "---\nname: codebase-map\ndescription: Orient in the repo.\nsource: local\n---\n\n" +
+        "Sync with `bunx zerostarter sync`; `packages/cli/` is the zerostarter scaffolding CLI.\n" +
+        "Dev URL `bunx portless get zerostarter`, api `api.zerostarter`, image `zerostarter-web`.\n",
+    )
+    reconcileForkSkillsFromRoot(dir)
+    const skill = read(join(dir, ".agents/skills/codebase-map/SKILL.md"))
+    expect(skill).toContain("bunx zerostarter sync")
+    expect(skill).toContain("zerostarter scaffolding CLI")
+    expect(skill).toContain("portless get acme-app")
+    expect(skill).toContain("api.acme-app")
+    expect(skill).toContain("acme-app-web")
+  })
 })

--- a/packages/cli/test/convert.test.ts
+++ b/packages/cli/test/convert.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 import { convertRepo, fixDangling } from "@/convert"
 import { exists, read, readJson, write } from "@/io"
+import { reconcileForkSkillsFromRoot } from "@/skills"
 
 let dir: string
 beforeEach(() => {
@@ -241,5 +242,36 @@ describe("convertRepo (in-place)", () => {
     expect(skill).toContain("source: https://github.com/nrjdalal/zerostarter")
     expect(skill).not.toContain("source: agent-browser")
     expect(skill).toContain("[!CAUTION]")
+  })
+})
+
+describe("reconcileForkSkillsFromRoot (sync path)", () => {
+  const devSkill = (dir: string) =>
+    write(
+      join(dir, ".agents/skills/dev/SKILL.md"),
+      "---\nname: dev\ndescription: Start the ZeroStarter dev stack.\nsource: local\n---\n\n# Dev\n\nRun `bunx portless get zerostarter`.\n",
+    )
+
+  test("rebrands overlaid skills from the fork's package.json name", () => {
+    write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
+    devSkill(dir)
+    reconcileForkSkillsFromRoot(dir)
+    const skill = read(join(dir, ".agents/skills/dev/SKILL.md"))
+    expect(skill).toContain("source: https://github.com/nrjdalal/zerostarter")
+    expect(skill).toContain("[!CAUTION]")
+    expect(skill).toContain("Start the acme-app dev stack")
+    expect(skill).toContain("portless get acme-app")
+    expect(skill).not.toContain("ZeroStarter")
+    expect(skill).not.toContain("get zerostarter")
+    // The upstream URL in the source line and sync note must NOT be rebranded to the fork.
+    expect(skill).toContain("Synced from https://github.com/nrjdalal/zerostarter")
+    expect(skill).not.toContain("nrjdalal/acme-app")
+  })
+
+  test("no-ops when the root package.json has no name", () => {
+    write(join(dir, "package.json"), JSON.stringify({ version: "1.0.0" }))
+    devSkill(dir)
+    expect(() => reconcileForkSkillsFromRoot(dir)).not.toThrow()
+    expect(read(join(dir, ".agents/skills/dev/SKILL.md"))).toContain("ZeroStarter")
   })
 })

--- a/web/next/content/docs/getting-started/cli.mdx
+++ b/web/next/content/docs/getting-started/cli.mdx
@@ -57,7 +57,7 @@ bunx zerostarter sync [dir]
 
 Overlays the latest starter onto your fork, updating shared starter files while preserving everything your fork owns. Unlike `init` and `reinit`, it does not commit: it leaves the changes in your working tree so you review the diff and commit yourself. It requires a clean repo and rolls back on failure.
 
-What it preserves: your content, `public/`, marketing, `packages/config/src/site.ts` branding, `README.md`, your root package identity (name, version, author fields), and the `PRESERVE_ON_SYNC` paths (`bun.lock`, `packages/db/drizzle/`, `packages/db/src/schema/`, `web/next/docs.config.ts`, and the favicon). What it overwrites: every shared starter file, so local edits to those are replaced by the upstream version.
+What it preserves: your content, `public/`, marketing, `packages/config/src/site.ts` branding, `README.md`, your root package identity (name, version, author fields), and the `PRESERVE_ON_SYNC` paths (`bun.lock`, `packages/db/drizzle/`, `packages/db/src/schema/`, `web/next/docs.config.ts`, and the favicon). What it overwrites: every shared starter file, so local edits to those are replaced by the upstream version. The overlaid skills in `.agents/skills/` are then rebranded to your project name (read from `package.json`), matching `init`, so a synced skill keeps your identity rather than the starter's.
 
 ```bash
 # review before committing


### PR DESCRIPTION
Makes a fork's skills read correctly, sourced from `package.json.name`.

## 1. Rebrand fork skills on `sync`

`.agents/skills/` is not preserved on sync, so every `bunx zerostarter sync` overlays the skills fresh from upstream (naming "zerostarter"), but `reconcileForkSkills` ran only in `init`/`reinit` — so a fork reverted to the starter's name on each sync. New `reconcileForkSkillsFromRoot` sources the fork name from the preserved root `package.json` and runs inside sync's atomic block.

## 2. Keep upstream references when rebranding

`reconcile` blunt-replaced every "zerostarter", which corrupted the two spots a fork must keep: `bunx zerostarter` (the CLI a fork still runs) and "the zerostarter scaffolding CLI". Now a lowercase `zerostarter` preceded by `bunx ` or followed by ` scaffolding CLI` is left alone; everything else still rebrands (portless dev-URLs, display, docker image `<slug>-web`, log paths). Fixes `init`/`reinit` too. The `source:` line and `[!CAUTION]` note are stamped verbatim, so the upstream URL is never rebranded (tested).

## 3. AGENTS.md polish

- Plain-text `[name](.agents/skills/name/SKILL.md)` links (dropped code font).
- Shortened the sync note.

## Verification

`bun test` (cli) 121 pass (+3), `check-types`/`oxfmt`/`oxlint`/`skills-manager --check` clean, no em-dashes. Docs: `cli.mdx` + `skills-manager` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACcMhx4kE3a9Paih7H2wH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync now rebrands overlaid skills using the project name from `package.json`, preserving project-specific identity.
  * Existing upstream references and scaffolding instructions remain intact during synchronization.

* **Documentation**
  * Updated sync documentation to explain how skill identity is handled.

* **Style**
  * Simplified skill links in the skills tables by removing inline-code formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->