### PR TITLE
docs(plans): add the Icebox section and park the RSS feed decision

### DIFF
--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -38,3 +38,9 @@ Candidate refactors that turn a scattered cluster into one deep module, ordered 
 - [One typed API envelope and a defineRoute helper](api-envelope-typed-endpoint.md) - shared `Envelope<T>` + boilerplate collapse; subsumes #664.
 - [Consolidate OG rendering behind one seam](og-render-consolidation.md) - #485; broadened to own size + URL scheme + defaults.
 - [Consolidate env into one schema with callable validation](env-schema-consolidation.md) - speculative; collapses shared-key duplication and import-time coupling.
+
+## Icebox
+
+Raised but undecided: real concerns with no agreed next action and no confident verdict. They sit here rather than in the backlog (which implies a plan) or closed (which loses the context), and leave only by being decided. Mirrored as checkboxes on the standing Icebox issue (#707).
+
+- [RSS feed](rss-feed.md) - built and removed on #744; ship by default, feature-flag it, or leave it to forks.

--- a/.github/notes/plans/rss-feed.md
+++ b/.github/notes/plans/rss-feed.md
@@ -1,0 +1,13 @@
+# RSS feed
+
+## Concern
+
+The blog ships machine-readable routes for agents (`/blog.md`, `/llms.txt`, `/llms-full.txt`) but nothing for humans' feed readers. A design critique flagged this as an inconsistency on a surface that advertises agent-readability as a feature: `/rss.xml`, `/feed.xml`, and `/blog/rss.xml` all 404 while the agent routes return 200.
+
+## Context
+
+A working implementation was built and then removed on PR #744 before merge. It lived at `web/next/src/app/rss.xml/route.ts`: RSS 2.0, `force-static` with `revalidate = 60`, gated on the same `getPublishedBlogPosts()` seam `sitemap.ts` uses so drafts could not leak, `dc:creator` rather than the RSS-invalid `<author>` display name, every interpolated value XML-escaped, and advertised via `alternates.types` in the root layout for autodiscovery. It served 200 with a valid document over the three published posts. The commit history on that branch has it if it is wanted back.
+
+## Open question
+
+Whether the starter should ship a feed at all. It is a fork-inherited surface, so every downstream site carries it, and no reader demand has been observed. Against that, it is small, has no dependencies, and reuses the publish gate that already exists. Undecided: shipping it by default, putting it behind a feature flag alongside `docs`/`blog`/`waitlist`, or leaving it out and letting a fork add it.


### PR DESCRIPTION
Split out of #744, which keeps the landing-page work.

The `icebox` skill says to link parked items under an `## Icebox` heading in `.github/notes/plans/README.md`, but the index had no such section, so the checkboxes on the standing Icebox issue (#707) pointed at nothing. This adds the section with its definition.

First entry is the **RSS feed**. A working implementation was built on #744 and removed before merge at the maintainer's request. The note records what existed (RSS 2.0, `force-static` with `revalidate = 60`, gated on the same `getPublishedBlogPosts()` seam `sitemap.ts` uses so drafts could not leak, `dc:creator` rather than the RSS-invalid `<author>`, every interpolated value escaped, autodiscovery via `alternates.types`) and what is unresolved: whether the starter should ship a feed at all, ship it behind a feature flag, or leave it to forks.

No verdict and no plan, per the skill: ice is for the genuinely undecided.

Docs only, no code.