### PR TITLE
feat: platform data table with virtualized infinite scroll and a console users page

### DIFF
--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -13,6 +13,7 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 
 ## Planned
 
+- [Platform data table](data-table.md) - full PRD; working spike on `spike/platform-data-table`, rebuild clean from the spec (PR #753).
 - [Dynamic per-branch preview URLs](dynamic-preview-urls.md) - predictable per-branch preview URLs on our own domains via alias-on-deploy (#677).
 
 ## Backlog / ideas

--- a/.github/notes/plans/data-table.md
+++ b/.github/notes/plans/data-table.md
@@ -1,0 +1,120 @@
+# Platform data table (PRD)
+
+- Status: planned
+- Links: PR #753 (this plan); working spike on `spike/platform-data-table` (~40 commits of iteration, all requirements below verified live there); shadcn data-table guide; TanStack Table v8 virtualized-infinite-scrolling example
+
+One data table for the whole platform, rebuilt clean from this spec. The spike proved every requirement end to end but its history is iterative churn; the rebuild implements this document directly and ports code from the spike where it is already right. Every requirement below was converged on deliberately, most after seeing the alternative fail.
+
+## Stance
+
+- The shadcn stance, held throughout: no all-in-one `<DataTable data={...} />` prop machine. The page owns its `useReactTable` instance; the family provides composable pieces.
+- Follow documented upstream patterns, never hand-rolled ones: TanStack Table v8 (headless), TanStack Query `useInfiniteQuery` (batches), TanStack Virtual (windowed rows, per their official virtualized-infinite-scrolling example), nuqs (URL state), `@chenglou/pretext` (text measurement).
+- Every table infinite-scrolls inside its own region. No numbered pagination anywhere.
+- Cells render plain text for now: no badges, avatars, or icons in data cells (the payload keeps `image`/`emailVerified` for a later visual treatment).
+
+## Architecture
+
+```
+components/data-table/            the family: generic rendering, no data knowledge
+  data-table.tsx                  DataTable (namesake file matches the export)
+  cell-text.tsx                   DataTableCellText: truncate | wrap overflow modes
+  column-header.tsx               DataTableColumnHeader: title + bare sort icon
+  column-manager.ts               COLUMN_MANAGER + applyColumnManager (all layout)
+  faceted-filter.tsx              DataTableFacetedFilter (Popover + Command)
+  toolbar.tsx                     DataTableToolbar (search + children slot + View)
+  view-options.tsx                DataTableViewOptions (labels from meta.label)
+hooks/
+  use-data-table.ts               server wiring: URL state + infinite query + table
+  use-data-table-state.ts         URL layer alone (client-side tables)
+app/(console)/console/(platform)/users/
+  page.tsx                        synchronous server component (no page gate)
+  components/data-columns.tsx     content only: header, cell, meta.label
+  components/data-table.tsx       UsersDataTable: fetchPage + composition
+api/hono/src/
+  middlewares/admin.ts            adminMiddleware (fresh role check)
+  routers/admin.ts                GET /api/v1/admin/users
+```
+
+- Route-colocated files are role-named; the page context lives in the export (`UsersDataTable`), not the filename. Family namesake file matches its export (`data-table/data-table.tsx` = `DataTable`).
+- The console gets a grouped sidebar (Getting Started > Documentation, Platform > Users) with `/console` a minimal landing; the users table lives at `/console/users` in a `(platform)` route group. Nav blocks are a typed `navGroups` array; the header Dashboard link matches `exact` so child routes do not highlight it.
+
+## Column manager
+
+`COLUMN_MANAGER` in the family owns every table's layout so columns files carry content only. Two levels: `global` (semantic archetypes) and `<area>.<table>` blocks written in column order, mapping column ids onto configs:
+
+```ts
+type ColumnConfig = {
+  align?: "center" | "left" | "right" // default left
+  extra?: number // allowance over a measured title (default 10)
+  flex?: boolean // default false
+  width?: number // spacing units; omit = measure the header
+}
+```
+
+- Units are Tailwind spacing units (1 = 0.25rem), rendered `calc(var(--spacing) * n)` so tables ride the theme token and user font-size; archetypes snap to multiples of 3. `width` is exact on a fixed column and the floor on a flex one.
+- Omit `width` and the column sizes as header title + `extra`: the `meta.label` measured via pretext (`measureNaturalWidth(prepareWithSegments(label, "500 14px " + body font))`), px converted at 4px/unit, snapped up to the 3-unit grid, cached per label+allowance. Measurement runs post-mount only (SSR has no canvas): server and hydration renders share a 24-unit fallback, then one settle applies measured widths, avoiding hydration mismatch.
+- Names follow what the column says, never the backing field: the column headed Status keys as `status` with `accessorKey: "banned"` underneath.
+- `global` keeps only consumed archetypes; columns files never carry raw numbers; a deliberate one-off number lives in the table block.
+- The users block converged to: `select { width: 12 }`, `name { extra: 48 }` (header + 12rem), `email { extra: 60, flex: true }`, `role {}`, `status {}`, `createdAt { align: "right", extra: 24 }`, `actions { align: "center", width: 12 }`. Role and status center; select stays left deliberately (see slack model).
+- `applyColumnManager(columns, manager, measure)` folds a block into defs by column id (`id`, else `accessorKey`), setting `size` and `meta { align, flex }`; `useDataTable` applies it via its `manager` option, client tables call it directly.
+
+## Slack model (who grows)
+
+- `flex` marks a column; capability reaches back to every column before it. Of the visible capable columns, only the last grows (a run of adjacent capables collapses); the rest hold their width. Hiding the growing column hands growth backward: hide email and name grows; hide both and select grows, which reads well only because select is left-aligned: the checkbox pins left and the empty box is the gap, with the remaining columns docked right.
+- A table with no flex column spreads its widthless columns instead (they share slack above their floors).
+- Explicit alignment: `center` drops horizontal padding (the shadcn cell strips `pr` around checkboxes, skewing a padded center; measured symmetric after). Dead space must never trail the row.
+- A `spacer` pseudo-column was tried and rejected; the flags + alignment model above is the answer.
+
+## Behaviors
+
+- Virtualized infinite scroll per the upstream example: semantic table tags flipped to grid/flex, rows absolutely positioned in a virtualizer-sized tbody, self-measured, `overscan: 5`; load more within 500px of the bottom, on scroll and after every batch. `getNextPageParam` compares loaded against the response `total` AND terminates on a zero-row page (stale totals must not loop). `onLoadMore` holds a stable identity (`useCallback`) so the effect does not re-arm per render.
+- 25-row batches, `placeholderData: keepPreviousData`, search through `useDeferredValue`. Sorting/search/filter changes scroll back to top (state-slice effect deps, not JSON.stringify).
+- URL state via nuqs: `q`, `sort` as `column.asc|desc` (custom parser with parse/serialize/eq), one array param per filter id. No page state. Parser maps must be module-scope stable (see traps).
+- `defaultSorting` (users: createdAt desc) applies as real table state when the URL has none, so the header chevron and `aria-sort` show it while the URL stays clean.
+- Sort UI: title is plain text (aligns with cell content natively; no margin nudges needed); the only control is a bare icon (native `button`, focus ring only, `aria-label="Sort by X"`), toggling asc/desc. No dropdown; Hide lives in View options. Right-aligned headers put the icon before the title.
+- `DataTableCellText` overflow modes: `truncate` (one line, ellipsis, tooltip only when actually cut, measured `scrollWidth > clientWidth` on hover/focus) and `wrap` (`whitespace-normal wrap-break-word`; the measured virtual row grows). Web terminology, not invented terms.
+- Selection: `id: "select"` column convention; the count line gates on that column's presence (tanstack injects a default `onRowSelectionChange`, so the option cannot gate it); selection resets when search/sort/filters reshape the result set.
+- Errors: cold failure renders the `empty` slot (Empty + message + Retry); failures after rows exist render an inline retry strip (stale rows must not sit silent under `keepPreviousData`).
+- Status line under the region: selection count left, `N of total` right.
+- Viewport filling: the page opts in with `h-svh` on `PageShell` plus `flex-1 min-h-0` down to the region. `min-h-svh` ancestors are height-indefinite, so without the definite `h-svh` the region grows with content, the page scrolls, and the always-visible bottom loads every batch at once.
+- The page stays a synchronous server component with no `assertConsoleAccess` of its own: the layout 404s non-admins and the API gates every row, so the shell paints instantly (~150ms) instead of suspending into the route spinner (no double loading phase).
+- Narrow viewports: fixed columns `shrink-0`, flex floors via `min-width`, table `min-w-max`; the region scrolls horizontally instead of crushing cells (verified at 375px).
+- Dev-only alternating column tints were a useful width-tuning aid and are intentionally NOT part of the final build.
+
+## API
+
+`GET /api/v1/admin/users`, drizzle-direct, standard envelope + OpenAPI + RPC:
+
+- Query: `dir` (asc|desc, default desc), `page` (min 1), `perPage` (1..100, default 10), `q` (trimmed, max 254), `role` (comma list validated against ["admin","user"], deduped), `sort` (whitelist enum, default createdAt).
+- One `SORTS` tuple feeds the zod enum and a `sortColumns` map (`satisfies Record<(typeof SORTS)[number], unknown>`); sortable: banned, createdAt, email, name, role. `banned` sorts via `coalesce(banned, false)`; `role` via `coalesce(role, 'user')` so null-role rows group with the label they display.
+- Search: `ilike` across name OR email with `%_\` escaped so literals match; role filter treats null as "user"; `asc(user.id)` tiebreaker so page boundaries cannot drift; count via `db.$count(user, where)` per batch (comment: fine at starter scale; page-1-only or pg_trgm at scale).
+- Response: `{ data: { total, users } }`, `createdAt` serialized `toISOString()` (Hono types a raw Date as string over RPC otherwise), `banned` normalized to boolean, `role` null-as-"user". Payload includes `image` and `emailVerified` even though cells do not render them yet.
+- `adminMiddleware` mirrors the console gate's rule AND freshness: it re-reads the session with `disableCookieCache: true` (a revoke locks the API on the very next request; the cached `authMiddleware` read alone leaves a 5-minute window) and refreshes the context vars. 403 `FORBIDDEN` via `forbiddenErrorResponses`; add both to `lib/error.ts`.
+- Client: `fetchPage` maps column ids to API sort fields (`status` -> `banned`) through a `SORT_FIELDS` map `satisfies Record<string, UsersSort>` where `UsersSort` derives from `InferRequestType`, so server renames become compile errors. The row type derives from `InferResponseType` (no hand-written mirror).
+
+## Accessibility
+
+- The scroll region is named and focusable (`role="region"`, `aria-label`, `tabIndex={0}`).
+- Grid/flex display strips implicit table semantics, so every structural role is restated (`table/rowgroup/row/columnheader/cell`) and virtualization reports `aria-rowcount` (full set) + per-row `aria-rowindex`; `aria-sort` on sorted columnheaders.
+- Labeled search input, sr-only names on icon-only controls, tooltip content mirrors the truncated value.
+
+## Traps the rebuild must honor (each cost real debugging in the spike)
+
+1. React Compiler x TanStack Table v8: the table mutates one stable instance during render; memoized consumers freeze one render behind (sorts update the URL but not rows, `getPageCount` sticks). Every file reading a `table`/`column` instance carries `"use no memo"`, including the hooks that call `useReactTable`.
+2. nuqs parser identity: parser maps built inline in a hook defeat the parse cache and leave `useSyncExternalStore` one update behind. Module-scope (or per-instance-stable) parser objects only.
+3. tanstack `defaultColumn.minSize` defaults to 20 (pixel-minded): it clamps spacing-unit sizes (12 rendered as 20). Set `defaultColumn: { minSize: 0 }`.
+4. `useInfiniteQuery` option order: `queryFn` must precede `getNextPageParam` or TS context-sensitive inference degrades `lastPage` to unknown.
+5. Next `next dev` forces `NODE_ENV=development`; the repo's `NODE_ENV=local` never reaches the client bundle. Client-side env gates use `isDevelopment`/`!isProduction`, never `isLocal`.
+6. `docs.config.ts` is the docs source of truth: `meta.json` and MDX frontmatter regenerate from it; editing them directly gets reverted by the docs script.
+7. Better Auth cookie cache (300s) serves stale roles; any fresh-role check needs `disableCookieCache` (the console gate and adminMiddleware both).
+8. Tailwind v4 renamed `break-words` to `wrap-break-word`.
+9. The npm package is `@chenglou/pretext` (bare `pretext` is unrelated); width comes from `measureNaturalWidth(prepareWithSegments(...))`.
+10. `getSize()` and the virtualizer think in numbers the renderer interprets; keep the calc(var(--spacing)) conversion in exactly one place (`columnLayout`).
+
+## Rebuild plan
+
+1. Deps: `@tanstack/react-table` `^8.21.3`, `@tanstack/react-virtual`, `nuqs` (+ `NuqsAdapter` in providers), `@chenglou/pretext` (catalog, caret).
+2. API first (middleware + endpoint + error responses), curl-verified: 200 matrix, 401, 403-after-revoke with cache-intact cookies, 400 issues.
+3. Family + hooks per this spec, porting from the spike.
+4. Console IA (sidebar groups, `(platform)/users`, landing) and the users table.
+5. Docs (`manage/data-tables` + touched pages) and skills (`design`, `api-endpoint`, `codebase-map`) in the same change; agent-browser verification at desktop and 375px, both themes; no screenshots with real user rows in the PR (verification stays textual).


### PR DESCRIPTION
## Summary

Adds the platform data-table: a composable component family over TanStack Table (sourced from the shadcn data-table guide and TanStack's own examples, ported to this repo's base-ui + remixicon dialect), URL-synced state via nuqs, **virtualized infinite scroll** per TanStack Table's virtualized-infinite-scrolling example (react-table + react-virtual + `useInfiniteQuery`), a new admin users API, and the console's Platform > Users page as its first real consumer. Follows the shadcn stance: no all-in-one prop machine; the page owns the table instance and composes the pieces.

## What's inside

- **`components/data-table/`**: `DataTable` (a focusable, viewport-filling region: sticky header, virtualized rows windowed by TanStack Virtual, load-more within 500px of the bottom, initial spinner, `Empty` fallback, inline retry on post-load failures, selection/total status line, explicit table roles + `aria-sort`/`aria-rowcount`), `DataTableCellText` (text-cell overflow: truncate with a tooltip only when actually cut, or wrap with the measured row growing), `DataTableColumnHeader`, `DataTableToolbar` (global-filter search + children slot), `DataTableViewOptions` (labels from `columnDef.meta.label`), `DataTableFacetedFilter`. Layout lives in the column manager (`COLUMN_MANAGER.<area>.<table>.<columnId>` holding `{ align?, flex?, width? }` in Tailwind spacing units rendered via `calc(var(--spacing) * n)`, folded into the defs by `applyColumnManager`/useDataTable's `manager` option): exact widths on fixed columns, floors on flex ones (a run of consecutive flex columns collapses to its last member growing, and whatever follows the last flex column docks to the right edge), optional center/right alignment, and widthless columns measure their header label via `@chenglou/pretext` (canvas metrics, applied post-mount behind a stable fallback). Columns files carry content only; content never shifts the layout. No numbered pagination anywhere.
- **`hooks/use-data-table.ts`**: the whole server-driven wiring in one generic call: URL state, the infinite query (`getNextPageParam` against the response total, `keepPreviousData`, deferred search), and the manual-mode table instance. A consumer brings only what a generic hook cannot know: columns, a typed `fetchPage`, filter ids.
- **`hooks/use-data-table-state.ts`**: the URL layer alone (`q`, `sort` as `column.asc|desc`, one array param per filter id via nuqs), for client-side tables. No page state: a state change resets the list.
- **`GET /api/v1/admin/users`**: server-driven list endpoint (drizzle-direct): page/perPage batches, whitelisted sort + dir, escaped `LIKE` search across name OR email, role filter with null-as-"user" handling. Gated by the new `adminMiddleware` (403 `FORBIDDEN`, same rule as the `/console` gate and the same freshness: the session cookie cache is bypassed, so a revoke locks the API on the next request) and documented via `forbiddenErrorResponses`.
- **`/console/users`**: the console gains a grouped sidebar (Getting Started with Documentation, Platform with Users) and the users table lives at its own Platform page, structured shadcn-style: a `(platform)` route group with the page's pieces colocated at `users/components/data-columns.tsx` + `data-table.tsx` (just columns + a typed `fetchPage` + composition). Server sorting/search/role facet, 25-row batches streaming in on scroll, virtualized rows, row selection, row actions, error state with retry. Columns cover what the data has and an admin needs, rendered as plain text for now: name, email, role, a Status column from the admin plugin's banned flag, and joined date; id stays behind the copy action, and image/emailVerified remain in the payload for a later visual treatment. The layout 404s non-admins and the API gates every row, so the page stays synchronous: the shell paints instantly on navigation (~150ms measured, no route-spinner phase) and only the table's data spinner shows. The page opts into the app-frame height chain (`h-svh` on `PageShell`, `flex-1 min-h-0` down to the region) so the table takes all available height and never resizes with its content; the console landing returns to a minimal home.
- **Docs + skills**: new `manage/data-tables` page (pieces, hooks, virtualized infinite scroll, the viewport-filling chain, server/client recipes); architecture/project-structure/authentication/api-conventions updated where they described the console as empty; `design`, `api-endpoint`, and `codebase-map` skills synced.

## The React Compiler gotcha (worth knowing)

TanStack Table v8 mutates one stable table instance during render, so with `reactCompiler: true` every memoized consumer comparing the instance identity froze one render behind (sort clicks updated the URL but not the rows). Every file reading a `table`/`column` instance now carries `"use no memo"`, per TanStack's v8 guidance, and the docs call it out so new consumers keep it.

Dashboard members table was built and then dropped per review direction (console-only for now); the family supports client-side tables and the docs include that recipe.

No screenshots attached: the console renders real user records, so verification is manual on a local run.

## Verification

- `curl` matrix on the endpoint: 200 as admin with q/sort/dir/role/paging, 401 unauthenticated, 403 as non-admin on the very next request after a revoke (verified against a cache-intact cookie jar), 400 with zod issues on bad `sort`/`role`; OpenAPI lists the route with 200/400/401/403/429/500.
- agent-browser E2E on `/console/users` as LocalAgent: sidebar groups render with correct active states (exact-matched Dashboard link), region fills the viewport with zero page scroll (measured), virtualization confirmed (window of ~22 rendered rows against a larger loaded set, tbody sized by the virtualizer), first batch only on load, scrolling streams the next batch and the status line updates to N of N, sticky header stays pinned mid-scroll, sort asc/desc resets to a fresh sorted batch scrolled to top (URL + first row verified), search (`q`, deferred), role facet composed with sort + search (`?sort=name.asc&role=admin` verified end to end), selection count, reset (clears filters, keeps sort), column hide/restore via View, focusable scroll region, light + dark themes. 375px pass: fixed columns hold their size and the region scrolls horizontally (924px content in a 341px region) instead of crushing cells. Explicit table roles survive the grid/flex flip (5 columnheaders in the a11y tree, `aria-rowcount`/`aria-rowindex` reflect the full virtualized set).
- `bun run check-types` green across all workspaces; oxlint + oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpGEatn22yd6GfW7VCbnUo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only Users page with searchable, sortable, filterable, virtualized tables and infinite scrolling.
  * Added user status, role, join date, selection, column visibility, and copy-to-clipboard actions.
  * Added URL-synchronized table filters and sorting.
  * Added admin access enforcement with clear unauthorized and forbidden responses.

* **Documentation**
  * Added data-table guidance and updated console, authentication, architecture, and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->