### PR TITLE
fix(scripts): make the skills-manager parser quote-aware

### DIFF
--- a/.github/scripts/skills-manager.ts
+++ b/.github/scripts/skills-manager.ts
@@ -22,17 +22,23 @@ type Skill = {
   file: string
 }
 
-// Parse the `---` frontmatter block into a flat key->value map (values are single-line here).
+// Parse the `---` frontmatter into a flat key->string map via real YAML, so a quoted value (a description with a colon must be quoted for strict parsers like GitHub's) is unwrapped, not read literally; fail loudly on an unquoted colon so a GitHub-unrenderable description never lands.
 function frontmatter(text: string): Record<string, string> {
   const lines = text.split("\n")
   if (lines[0] !== "---") throw new Error("missing frontmatter")
   const end = lines.indexOf("---", 1)
   if (end === -1) throw new Error("unterminated frontmatter")
-  const fm: Record<string, string> = {}
   for (const line of lines.slice(1, end)) {
-    const m = line.match(/^([a-z0-9_-]+):\s*(.*)$/i)
-    if (m) fm[m[1]!] = m[2]!.trim()
+    const m = line.match(/^([a-z0-9_-]+): (.*: .*)$/i)
+    if (m && !/^["']/.test(m[2]!))
+      throw new Error(
+        `frontmatter "${m[1]}" has an unquoted colon; wrap the value in quotes, since strict YAML like GitHub's rejects it: ${line.trim()}`,
+      )
   }
+  const parsed = Bun.YAML.parse(lines.slice(1, end).join("\n"))
+  const fm: Record<string, string> = {}
+  if (parsed && typeof parsed === "object")
+    for (const [k, v] of Object.entries(parsed)) if (typeof v === "string") fm[k] = v
   return fm
 }
 


### PR DESCRIPTION
Completes #740. That PR quoted the 4 skill descriptions containing a colon (strict YAML like GitHub's rejects an unquoted `key: a: b`, which was rendering "Error in user YAML" on those SKILL.md files), but it changed only the SKILL.md files.

## The problem it left

`skills-manager.ts`'s frontmatter parser is a regex that reads everything after `key: ` literally, so it pulled the surrounding quotes into the generated AGENTS.md table (`| "Orient in this repo…`). As a result, **on canary right now `bun .github/scripts/skills-manager.ts --check` fails** ("tables are stale"), and the next skill edit's pre-commit auto-regen would commit a quote-corrupted table.

## Fix

- Parse the frontmatter with real YAML (`Bun.YAML.parse`) so a quoted value is unwrapped, not read literally.
- **Guard:** throw on an unquoted value containing a colon, so a GitHub-unrenderable description fails `--check`/pre-commit instead of shipping. Message points at the offending line and says to quote it.

## Verification

- `skills-manager --check` now **passes**; regenerating AGENTS.md produces **zero diff** (the committed table was already correct).
- Guard fires on an injected unquoted-colon description with a clear message.
- `--outdated` unaffected; `check-types` (incl. `tsgo` on `.github/scripts`), `oxfmt`, `oxlint` clean; no em-dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CACcMhx4kE3a9Paih7H2wH