### PR TITLE
fix(ci): run the centralized suite from the repo root

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -45,7 +45,9 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Test
+        # The suite lives at the repo root now (one tests/ mirror, no per-package test script), so this step steps out of the job's packages/cli default.
         run: bun run test
+        working-directory: .
 
   release:
     if: |

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare": "bunx lefthook install",
     "shadcn:update": "bash .github/scripts/shadcn-update.sh && bun i",
     "start": "turbo run start",
-    "test": "if [ -d tests ]; then bun test tests; fi"
+    "test": "if [ -d tests ]; then bun packages/scripts/src/data-table-metrics.ts && bun test tests; fi"
   },
   "devDependencies": {
     "@commitlint/cli": "catalog:",


### PR DESCRIPTION
Follow-up to #754, which centralized every test under the root `tests/` mirror and dropped the per-package `test` scripts.

`cli-release.yml`'s test job sets `working-directory: packages/cli` and runs `bun run test`, so on canary it failed with `a package.json script "test" was not found` and gated the CLI publish. The step now runs from the repo root.

Fixing that surfaced a second gap: the web layout tests import `.generated/data-table-metrics.json`, which only the `build`, `dev`, and `check-types` chains produce. `bun run test` on its own (exactly what `cli-release` does) therefore failed on a clean checkout with `Cannot find module 'generated/data-table-metrics.json'`. The root `test` script now generates the metrics first, the same way those chains do.

## Verification

- Reproduced both failures in a fresh worktree before fixing: the missing `test` script, then the missing metrics (`132 pass, 1 fail`).
- After: `bun run test` from a cold checkout with `.generated/` deleted → **149 pass, 0 fail**.
- Fork case still no-ops: with `tests/` removed the script exits 0 without running the generator.
- `check-types` 13/13, `lint`, and `format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpGEatn22yd6GfW7VCbnUo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the test workflow to run from the repository root.
  * Added automatic data-table metrics generation before running tests when test files are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->