### PR TITLE
fix(cli): honor skill provenance on sync, fix the marketing-fonts abort and --outdated drift

### DIFF
--- a/.agents/skills/skills-manager/SKILL.md
+++ b/.agents/skills/skills-manager/SKILL.md
@@ -14,7 +14,7 @@ Each skill carries its **provenance** in frontmatter:
 
 - `source: local` is authored here (this repo is the origin).
 - `source: <tool>` is vendored: re-synced by re-running the tool, never hand-edited.
-- `source: https://github.com/<owner>/<repo>` marks a skill a fork syncs from upstream (the CLI stamps this, with a `[!CAUTION]` sync note, when it scaffolds a fork).
+- `source: https://github.com/<owner>/<repo>` marks a skill a fork syncs from upstream (the CLI stamps this, with a `[!CAUTION]` sync note, when it scaffolds a fork). A synced skill also carries two drift stamps: `source-hash` (the upstream body it was last synced from) and `synced-hash` (the body as written by that sync). Both are 16 hex chars of sha256 over the LF-normalized, trimmed body, always double-quoted (an all-digit hash would otherwise parse as a YAML number and vanish); the implementations in `packages/cli/src/skills.ts` and `.github/scripts/skills-manager.ts` must stay identical.
 
 ## Regenerate the tables
 
@@ -29,13 +29,13 @@ Each cell is the description's summary, the sentence before `Use ...`, so keep e
 
 ## How a fork syncs
 
-A fork inherits its skills from the scaffold. On `init` and `sync` the CLI rebrands each skill's prose to the fork's project name (read from `package.json`) and marks it with `source: <upstream repo>` plus a `[!CAUTION]` note at the top. That note is the contract: `bunx zerostarter` updates a skill only while the note is intact and the body still matches upstream. Customize the skill or drop the note and the fork owns it. Check state with:
+A fork inherits its skills from the scaffold. On `init` the CLI rebrands each skill's prose to the fork's project name (read from `package.json`) and marks it with `source: <upstream repo>`, a `[!CAUTION]` note at the top, and the two drift stamps. That is the contract, and `sync` enforces it per skill from a pre-overlay snapshot: it takes the fresh upstream body only when `source` is the upstream repo, the note is intact, and the body still hashes to `synced-hash` (nothing was customized since the last sync). A non-upstream `source` (local, a tool, another repo), a removed note, or a customized body leaves the fork's file exactly as it was. The one exception is a note-intact skill with no stamp (synced before stamps existed): it is overwritten once to gain its stamps, and named in the sync summary so a lost customization is recoverable from the diff. Check state with:
 
 ```bash
 bun .github/scripts/skills-manager.ts --outdated
 ```
 
-which reports each skill as `local, no upstream`, `vendored (<tool>)`, or, for a synced skill, `up to date` / `DIFFERS from upstream`.
+which reports each skill as `local, no upstream`, `vendored (<tool>)`, or, for a synced skill, `up to date` / `OUTDATED (upstream changed since the last sync)`, comparing `source-hash` against a fresh upstream fetch (the sync transform guarantees raw bodies never match in a fork), and `unverifiable` when the stamp is missing.
 
 ## Notes
 

--- a/.github/scripts/skills-manager.ts
+++ b/.github/scripts/skills-manager.ts
@@ -7,6 +7,7 @@ import { $, Glob } from "bun"
 //   bun .github/scripts/skills-manager.ts --check    fail on drift instead of writing (the pre-commit gate)
 //   bun .github/scripts/skills-manager.ts --outdated fetch each skill's source upstream and report drift
 // A skill's source is its provenance: a full github link it was inherited from (checked by --outdated), a bare tool name (vendored, re-run the tool), or local (authored here).
+// A synced skill also carries source-hash, the hash of the upstream body it was last synced from (stamped by bunx zerostarter); --outdated compares that against a fresh upstream fetch, since the sync transform (rebrand + sync note) guarantees the raw bodies never match in a fork.
 
 const ROOT = path.resolve(import.meta.dir, "../..")
 const SKILLS_DIR = path.join(ROOT, ".agents/skills")
@@ -18,6 +19,7 @@ type Skill = {
   description: string
   summary: string
   source: string
+  sourceHash: string
   dir: string
   file: string
 }
@@ -62,6 +64,7 @@ async function readSkills(): Promise<Skill[]> {
       description: fm.description,
       summary: summaryOf(fm.description),
       source: fm.source,
+      sourceHash: fm["source-hash"] ?? "",
       dir: rel.split(/[/\\]/)[0]!,
       file,
     })
@@ -103,6 +106,13 @@ async function format(doc: string): Promise<string> {
   }
 }
 
