### PR TITLE
fix(skills): quote skill descriptions containing a colon

### DIFF
--- a/.agents/skills/api-endpoint/SKILL.md
+++ b/.agents/skills/api-endpoint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-endpoint
-description: Add a typed Hono API endpoint or WebSocket route: router, OpenAPI docs, validation envelope, and RPC client wiring. Use when adding or modifying routes in api/hono.
+description: "Add a typed Hono API endpoint or WebSocket route: router, OpenAPI docs, validation envelope, and RPC client wiring. Use when adding or modifying routes in api/hono."
 ---
 
 # API Endpoint

--- a/.agents/skills/codebase-map/SKILL.md
+++ b/.agents/skills/codebase-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-map
-description: Orient in this repo: which file to edit for a change, how a change ripples across the stack, and how to search the code. Use at the start of a task in an unfamiliar area, or before a cross-cutting change.
+description: "Orient in this repo: which file to edit for a change, how a change ripples across the stack, and how to search the code. Use at the start of a task in an unfamiliar area, or before a cross-cutting change."
 ---
 
 # Codebase Map

--- a/.agents/skills/icebox/SKILL.md
+++ b/.agents/skills/icebox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: icebox
-description: Icebox a raised-but-undecided concern instead of forcing a plan-or-dismiss call: record it with no verdict so the context survives. Use when a review, PR, audit, or eval surfaces something real-maybe that should not be scheduled or closed yet, or when the user says to icebox or park an item.
+description: "Icebox a raised-but-undecided concern instead of forcing a plan-or-dismiss call: record it with no verdict so the context survives. Use when a review, PR, audit, or eval surfaces something real-maybe that should not be scheduled or closed yet, or when the user says to icebox or park an item."
 ---
 
 # Icebox

--- a/.agents/skills/runtime-apis/SKILL.md
+++ b/.agents/skills/runtime-apis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runtime-apis
-description: Prefer Bun-native APIs, else Node built-ins with the node: prefix. Use when importing a Node built-in (fs, path, child_process, crypto, os, util), reading or writing files, spawning a process, or choosing between a Bun and a Node API.
+description: "Prefer Bun-native APIs, else Node built-ins with the node: prefix. Use when importing a Node built-in (fs, path, child_process, crypto, os, util), reading or writing files, spawning a process, or choosing between a Bun and a Node API."
 ---
 
 # Runtime APIs


### PR DESCRIPTION
## Problem

Four `SKILL.md` files render on GitHub as:

> Error in user YAML: (\<unknown\>): mapping values are not allowed in this context at line 2 column 33

Their `description` is an unquoted YAML scalar containing a colon-space, so the parser reads the text after the colon as a nested mapping key inside an already-open mapping. GitHub then drops the frontmatter table and shows the error banner instead. Forks inherit the same files, which is where it was spotted.

Column 33 on `codebase-map` lines up exactly: `description: ` ends at 13, `Orient in this repo` runs 14-32, the stray colon lands on 33. (GitHub strips the opening `---`, so its "line 2" is file line 3.)

## Fix

Quote the four affected values. The description text itself is byte-identical, so skill matching is unaffected.

| File | Offending substring |
| --- | --- |
| `.agents/skills/api-endpoint/SKILL.md` | `WebSocket route: router,` |
| `.agents/skills/codebase-map/SKILL.md` | `in this repo: which file` |
| `.agents/skills/icebox/SKILL.md` | `plan-or-dismiss call: record` |
| `.agents/skills/runtime-apis/SKILL.md` | `the node: prefix` |

The diff against `canary` is exactly those four lines, nothing else.

## Verification

Parsed the frontmatter block of every `.md`/`.mdx` in the tree with a real YAML parser:

- Before: the four files above throw; nothing else does.
- After: all 56 frontmatter blocks parse clean.

Also confirmed on the pushed branch that GitHub now renders `codebase-map/SKILL.md` without the error banner.

`#738`'s fork-skill reconcile is unaffected: `packages/cli/src/skills.ts` only rewrites `source:` lines in the frontmatter and rebrands the body, never `description:`.

No doc sync needed. The skill tables in `AGENTS.md`/`CLAUDE.md` are Markdown, not YAML, and the description wording did not change.