### PR TITLE
fix(ci): give the cli-release suite the env its build needs

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -48,6 +48,10 @@ jobs:
         # The suite lives at the repo root now (one tests/ mirror, no per-package test script), so this step steps out of the job's packages/cli default.
         run: bun run test
         working-directory: .
+        # The suite builds packages/* first, and @packages/db reads env while tsdown loads its config, so this needs what auto-check-build already sets. There is no .env on a runner.
+        env:
+          NODE_ENV: production
+          SKIP_ENV_VALIDATION: true
 
   release:
     if: |


### PR DESCRIPTION
Follow-up to #772. That PR made `bun run test` build `packages/*` first, which fixed the module resolution that had blocked the npm publish since v0.1.15. But it moved the failure rather than clearing it, and the v0.1.18 release run failed on the new one.

## What happened

`@packages/db` reads env while tsdown loads its config, so building it needs env. A runner has no `.env`, and `cli-release` sets no environment, so the build died:

```
❌ Invalid environment variables: [
    path: [ 'NODE_ENV' ],     message: 'Invalid option: expected one of "local"|...|"production"'
    path: [ 'POSTGRES_URL' ], message: 'Invalid input: expected string, received undefined'
]
Failed: @packages/db#build
```

`auto-check-build` never showed this because it has set both variables all along:

```yaml
env:
  NODE_ENV: production
  SKIP_ENV_VALIDATION: true
```

`cli-release` is the only other workflow that runs the suite, and it was the only one missing them. This PR gives it the same block.

## Verification

On a worktree with no `.env` and every `dist` deleted, matching a runner:

| Condition | Result |
| --- | --- |
| no env vars set | `@packages/db#build` fails on `NODE_ENV` and `POSTGRES_URL`, exit 1 |
| with the two variables | 5 build tasks, then **259 pass, 0 fail** |

I also checked that no third workflow runs the suite: `bun run test` appears in `auto-check-build.yml` and `cli-release.yml` only, and both now set the env.

## On the local case

A normal checkout is unaffected. `.env.example` ships `NODE_ENV=local` and an empty `POSTGRES_URL`, and setup copies it to `.env`, so the build finds what it needs. Only a runner, which has no `.env` at all, hits this.

## After this merges

v0.1.18 is tagged and released on GitHub but still not on npm, where `latest` remains 0.1.14. `cli-release` publishes the version at the latest tag, so once this is on `canary` the publish can be re-triggered for v0.1.18 without cutting a new version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI release testing environment to use production settings and bypass environment validation during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->