+// Drift stamp shared with packages/cli/src/skills.ts (the sync writes it): 16 hex chars of sha256 over the LF-normalized, trimmed text; keep both implementations identical.
+const hashBody = (text: string): string =>
+  new Bun.CryptoHasher("sha256")
+    .update(text.replace(/\r\n/g, "\n").trim())
+    .digest("hex")
+    .slice(0, 16)
+
 async function outdated(): Promise<void> {
   const skills = await readSkills()
   for (const s of skills) {
@@ -128,7 +138,18 @@ async function outdated(): Promise<void> {
     const body = (t: string) => t.slice(t.indexOf("---", 3) + 3).trim()
     const ours = body(await Bun.file(s.file).text())
     const theirs = body(await res.text())
-    console.log(`  ${s.name}: ${ours === theirs ? "up to date" : "DIFFERS from upstream"}`)
+    if (ours === theirs) {
+      console.log(`  ${s.name}: up to date`)
+      continue
+    }
+    // In a fork the sync transform (rebrand + sync note) guarantees the raw bodies differ, so the real signal is the source-hash stamp: it changes only when upstream's body has.
+    if (s.sourceHash) {
+      console.log(
+        `  ${s.name}: ${hashBody(theirs) === s.sourceHash ? "up to date" : "OUTDATED (upstream changed since the last sync)"}`,
+      )
+      continue
+    }
+    console.log(`  ${s.name}: unverifiable (no source-hash stamp; bunx zerostarter sync adds one)`)
   }
 }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents working in this repository, a Bun monorepo: the `p
 
 ## Workflow
 
-- ALWAYS: Do every change in its own git worktree, never on the primary checked-out branch. Create it under `.claude/worktrees/` (repo-root relative, one directory per worktree; never `/tmp`, home, or a sibling of the repo), and merge the latest `canary` into the working branch before starting so the change builds on current main.
+- ALWAYS: Do every change in its own git worktree, never on the primary checked-out branch. Create it under `.claude/worktrees/` (repo-root relative, one directory per worktree; never `/tmp`, home, or a sibling of the repo), and fork its branch from the latest `canary`: fetch first, then branch from `origin/canary` (`git fetch origin canary && git worktree add .claude/worktrees/<name> -b <branch> origin/canary`), so the change builds on current main.
 - ALWAYS: Keep documentation in sync with every change. Whenever code, structure, conventions, or tooling change, update the matching docs in the same change (e.g. `web/next/content/docs/`, `README.md`, the `llms.txt`/`llms-full.txt` context routes, skill docs under `.agents/skills/` and `.claude/skills/`, and these agent guides `AGENTS.md`/`CLAUDE.md`). Docs must never drift. See the `doc-sync` skill.
 - ALWAYS: When code, a convention, a command, a path, or tooling changes, review the skills in `.agents/skills/` that touch it and update them in the same change, so every skill stays accurate and relevant. A skill that describes old behavior misleads every agent that loads it, which is worse than no skill. If a change makes a skill obsolete, remove it; if it reveals a gap, consider adding one.
 

--- a/packages/cli/bin/commands/sync.ts
+++ b/packages/cli/bin/commands/sync.ts
@@ -12,7 +12,7 @@ import {
 } from "@/git"
 import { exists, findPackageJsons, readJson, remove, writeJson } from "@/io"
 import { mergePkg, type Pkg } from "@/pkg"
-import { reconcileForkSkillsFromRoot } from "@/skills"
+import { type SkillSyncResult, snapshotForkSkills, syncForkSkills } from "@/skills"
 
 import { parseArgsOrExit } from "./_args"
 import { ensureBun } from "./_bun"
@@ -57,6 +57,8 @@ export const sync = async (argv: string[]) => {
   const rootPkg = join(target, "package.json")
   // Snapshot every workspace manifest before the overlay overwrites them (web/next + api/hono carry the deps).
   const forkPkgs = new Map(findPackageJsons(target).map((p) => [p, readJson<Pkg>(p)]))
+  // Snapshot every skill too: the overlay re-adds upstream SKILL.md files, and the reconcile decides per skill, from this snapshot, whether the fork owns it.
+  const forkSkills = snapshotForkSkills(target)
 
   // Read the preserve directive before the overlay, so a fetch error aborts before mutating the fork.
   const preserve = parseForkLayout(await fetchGitpickignore()).preserve
@@ -65,6 +67,7 @@ export const sync = async (argv: string[]) => {
   }
 
   // Run overlay + reconcile atomically; withRollback resets to the pre-sync commit on any failure.
+  let skills: SkillSyncResult = { added: [], kept: [], skipped: [], unverified: [], updated: [] }
   await withRollback(
     target,
     yellow("Sync failed; rolled the working tree back to your last commit."),
@@ -79,8 +82,8 @@ export const sync = async (argv: string[]) => {
         if (!exists(path)) continue
         writeJson(path, mergePkg(forkPkg, readJson<Pkg>(path), path === rootPkg))
       }
-      // Rebrand the overlaid skills to the fork: the overlay re-added upstream SKILL.md files naming "zerostarter", so re-run init's reconcile, sourcing the fork name from the just-restored root package.json.
-      reconcileForkSkillsFromRoot(target)
+      // Reconcile the overlaid skills to the fork, honoring provenance: only note-intact, uncustomized upstream-sourced skills take the fresh body; everything else is restored from the pre-overlay snapshot.
+      skills = syncForkSkills(target, forkSkills)
       // Restore the fork-owned local files the .gitpickignore directive names (favicon, audit record).
       await gitRestore(target, preserve)
     },
@@ -93,8 +96,20 @@ export const sync = async (argv: string[]) => {
   note(
     [
       "Starter files were updated (edits overwritten); your content, public/marketing, and branding were preserved.",
+      skills.added.length > 0 && `Skills added from upstream: ${skills.added.join(", ")}`,
+      skills.updated.length > 0 && `Skills updated from upstream: ${skills.updated.join(", ")}`,
+      skills.unverified.length > 0 &&
+        yellow(
+          `Skills overwritten without a sync stamp (this sync adds one; recover any customization from the diff): ${skills.unverified.join(", ")}`,
+        ),
+      skills.skipped.length > 0 &&
+        `Skills left untouched (customized or sync note removed; the fork owns them): ${skills.skipped.join(", ")}`,
+      skills.kept.length > 0 &&
+        `Skills left untouched (local or vendored provenance): ${skills.kept.join(", ")}`,
       yellow(`Review the diff and commit: git -C ${target} status`),
-    ].join("\n"),
+    ]
+      .filter((line): line is string => Boolean(line))
+      .join("\n"),
     "Review the changes",
   )
   outro(orange("Synced to the latest ZeroStarter"))

--- a/packages/cli/src/convert.ts
+++ b/packages/cli/src/convert.ts
@@ -59,18 +59,12 @@ const scaffoldContent = (root: string, brand: Brand): void => {
   write(p(root, "README.md"), readmeTemplate(brand))
 }
 
-// Strip the dangling /hire entry the route excludes leave in the shared navbar, then fail loudly on drift.
+// Strip the dangling /hire entry the route excludes leave in the shared navbar, then fail loudly on drift. Runs on init and sync, so it must tolerate a fork that owns fork-excluded modules (web/next/src/lib/marketing/); the init-only strip invariant lives in assertMarketingStripped.
 export const fixDangling = (root: string): void => {
   const fontsPath = p(root, "web/next/src/lib/fonts.ts")
-  const marketingFontsPath = p(root, "web/next/src/lib/marketing/fonts.ts")
   const navPath = p(root, "web/next/src/components/common/navbar.tsx")
   removeMatch(navPath, HIRE_NAV)
-  // The author-only marketing fonts are wholesale fork-excluded (web/next/src/lib/marketing/ in .gitpickignore). If the module survived, that .gitpickignore path drifted; if the shared fonts.ts refers to fonts/marketing/, a marketing font leaked back into the file that ships to forks (whose woff2 dir does not).
-  if (exists(marketingFontsPath)) {
-    throw new Error(
-      "web/next/src/lib/marketing/fonts.ts survived the fork strip (add web/next/src/lib/marketing/ to .gitpickignore).",
-    )
-  }
+  // If the shared fonts.ts refers to fonts/marketing/, a marketing font leaked back into the file that ships to forks (whose woff2 dir does not).
   if (exists(fontsPath) && read(fontsPath).includes("fonts/marketing/")) {
     throw new Error(
       "fonts.ts references fonts/marketing/; author-only marketing fonts must live in the fork-excluded web/next/src/lib/marketing/, not the shared fonts.ts.",
@@ -79,6 +73,15 @@ export const fixDangling = (root: string): void => {
   if (exists(navPath) && /href:\s*["']\/hire["']/.test(read(navPath))) {
     throw new Error(
       "common/navbar.tsx still has the /hire entry after fixDangling (regex drift). Update packages/cli/src/convert.ts.",
+    )
+  }
+}
+
+// Init/reinit-only invariant: the fork strip must have removed the author-only marketing font module (web/next/src/lib/marketing/ in .gitpickignore); if it survived, that .gitpickignore path drifted. Never run on sync, where a fork legitimately owns the directory.
+export const assertMarketingStripped = (root: string): void => {
+  if (exists(p(root, "web/next/src/lib/marketing/fonts.ts"))) {
+    throw new Error(
+      "web/next/src/lib/marketing/fonts.ts survived the fork strip (add web/next/src/lib/marketing/ to .gitpickignore).",
     )
   }
 }
@@ -121,6 +124,7 @@ export const convertRepo = (
   removeForkExcludes(root)
   scaffoldContent(root, brand)
   fixDangling(root)
+  assertMarketingStripped(root)
   rebrand(root, brand, features)
   // Reconcile the inherited skills to the fork: rename the upstream identity, point source at it, and stamp the sync note.
   reconcileForkSkills(root, brand)

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { readdirSync } from "node:fs"
 import { join } from "node:path"
 
@@ -23,36 +24,119 @@ const syncNote = (): string =>
   `> [!CAUTION]
 > Synced from ${UPSTREAM}. Customize this skill or remove this note to stop syncing.`
 
-// Reconcile every scaffolded skill to the fork: rename the upstream identity in prose, point source at the upstream repo, and stamp the sync note; a fork has no packages/cli of its own, so bunx zerostarter is how it later pulls skill updates.
-export const reconcileForkSkills = (root: string, brand: Brand): void => {
+// Drift stamp shared with .github/scripts/skills-manager.ts: 16 hex chars of sha256 over the LF-normalized, trimmed text; keep both implementations identical.
+const hashBody = (text: string): string =>
+  createHash("sha256").update(text.replace(/\r\n/g, "\n").trim()).digest("hex").slice(0, 16)
+
+// Split a SKILL.md into frontmatter lines and body, tolerating CRLF (a gitpick checkout on Windows); throws on a missing frontmatter block, which means the skill shape drifted.
+const splitSkill = (skill: string, text: string): { fm: string[]; body: string } => {
+  const lines = text.replace(/\r\n/g, "\n").split("\n")
+  const close = lines.indexOf("---", 1)
+  if (lines[0] !== "---" || close === -1) {
+    throw new Error(
+      `.agents/skills/${skill}/SKILL.md has no frontmatter to reconcile (the skill shape drifted). Update packages/cli/src/skills.ts.`,
+    )
+  }
+  return { body: lines.slice(close + 1).join("\n"), fm: lines.slice(1, close) }
+}
+
+// Read a single-line frontmatter value, unwrapping double quotes; "" when the key is absent.
+const fmValue = (fm: string[], key: string): string => {
+  for (const line of fm) {
+    if (!line.startsWith(`${key}: `)) continue
+    return line
+      .slice(key.length + 2)
+      .trim()
+      .replace(/^"(.*)"$/, "$1")
+  }
+  return ""
+}
+
+// Transform one upstream SKILL.md for the fork: rebrand the prose, point source at upstream, stamp the sync note, and record the drift hashes. source-hash is the upstream body as fetched (what skills-manager --outdated compares against a fresh upstream fetch); synced-hash is the body as written (what the next sync compares to detect fork customization).
+const transformSkill = (skill: string, text: string, slug: string, name: string): string => {
+  const { body: rawBody, fm: rawFm } = splitSkill(skill, text)
+  const fm = rawFm
+    .filter((line) => !line.startsWith("source-hash:") && !line.startsWith("synced-hash:"))
+    .map((line) =>
+      line.startsWith("source:") ? `source: ${UPSTREAM}` : reconcile(line, slug, name),
+    )
+  if (!fm.some((line) => line.startsWith("source:"))) fm.push(`source: ${UPSTREAM}`)
+  const written = `${syncNote()}\n\n${reconcile(rawBody, slug, name).replace(/^\n+/, "")}`
+  // Double-quoted so YAML always reads the stamp as a string (an all-digit or digits+e hash would otherwise parse as a number and vanish).
+  fm.push(`source-hash: "${hashBody(rawBody)}"`, `synced-hash: "${hashBody(written)}"`)
+  return `---\n${fm.join("\n")}\n---\n\n${written}`
+}
+
+// Every .agents/skills/<skill>/SKILL.md under root, as [skill, path] pairs.
+const skillFiles = (root: string): [string, string][] => {
   const dir = join(root, ".agents/skills")
-  if (!exists(dir)) return
-  const slug = slugify(brand.name)
+  if (!exists(dir)) return []
+  const out: [string, string][] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue
     const file = join(dir, entry.name, "SKILL.md")
-    if (!exists(file)) continue
-    const lines = read(file).split("\n")
-    const open = lines.indexOf("---")
-    const close = lines.indexOf("---", open + 1)
-    // Fail loudly on drift, like fixDangling/rebrand: a skill with no frontmatter means the shape moved.
-    if (open !== 0 || close === -1) {
-      throw new Error(
-        `.agents/skills/${entry.name}/SKILL.md has no frontmatter to reconcile (the skill shape drifted). Update packages/cli/src/skills.ts.`,
-      )
-    }
-    const fm = lines.slice(open + 1, close).map((line) => {
-      if (line.startsWith("source:")) return `source: ${UPSTREAM}`
-      return reconcile(line, slug, brand.name)
-    })
-    if (!fm.some((line) => line.startsWith("source:"))) fm.push(`source: ${UPSTREAM}`)
-    const body = reconcile(lines.slice(close + 1).join("\n"), slug, brand.name).replace(/^\n+/, "")
-    write(file, `---\n${fm.join("\n")}\n---\n\n${syncNote()}\n\n${body}`)
+    if (exists(file)) out.push([entry.name, file])
+  }
+  return out
+}
+
+// Reconcile every scaffolded skill to the fork (init/reinit, where the whole tree is a fresh upstream fetch): rename the upstream identity in prose, point source at the upstream repo, and stamp the sync note plus drift hashes; a fork has no packages/cli of its own, so bunx zerostarter is how it later pulls skill updates.
+export const reconcileForkSkills = (root: string, brand: Brand): void => {
+  const slug = slugify(brand.name)
+  for (const [skill, file] of skillFiles(root)) {
+    write(file, transformSkill(skill, read(file), slug, brand.name))
   }
 }
 
-// Rebrand a fork's overlaid skills from its own package.json name. A sync overlay re-adds upstream SKILL.md files that name "zerostarter" and there is no brand prompt, so source the fork identity from the preserved root package.json (mergePkg keeps `name` on sync). A missing name (never scaffolded) is a no-op.
-export const reconcileForkSkillsFromRoot = (root: string): void => {
+// Snapshot every skill before the sync overlay overwrites them, keyed by skill directory name.
+export const snapshotForkSkills = (root: string): Map<string, string> =>
+  new Map(skillFiles(root).map(([skill, file]) => [skill, read(file)]))
+
+export type SkillSyncResult = {
+  added: string[]
+  kept: string[]
+  skipped: string[]
+  unverified: string[]
+  updated: string[]
+}
+
+// Provenance-aware skill reconcile for sync: the overlay re-added upstream SKILL.md files over the fork's, so decide per skill, from its pre-overlay snapshot, who owns it. A source that is not this repo (local, a tool, another repo) restores the fork's file untouched (kept). A dropped sync note, an unparseable file, or a body customized since its synced-hash stamp restores the fork's file untouched (skipped). A note-intact skill whose stamp matches takes the fresh upstream body (updated). A note-intact skill with no stamp (a pre-stamp fork) is overwritten but reported by name (unverified), so customizations are recoverable from the sync diff; the fork identity comes from the preserved root package.json (a missing name means never scaffolded: no-op).
+export const syncForkSkills = (root: string, preSkills: Map<string, string>): SkillSyncResult => {
+  const result: SkillSyncResult = { added: [], kept: [], skipped: [], unverified: [], updated: [] }
   const name = readJson<{ name?: string }>(join(root, "package.json")).name
-  if (name) reconcileForkSkills(root, { name })
+  if (!name) return result
+  const slug = slugify(name)
+  for (const [skill, file] of skillFiles(root)) {
+    const post = read(file)
+    const pre = preSkills.get(skill)
+    if (pre === undefined) {
+      write(file, transformSkill(skill, post, slug, name))
+      result.added.push(skill)
+      continue
+    }
+    if (post === pre) continue
+    let split: { fm: string[]; body: string }
+    try {
+      split = splitSkill(skill, pre)
+    } catch {
+      write(file, pre)
+      result.skipped.push(skill)
+      continue
+    }
+    if (fmValue(split.fm, "source") !== UPSTREAM) {
+      write(file, pre)
+      result.kept.push(skill)
+      continue
+    }
+    const stamp = fmValue(split.fm, "synced-hash")
+    if (!split.body.includes(syncNote()) || (stamp && hashBody(split.body) !== stamp)) {
+      write(file, pre)
+      result.skipped.push(skill)
+      continue
+    }
+    const next = transformSkill(skill, post, slug, name)
+    write(file, next)
+    if (next !== pre) (stamp ? result.updated : result.unverified).push(skill)
+  }
+  return result
 }

--- a/packages/cli/test/convert.test.ts
+++ b/packages/cli/test/convert.test.ts
@@ -3,9 +3,9 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { convertRepo, fixDangling } from "@/convert"
+import { assertMarketingStripped, convertRepo, fixDangling } from "@/convert"
 import { exists, read, readJson, write } from "@/io"
-import { reconcileForkSkillsFromRoot } from "@/skills"
+import { syncForkSkills } from "@/skills"
 
 let dir: string
 beforeEach(() => {
@@ -76,10 +76,11 @@ describe("fixDangling", () => {
     expect(() => fixDangling(dir)).toThrow(/fonts\.ts/)
   })
 
-  test("throws when the marketing font module survived the fork strip", () => {
+  test("tolerates a fork-owned marketing font module (sync path)", () => {
     setup(FONTS, NAV)
     write(join(dir, "web/next/src/lib/marketing/fonts.ts"), MARKETING_FONTS)
-    expect(() => fixDangling(dir)).toThrow(/lib\/marketing/)
+    expect(() => fixDangling(dir)).not.toThrow()
+    expect(nav()).not.toContain("/hire")
   })
 
   test("no-ops when the starter already dropped /hire (evolution)", () => {
@@ -87,6 +88,17 @@ describe("fixDangling", () => {
     expect(() => fixDangling(dir)).not.toThrow()
     expect(fonts()).toContain("dmSans")
     expect(nav()).toContain("/dashboard")
+  })
+})
+
+describe("assertMarketingStripped (init/reinit only)", () => {
+  test("throws when the marketing font module survived the fork strip", () => {
+    write(join(dir, "web/next/src/lib/marketing/fonts.ts"), MARKETING_FONTS)
+    expect(() => assertMarketingStripped(dir)).toThrow(/lib\/marketing/)
+  })
+
+  test("passes when the module was stripped", () => {
+    expect(() => assertMarketingStripped(dir)).not.toThrow()
   })
 })
 
@@ -229,6 +241,8 @@ describe("convertRepo (in-place)", () => {
     expect(skill).toContain("Start the Acme App dev stack")
     expect(skill).toContain("portless get acme-app")
     expect(skill).not.toContain("get zerostarter")
+    expect(skill).toMatch(/source-hash: "[0-9a-f]{16}"/)
+    expect(skill).toMatch(/synced-hash: "[0-9a-f]{16}"/)
   })
 
   test("re-points a vendored skill's source at upstream (a fork inherits it through zerostarter, not the tool)", () => {
@@ -245,24 +259,33 @@ describe("convertRepo (in-place)", () => {
   })
 })
 
-describe("reconcileForkSkillsFromRoot (sync path)", () => {
-  const devSkill = (dir: string) =>
-    write(
-      join(dir, ".agents/skills/dev/SKILL.md"),
-      "---\nname: dev\ndescription: Start the ZeroStarter dev stack.\nsource: local\n---\n\n# Dev\n\nRun `bunx portless get zerostarter`.\n",
-    )
+describe("syncForkSkills (sync path)", () => {
+  const UPSTREAM_DEV =
+    "---\nname: dev\ndescription: Start the ZeroStarter dev stack.\nsource: local\n---\n\n# Dev\n\nRun `bunx portless get zerostarter`.\n"
+  const skillPath = () => join(dir, ".agents/skills/dev/SKILL.md")
 
-  test("rebrands overlaid skills from the fork's package.json name", () => {
+  // Simulate the state a previous sync left in the fork: the raw upstream skill transformed and stamped.
+  const previousSync = (raw: string): string => {
     write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
-    devSkill(dir)
-    reconcileForkSkillsFromRoot(dir)
-    const skill = read(join(dir, ".agents/skills/dev/SKILL.md"))
+    write(skillPath(), raw)
+    syncForkSkills(dir, new Map())
+    return read(skillPath())
+  }
+
+  test("adds a new upstream skill: rebrands, sets source, stamps the note and drift hashes", () => {
+    write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
+    write(skillPath(), UPSTREAM_DEV)
+    const result = syncForkSkills(dir, new Map())
+    expect(result.added).toEqual(["dev"])
+    const skill = read(skillPath())
     expect(skill).toContain("source: https://github.com/nrjdalal/zerostarter")
     expect(skill).toContain("[!CAUTION]")
     expect(skill).toContain("Start the acme-app dev stack")
     expect(skill).toContain("portless get acme-app")
     expect(skill).not.toContain("ZeroStarter")
     expect(skill).not.toContain("get zerostarter")
+    expect(skill).toMatch(/source-hash: "[0-9a-f]{16}"/)
+    expect(skill).toMatch(/synced-hash: "[0-9a-f]{16}"/)
     // The upstream URL in the source line and sync note must NOT be rebranded to the fork.
     expect(skill).toContain("Synced from https://github.com/nrjdalal/zerostarter")
     expect(skill).not.toContain("nrjdalal/acme-app")
@@ -270,9 +293,9 @@ describe("reconcileForkSkillsFromRoot (sync path)", () => {
 
   test("no-ops when the root package.json has no name", () => {
     write(join(dir, "package.json"), JSON.stringify({ version: "1.0.0" }))
-    devSkill(dir)
-    expect(() => reconcileForkSkillsFromRoot(dir)).not.toThrow()
-    expect(read(join(dir, ".agents/skills/dev/SKILL.md"))).toContain("ZeroStarter")
+    write(skillPath(), UPSTREAM_DEV)
+    expect(() => syncForkSkills(dir, new Map())).not.toThrow()
+    expect(read(skillPath())).toContain("ZeroStarter")
   })
 
   test("keeps upstream refs (bunx zerostarter, scaffolding CLI) but rebrands fork identity", () => {
@@ -283,12 +306,72 @@ describe("reconcileForkSkillsFromRoot (sync path)", () => {
         "Sync with `bunx zerostarter sync`; `packages/cli/` is the zerostarter scaffolding CLI.\n" +
         "Dev URL `bunx portless get zerostarter`, api `api.zerostarter`, image `zerostarter-web`.\n",
     )
-    reconcileForkSkillsFromRoot(dir)
+    syncForkSkills(dir, new Map())
     const skill = read(join(dir, ".agents/skills/codebase-map/SKILL.md"))
     expect(skill).toContain("bunx zerostarter sync")
     expect(skill).toContain("zerostarter scaffolding CLI")
     expect(skill).toContain("portless get acme-app")
     expect(skill).toContain("api.acme-app")
     expect(skill).toContain("acme-app-web")
+  })
+
+  test("updates an uncustomized synced skill when upstream advances", () => {
+    const pre = previousSync(UPSTREAM_DEV)
+    write(skillPath(), UPSTREAM_DEV.replace("# Dev", "# Dev\n\nNow with turbo."))
+    const result = syncForkSkills(dir, new Map([["dev", pre]]))
+    expect(result.updated).toEqual(["dev"])
+    const skill = read(skillPath())
+    expect(skill).toContain("Now with turbo.")
+    expect(skill).toContain("[!CAUTION]")
+    expect(skill).toMatch(/synced-hash: "[0-9a-f]{16}"/)
+  })
+
+  test("skips a synced skill the fork customized (synced-hash mismatch)", () => {
+    const customized = `${previousSync(UPSTREAM_DEV)}\nFork-only bullet.\n`
+    write(skillPath(), UPSTREAM_DEV.replace("# Dev", "# Dev v2"))
+    const result = syncForkSkills(dir, new Map([["dev", customized]]))
+    expect(result.skipped).toEqual(["dev"])
+    expect(read(skillPath())).toBe(customized)
+  })
+
+  test("skips a synced skill whose sync note was removed", () => {
+    const owned = previousSync(UPSTREAM_DEV).replace(/> \[!CAUTION\]\n> Synced from[^\n]*\n\n/, "")
+    write(skillPath(), UPSTREAM_DEV)
+    const result = syncForkSkills(dir, new Map([["dev", owned]]))
+    expect(result.skipped).toEqual(["dev"])
+    expect(read(skillPath())).toBe(owned)
+  })
+
+  test("restores a skill with non-upstream provenance instead of restamping it", () => {
+    write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
+    const path = join(dir, ".agents/skills/agent-browser/SKILL.md")
+    const vendored =
+      "---\nname: agent-browser\ndescription: Browser automation CLI for AI agents.\nsource: agent-browser\n---\n\n# Agent Browser\n"
+    write(path, vendored.replace("# Agent Browser", "# Agent Browser (upstream edit)"))
+    const result = syncForkSkills(dir, new Map([["agent-browser", vendored]]))
+    expect(result.kept).toEqual(["agent-browser"])
+    expect(read(path)).toBe(vendored)
+  })
+
+  test("overwrites but names a note-intact skill with no drift stamp (pre-stamp fork)", () => {
+    write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
+    const prestamp =
+      "---\nname: dev\ndescription: Start the acme-app dev stack.\nsource: https://github.com/nrjdalal/zerostarter\n---\n\n> [!CAUTION]\n> Synced from https://github.com/nrjdalal/zerostarter. Customize this skill or remove this note to stop syncing.\n\n# Dev\n"
+    write(skillPath(), UPSTREAM_DEV)
+    const result = syncForkSkills(dir, new Map([["dev", prestamp]]))
+    expect(result.unverified).toEqual(["dev"])
+    expect(read(skillPath())).toMatch(/synced-hash: "[0-9a-f]{16}"/)
+  })
+
+  test("leaves a fork-only skill alone (the overlay never touched it)", () => {
+    write(join(dir, "package.json"), JSON.stringify({ name: "acme-app" }))
+    const path = join(dir, ".agents/skills/vendor/SKILL.md")
+    const forkOnly =
+      "---\nname: vendor\ndescription: Vendor a dep.\nsource: local\n---\n\n# Vendor\n"
+    write(path, forkOnly)
+    const result = syncForkSkills(dir, new Map([["vendor", forkOnly]]))
+    expect(read(path)).toBe(forkOnly)
+    expect(result.added).toEqual([])
+    expect(result.kept).toEqual([])
   })
 })

--- a/web/next/content/docs/getting-started/cli.mdx
+++ b/web/next/content/docs/getting-started/cli.mdx
@@ -57,7 +57,9 @@ bunx zerostarter sync [dir]
 
 Overlays the latest starter onto your fork, updating shared starter files while preserving everything your fork owns. Unlike `init` and `reinit`, it does not commit: it leaves the changes in your working tree so you review the diff and commit yourself. It requires a clean repo and rolls back on failure.
 
-What it preserves: your content, `public/`, marketing, `packages/config/src/site.ts` branding, `README.md`, your root package identity (name, version, author fields), and the `PRESERVE_ON_SYNC` paths (`bun.lock`, `packages/db/drizzle/`, `packages/db/src/schema/`, `web/next/docs.config.ts`, and the favicon). What it overwrites: every shared starter file, so local edits to those are replaced by the upstream version. The overlaid skills in `.agents/skills/` are then rebranded to your project name (read from `package.json`), matching `init`, so a synced skill keeps your identity rather than the starter's.
+What it preserves: your content, `public/`, marketing, `packages/config/src/site.ts` branding, `README.md`, your root package identity (name, version, author fields), and the `PRESERVE_ON_SYNC` paths (`bun.lock`, `packages/db/drizzle/`, `packages/db/src/schema/`, `web/next/docs.config.ts`, and the favicon). What it overwrites: every shared starter file, so local edits to those are replaced by the upstream version.
+
+Skills in `.agents/skills/` follow their own provenance contract instead of the blanket overwrite: a skill takes the fresh upstream body (rebranded to your project name, read from `package.json`) only while its `source` points at the starter, its sync note is intact, and its body is unchanged since the last sync (checked against the stamped `synced-hash`). A skill you customized, whose note you removed, or whose `source` is `local`, a tool, or another repo stays exactly yours, and the sync summary names every skill it updated or left alone.
 
 ```bash
 # review before committing


### PR DESCRIPTION
Fixes #749, fixes #750, fixes #751, and updates the AGENTS.md worktree rule.

## What changed

**#749 - sync aborted on a fork that owns `web/next/src/lib/marketing/`**
The unconditional existence check in `fixDangling` was an init/reinit invariant (verify the fork strip removed the author-only marketing module) that also ran on the sync path, where a fork owning that directory is the expected state. It now lives in `assertMarketingStripped`, called only from `convertRepo` (init/reinit); `sync` keeps the navbar strip and the `fonts/marketing/` leak check, which stay valid after an overlay.

**#750 - sync overwrote customized skills and restamped local/vendored provenance**
`sync` now snapshots every `.agents/skills/*/SKILL.md` before the overlay and reconciles per skill from that snapshot, honoring the documented contract:

- `source` not the upstream repo (`local`, a tool, another repo): the fork's file is restored byte-for-byte, never restamped.
- Sync note removed, or body customized since the last sync: the fork's file is restored untouched.
- Note intact and body verified unchanged: the fresh upstream body is taken (rebranded, as before).
- Fork-only skills the overlay never touched are left alone.

Verification uses two new frontmatter stamps written on every transform: `source-hash` (the upstream body the skill was synced from) and `synced-hash` (the body as written, which the next sync hashes against to detect customization). A note-intact skill with no stamp (a fork synced before stamps existed) is overwritten once to gain its stamps and is named in the sync summary, so a lost customization is recoverable from the reviewable diff; every category is reported by name instead of being folded into "edits overwritten".

**#751 - `--outdated` reported DIFFERS for every synced skill in a fork**
The raw-body comparison could never match in a fork (the transform inserts the CAUTION note and rebrands prose). When raw bodies differ, `skills-manager.ts` now hashes the fresh upstream body and compares it to the stamped `source-hash`: match reports `up to date`, mismatch reports `OUTDATED (upstream changed since the last sync)`, and a missing stamp reports `unverifiable` instead of a false positive. This is the frontmatter-stamp fix the issue suggested, chosen over prose normalization since a fork name can appear in code fences, URLs, and log paths.

**AGENTS.md** - the worktree rule now prescribes forking the branch from the latest `canary` (`git fetch origin canary && git worktree add .claude/worktrees/<name> -b <branch> origin/canary`) instead of merging canary in after the fact.

## Notes

- Stamps are double-quoted in frontmatter: strict YAML parses an unquoted all-digit (or `digits+e`) hash as a number, and `skills-manager`'s parser would then drop it. Caught by end-to-end simulation, covered in the skill doc.
- Both hash implementations (`packages/cli/src/skills.ts`, `.github/scripts/skills-manager.ts`) are 16 hex chars of sha256 over the LF-normalized trimmed body and must stay identical; both files say so.
- Docs synced in the same change: `getting-started/cli.mdx` (sync section) and the `skills-manager` skill (contract, stamps, new `--outdated` outputs).

## Verification

- `packages/cli`: 129 tests pass (new coverage: sync tolerates fork-owned marketing fonts; init still asserts the strip; per-outcome sync cases for added/updated/customized/note-removed/non-upstream/fork-only skills).
- `bun run check-types`, `bun run lint`, `skills-manager --check` all clean.
- End-to-end simulation against live upstream (scratch fork + the new `skills-manager.ts`): stamped-and-current reports `up to date`, stale stamp reports `OUTDATED`, missing stamp reports `unverifiable`; the `node:crypto` and `Bun.CryptoHasher` hashes agree byte-for-byte.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved skill synchronization with provenance and hash tracking.
  * Preserves customized or unverifiable skills while updating unchanged upstream skills.
  * Sync results now summarize added, updated, kept, skipped, and unverifiable skills.

* **Bug Fixes**
  * Prevents customized fork skills from being unintentionally overwritten during sync.
  * Improves handling of missing or malformed synchronization metadata.

* **Documentation**
  * Updated CLI guidance to explain skill preservation and synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->