### PR TITLE
fix(test): make the digest guard survive a CRLF checkout

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,6 +6,9 @@ on:
       - canary
     paths:
       - "packages/cli/**"
+      # the CLI's suite lives at the repo-root tests/ mirror, so a test-only change has to reach
+      # this matrix too; without it the legs that gate the publish never re-run on the fix
+      - "tests/packages/cli/**"
   workflow_run:
     workflows: ["auto-release"]
     types: [completed]

--- a/tests/packages/cli/src/skills.test.ts
+++ b/tests/packages/cli/src/skills.test.ts
@@ -240,15 +240,15 @@ describe("the sync ledger", () => {
 
   // The CLI and .github/scripts/skills-manager.ts hash the ledger independently (a fork ships no
   // packages/cli to import), so a one-sided edit would make every skill silently read as untracked.
+  // Whitespace is stripped rather than matched, which keeps this insensitive to how either file is
+  // formatted and to the CRLF a Windows checkout brings, the very thing the hash normalizes away.
   test("hashes identically to the maintainer script", async () => {
-    const script = await Bun.file(
-      join(import.meta.dir, "../../../../.github/scripts/skills-manager.ts"),
-    ).text()
-    const theirs = script.match(/const digest = \(text: string\) =>\s*([\s\S]*?)\n\n/)
-    expect(theirs).not.toBeNull()
-    const normalized = (s: string) => s.replace(/\s+/g, "")
-    expect(normalized(theirs![1]!)).toContain(normalized('createHash("sha256")'))
-    expect(normalized(theirs![1]!)).toContain(normalized('.replace(/\\r\\n/g, "\\n")'))
-    expect(normalized(theirs![1]!)).toContain(normalized('.digest("hex").slice(0, 12)'))
+    const strip = (s: string) => s.replace(/\s+/g, "")
+    const pipeline = strip(
+      `createHash("sha256").update(text.replace(/\\r\\n/g, "\\n")).digest("hex").slice(0, 12)`,
+    )
+    const source = async (rel: string) => strip(await Bun.file(join(import.meta.dir, rel)).text())
+    expect(await source("../../../../packages/cli/src/skills.ts")).toContain(pipeline)
+    expect(await source("../../../../.github/scripts/skills-manager.ts")).toContain(pipeline)
   })
 })


### PR DESCRIPTION
The Windows leg of `cli-release` failed on #777's new digest guard, which blocked the v0.1.20 release (`release` job is `needs: [test]`, so it skipped rather than half-published).

## Cause

The guard regex-matched the maintainer script's source and anchored on a blank line as `\n\n`:

```ts
script.match(/const digest = \(text: string\) =>\s*([\s\S]*?)\n\n/)
```

A Windows checkout writes that as `\r\n\r\n`, so the match returned `null` and the test failed before asserting anything. A test written to guard CRLF-safe hashing was itself the one thing that was not CRLF-safe.

## Fix

Strip whitespace from both files and look for the digest pipeline in that form, which is insensitive to line endings and to how either file is formatted. It now also compares the CLI against the script rather than only inspecting the script, which is what "hashes identically" claimed in the first place.

## Verified

Reproduced the Windows condition locally by rewriting the script to CRLF, rather than guessing:

```
old regex on LF   : matches
old regex on CRLF : NULL -> test fails
new check on LF   : true
new check on CRLF : true
```

Suite green on both line endings; `276 pass, 0 fail`.