### PR TITLE
feat(web): migrate the data table to @tanstack/react-table v9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -244,7 +244,7 @@
     "@tanstack/react-form": "^1.33.2",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-devtools": "^5.101.2",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.0.0",
     "@tanstack/react-virtual": "^3.14.9",
     "@types/bun": "^1.3.14",
     "@types/fontkit": "^2.0.9",
@@ -965,13 +965,13 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+    "@tanstack/react-table": ["@tanstack/react-table@9.0.0", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.0.0" }, "peerDependencies": { "react": ">=18" } }, "sha512-Q/Z49MQcdMwge67U+LTjSEQJCnQE9/tNWK5IpiYex9JFDzfjNkLIi7yzGA4dfW4UpuMBrtqbSnSzn7oPr60T+w=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.9", "", { "dependencies": { "@tanstack/virtual-core": "3.17.7" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ=="],
 
     "@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+    "@tanstack/table-core": ["@tanstack/table-core@9.0.0", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.7", "", {}, "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA=="],
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@tanstack/react-form": "^1.33.2",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-devtools": "^5.101.2",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.0.0",
     "@tanstack/react-virtual": "^3.14.9",
     "@types/bun": "^1.3.14",
     "@types/fontkit": "^2.0.9",

--- a/web/next/src/app/(console)/console/(access)/allowlist/components/data-columns.tsx
+++ b/web/next/src/app/(console)/console/(access)/allowlist/components/data-columns.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { apiClient } from "@/lib/api/client"
 import { copyToClipboard } from "@/lib/clipboard"
+import type { Features } from "@/lib/data-table-features"
 
 // Row shape inferred from GET /api/v1/admin/allowlist, so the endpoint cannot drift from these columns.
 export type AllowlistRuleRow = InferResponseType<
@@ -41,7 +42,7 @@ export const allowlistColumnConfig: Record<string, ColumnConfig> = {
 
 export const allowlistColumns = (
   onDelete: (rule: AllowlistRuleRow) => void,
-): ColumnDef<AllowlistRuleRow>[] => [
+): ColumnDef<Features, AllowlistRuleRow, unknown>[] => [
   selectColumn((row) => row.value),
   {
     id: "rule",

--- a/web/next/src/app/(console)/console/(access)/users/components/data-columns.tsx
+++ b/web/next/src/app/(console)/console/(access)/users/components/data-columns.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { apiClient } from "@/lib/api/client"
 import { copyToClipboard } from "@/lib/clipboard"
+import type { Features } from "@/lib/data-table-features"
 import { relativeTime } from "@/lib/time"
 
 // Row shape inferred from GET /api/v1/admin/users, so the endpoint cannot drift from these columns.
@@ -47,7 +48,7 @@ export const usersColumnConfig: Record<string, ColumnConfig> = {
 
 export const usersColumns = (
   onSetStatus: (users: ConsoleUser[], banned: boolean) => void,
-): ColumnDef<ConsoleUser>[] => [
+): ColumnDef<Features, ConsoleUser, unknown>[] => [
   selectColumn((row) => row.email),
   {
     accessorKey: "name",

--- a/web/next/src/app/(console)/console/(access)/users/components/role-select.tsx
+++ b/web/next/src/app/(console)/console/(access)/users/components/role-select.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select"
 import { toast } from "@/components/ui/toast"
 import { apiClient, unwrap } from "@/lib/api/client"
+import type { Features } from "@/lib/data-table-features"
 
 // The role cell for someone who may change roles. A member never renders this, and every rule it appears to enforce is enforced again on the API, which refuses with the reason shown here.
 export function UserRoleSelect({
@@ -25,7 +26,7 @@ export function UserRoleSelect({
   role,
   userId,
 }: {
-  column: Column<ConsoleUser, unknown>
+  column: Column<Features, ConsoleUser, unknown>
   email: string
   role: string
   userId: string

--- a/web/next/src/app/(console)/console/activity/components/data-columns.tsx
+++ b/web/next/src/app/(console)/console/activity/components/data-columns.tsx
@@ -23,6 +23,7 @@ import {
 import { actionLabel, activityJson } from "@/lib/activity"
 import { apiClient } from "@/lib/api/client"
 import { copyToClipboard } from "@/lib/clipboard"
+import type { Features } from "@/lib/data-table-features"
 import { relativeTime } from "@/lib/time"
 
 export type ActivityEvent = InferResponseType<
@@ -38,7 +39,7 @@ export const activityColumnConfig: Record<string, ColumnConfig> = {
   actions: { align: "center", width: 12 },
 }
 
-export const activityColumns: ColumnDef<ActivityEvent>[] = [
+export const activityColumns: ColumnDef<Features, ActivityEvent, unknown>[] = [
   selectColumn((row: ActivityEvent) => row.summary),
   {
     accessorKey: "actor",

--- a/web/next/src/app/(console)/console/waitlist/components/data-columns.tsx
+++ b/web/next/src/app/(console)/console/waitlist/components/data-columns.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { apiClient } from "@/lib/api/client"
 import { copyToClipboard } from "@/lib/clipboard"
+import type { Features } from "@/lib/data-table-features"
 import { relativeTime } from "@/lib/time"
 
 export type WaitlistSignup = InferResponseType<
@@ -38,7 +39,7 @@ export const waitlistColumnConfig: Record<string, ColumnConfig> = {
 
 export const waitlistColumns = (
   onRemove: (signup: WaitlistSignup) => void,
-): ColumnDef<WaitlistSignup>[] => [
+): ColumnDef<Features, WaitlistSignup, unknown>[] => [
   selectColumn((row: WaitlistSignup) => row.email),
   {
     accessorKey: "email",

--- a/web/next/src/components/data-table.tsx
+++ b/web/next/src/components/data-table.tsx
@@ -14,15 +14,15 @@ import {
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query"
 import {
   flexRender,
-  getCoreRowModel,
-  useReactTable,
+  useTable,
   type Column,
   type ColumnDef,
   type ColumnFiltersState,
   type OnChangeFn,
+  type RowData,
   type RowSelectionState,
   type SortingState,
-  type Table as TableInstance,
+  type ReactTable as TableInstance,
   type Updater,
 } from "@tanstack/react-table"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -69,6 +69,7 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { features, type Features } from "@/lib/data-table-features"
 import { applyColumnManager, growingColumnIds, type ColumnConfig } from "@/lib/data-table-layout"
 import { cn } from "@/lib/utils"
 
@@ -196,14 +197,16 @@ export type DataTablePage<TRow> = {
 }
 
 // The select column, so a second table cannot ship a third variant of it. label names the row for a screen reader, which is the part that had already drifted.
-export function selectColumn<TData>(label: (row: TData) => string): ColumnDef<TData> {
+export function selectColumn<TData extends RowData>(
+  label: (row: TData) => string,
+): ColumnDef<Features, TData, unknown> {
   return {
     id: "select",
     header: ({ table }) => (
       <Checkbox
         aria-label="Select all"
         checked={table.getIsAllPageRowsSelected()}
-        indeterminate={table.getIsSomePageRowsSelected()}
+        indeterminate={table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected()}
         onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
       />
     ),
@@ -220,7 +223,7 @@ export function selectColumn<TData>(label: (row: TData) => string): ColumnDef<TD
 }
 
 // The generic server-driven table wiring. A page brings only what a generic hook cannot know (its columns, its fetcher, its filter ids, its column config) and spreads tableProps into DataTable. Client-side tables skip this and use useDataTableState directly.
-export function useDataTable<TRow>({
+export function useDataTable<TRow extends RowData>({
   batchSize = 25,
   columnConfig,
   columns,
@@ -233,7 +236,7 @@ export function useDataTable<TRow>({
 }: {
   batchSize?: number
   columnConfig?: Record<string, ColumnConfig>
-  columns: ColumnDef<TRow>[]
+  columns: ColumnDef<Features, TRow, unknown>[]
   defaultSorting?: SortingState
   enableRowSelection?: boolean
   fetchPage: (input: DataTablePageInput) => Promise<DataTablePage<TRow>>
@@ -318,7 +321,7 @@ export function useDataTable<TRow>({
     setRowSelection({})
   }, [filters, search, sorting])
 
-  const table = useReactTable({
+  const table = useTable({
     columns: managedColumns,
     data: rows,
     state: { columnFilters, globalFilter, rowSelection, sorting },
@@ -327,7 +330,7 @@ export function useDataTable<TRow>({
     // Single-column sorting only: fetchPage sends one sort to the server, so shift-click multi-sort would silently drop the extra columns.
     enableMultiSort: false,
     enableRowSelection,
-    getCoreRowModel: getCoreRowModel(),
+    features,
     getRowId,
     manualFiltering: true,
     manualSorting: true,
@@ -365,7 +368,7 @@ export function useDataTable<TRow>({
 const ROW_ESTIMATE_PX = 45
 
 // Renders a table instance the page owns as a virtualized infinite-scroll region, following TanStack Table's virtualized-infinite-scrolling example: semantic table tags flipped to grid/flex so absolutely positioned virtual rows work, a sticky header, onLoadMore fired within 500px of the bottom, a spinner while loading, and an Empty fallback. The wrapper is the scroll container, focusable and named so keyboard users can reach the overflow; the inner shadcn container is flattened via its data-slot.
-export function DataTable<TData>({
+export function DataTable<TData extends RowData>({
   "aria-label": ariaLabel,
   empty,
   errorMessage,
@@ -390,7 +393,7 @@ export function DataTable<TData>({
   onRetry?: () => void
   // What can be done to the selected rows. Rendered in a bar that floats in over the bottom of the table while anything is selected, next to the rows it acts on rather than up in the toolbar with the filters.
   selectionActions?: React.ReactNode
-  table: TableInstance<TData>
+  table: TableInstance<Features, TData>
   total?: number
 }) {
   const containerRef = React.useRef<HTMLDivElement>(null)
@@ -424,7 +427,7 @@ export function DataTable<TData>({
   }, [loadMoreOnBottomReached, rows.length])
 
   // Back to the top whenever sorting, search, or filters reshape the list; these state slices keep stable identities between changes, so they work as deps directly. The virtualizer instance is stable and deliberately not a dep.
-  const { columnFilters, globalFilter, sorting } = table.getState()
+  const { columnFilters, globalFilter, sorting } = table.state
   const filtering = Boolean(globalFilter) || columnFilters.length > 0
   React.useEffect(() => {
     if (rowVirtualizer.getVirtualItems().length) rowVirtualizer.scrollToIndex(0)
@@ -438,7 +441,7 @@ export function DataTable<TData>({
       id: column.id,
     })),
   )
-  const columnLayout = (column: Column<TData, unknown>) => {
+  const columnLayout = (column: Column<Features, TData, unknown>) => {
     const meta = column.columnDef.meta
     // Centered columns drop the horizontal padding: the shadcn cell strips pr when it holds a checkbox, which would skew a padded center.
     const align =
@@ -628,12 +631,12 @@ export function DataTable<TData>({
 // Column header: a plain title with a bare sort icon.
 
 // Sortable column header: the title stays text so it aligns with cell content natively; the only control is the icon, a native button for keyboard and screen readers with a focus ring as its only chrome, toggling asc and desc (hiding lives in the view options). A right-aligned header mirrors the icon to the left so the title stays flush with the cell text. Falls back to a plain label for non-sortable columns.
-export function DataTableColumnHeader<TData, TValue>({
+export function DataTableColumnHeader<TData extends RowData, TValue>({
   className,
   column,
 }: {
   className?: string
-  column: Column<TData, TValue>
+  column: Column<Features, TData, TValue>
 }) {
   // meta.label is the one source for this column's header text, its measured width, and its view-options entry; a separate title prop would silently desync the width from what the header actually renders.
   const title =
@@ -673,14 +676,14 @@ export function DataTableColumnHeader<TData, TValue>({
 // Cell text: overflow behavior from the column config.
 
 // Text cells render through this so column widths never move with content. The mode comes from the column config's wrap flag through column meta: false truncates to one line with an ellipsis and reveals the full value in a tooltip only when actually cut (measured on hover); true flows onto multiple lines and lets the self-measured virtual row grow. Truncation is CSS-only, so the full value stays in the DOM and assistive tech reads it whether or not the tooltip ever opens; the tooltip is a sighted-pointer convenience, which is why the trigger takes no tab stop (one per text cell would bury the table's real controls).
-export function DataTableCellText<TData, TValue>({
+export function DataTableCellText<TData extends RowData, TValue>({
   children,
   className,
   column,
 }: {
   children: React.ReactNode
   className?: string
-  column?: Column<TData, TValue>
+  column?: Column<Features, TData, TValue>
 }) {
   const ref = React.useRef<HTMLSpanElement>(null)
   const [truncated, setTruncated] = React.useState(false)
@@ -715,7 +718,7 @@ export function DataTableCellText<TData, TValue>({
 // Toolbar.
 
 // Search box wired to the table's global filter, a children slot for faceted filters, a reset button once anything filters, and on the right the view-options toggle followed by an actions slot.
-export function DataTableToolbar<TData>({
+export function DataTableToolbar<TData extends RowData>({
   actions,
   children,
   searchMaxLength,
@@ -727,11 +730,11 @@ export function DataTableToolbar<TData>({
   children?: React.ReactNode
   searchMaxLength?: number
   searchPlaceholder?: string
-  table: TableInstance<TData>
+  table: TableInstance<Features, TData>
 }) {
-  const globalFilter = table.getState().globalFilter
+  const globalFilter = table.state.globalFilter
   const search = typeof globalFilter === "string" ? globalFilter : ""
-  const isFiltered = search !== "" || table.getState().columnFilters.length > 0
+  const isFiltered = search !== "" || table.state.columnFilters.length > 0
   // The placeholder doubles as the accessible name, minus its trailing ellipsis: a screen reader would otherwise announce "Search users dot dot dot".
   const searchLabel = searchPlaceholder.replace(/[.\u2026]+$/, "")
 
@@ -774,7 +777,11 @@ export function DataTableToolbar<TData>({
 // View options.
 
 // Column visibility toggle for every hideable accessor column, labeled from columnDef.meta.label when set.
-export function DataTableViewOptions<TData>({ table }: { table: TableInstance<TData> }) {
+export function DataTableViewOptions<TData extends RowData>({
+  table,
+}: {
+  table: TableInstance<Features, TData>
+}) {
   const columns = table
     .getAllColumns()
     .filter((column) => typeof column.accessorFn !== "undefined" && column.getCanHide())
@@ -812,12 +819,12 @@ export function DataTableViewOptions<TData>({ table }: { table: TableInstance<TD
 // Faceted filter.
 
 // Multi-select filter over a column's values; renders nothing when the column is absent so call sites can pass table.getColumn(...) directly.
-export function DataTableFacetedFilter<TData, TValue>({
+export function DataTableFacetedFilter<TData extends RowData, TValue>({
   column,
   options,
   title,
 }: {
-  column: Column<TData, TValue> | undefined
+  column: Column<Features, TData, TValue> | undefined
   options: { icon?: RemixiconComponentType; label: string; value: string }[]
   title: string
 }) {

--- a/web/next/src/lib/data-table-features.ts
+++ b/web/next/src/lib/data-table-features.ts
@@ -1,0 +1,32 @@
+import {
+  columnFacetingFeature,
+  columnFilteringFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  createFacetedRowModel,
+  createFacetedUniqueValues,
+  createFilteredRowModel,
+  createSortedRowModel,
+  globalFilteringFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  tableFeatures,
+} from "@tanstack/react-table"
+
+// The table features this app registers, and the single value every table type is generic over. v9 bundles nothing by default: a method is only on the instance when its feature is registered here, and a row model only exists when its slot is filled. Registered explicitly rather than through stockFeatures so the bundle carries only what the console's tables call.
+export const features = tableFeatures({
+  columnFacetingFeature,
+  columnFilteringFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  globalFilteringFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  filteredRowModel: createFilteredRowModel(),
+  sortedRowModel: createSortedRowModel(),
+})
+
+// Infer rather than hand-write: every ColumnDef, Column, and Table type in the app is parameterized by this.
+export type Features = typeof features

--- a/web/next/src/lib/data-table-layout.ts
+++ b/web/next/src/lib/data-table-layout.ts
@@ -1,11 +1,13 @@
-import type { ColumnDef, RowData } from "@tanstack/react-table"
+import type { ColumnDef, RowData, TableFeatures } from "@tanstack/react-table"
 import rawFontMetrics from "generated/data-table-metrics.json"
+
+import type { Features } from "@/lib/data-table-features"
 
 // The data table's layout math: pure arithmetic over the column config and the build-time font metrics, with no React and no DOM. It lives beside the module rather than inside it so it can be exercised directly (tests/web/next/src/lib); components/data-table.tsx re-exports the parts consumers use, so a table still imports everything from one place.
 
 // Column meta carried from the column config: labels for the view-options menu, plus the layout and overflow flags the renderer reads.
 declare module "@tanstack/react-table" {
-  interface ColumnMeta<TData extends RowData, TValue> {
+  interface ColumnMeta<TFeatures extends TableFeatures, TData extends RowData, TValue> {
     align?: "center" | "left" | "right"
     auto?: boolean
     flex?: boolean
@@ -54,10 +56,10 @@ export function autoWidthUnits(label: string, extraUnits: number): number {
 
 // Folds a table's column config into its defs by column id (id, else accessorKey), so useReactTable sees size plus the align/flex/wrap meta. A widthless config sizes from its header label via the bundled metrics. Flex capability reaches back from a flex column to every column before it. useDataTable applies this via its columnConfig option; client-side tables call it directly.
 export function applyColumnManager<TData extends RowData>(
-  columns: ColumnDef<TData>[],
+  columns: ColumnDef<Features, TData, unknown>[],
   columnConfig: Record<string, ColumnConfig>,
-): ColumnDef<TData>[] {
-  const configFor = (column: ColumnDef<TData>) => {
+): ColumnDef<Features, TData, unknown>[] {
+  const configFor = (column: ColumnDef<Features, TData, unknown>) => {
     const id = column.id
       ? column.id
       : "accessorKey" in column


### PR DESCRIPTION
`@tanstack/react-table@9.0.0` shipped today (2026-08-04 06:29 UTC), and a `--latest` bump pulled it into the catalog. It is a rewrite, not a rename, so the build broke immediately:

> The export `useReactTable` was not found... Did you mean to import `useTable`?

This migrates rather than pins.

## What v9 changes

Nothing is bundled by default. A method only exists on the table instance when its **feature** is registered, and a row model only exists when its **slot** is filled.

`web/next/src/lib/data-table-features.ts` is the single registration every table type is generic over. It lists the features the console's tables actually call rather than `stockFeatures`, so the bundle carries nothing unused.

| v8 | v9 |
| --- | --- |
| `useReactTable(options)` | `useTable({ ...options, features })` |
| `getCoreRowModel()` | removed, core is automatic |
| `getFilteredRowModel()` / `getFacetedUniqueValues()` | `filteredRowModel`, `facetedRowModel`, `facetedUniqueValues`, `sortedRowModel` slots |
| `ColumnDef<TData>` / `Column<TData, TValue>` | `ColumnDef<Features, TData, TValue>` / `Column<Features, TData, TValue>` |
| `ColumnMeta<TData, TValue>` | `ColumnMeta<TFeatures, TData, TValue>` |
| `table.getState()` | `table.state` |
| `RowData = unknown` | row data must be a record or array |

Two subtleties worth calling out:

- **`table.state` is on `ReactTable`, not core `Table`.** Core only exposes `store`, which v9 deprecates for render reads. The component props that read state are now typed as the instance `useTable` returns.
- **`getIsSomePageRowsSelected()` changed meaning** to "at least one, *including* when all are selected". The header checkbox now computes indeterminate as `getIsSomePageRowsSelected() && !getIsAllPageRowsSelected()`. Left alone it would render a dash where a tick belongs, with types perfectly green.

Both mappings come from the library's own `migrate-v8-to-v9` skill, which v9 ships inside the package and versions with the release, so this follows the authors' guidance rather than a reverse-engineered reading of `.d.ts` files.

## Verified in a browser, not just typechecked

A headless table library that compiles proves very little, particularly when v9 moved methods onto prototypes. Ran against a disposable Postgres seeded with fake rows (60 users, 40 waitlist, 35 allowlist, 45 activity):

- all four console tables render (`/console/users`, `/activity`, `/allowlist`, `/waitlist`), no error text
- select-all reports **50 of 50 row(s) selected**, deselecting one gives **49 of 50** — so the filtered selection model resolves, which only works if the filtering feature and its row-model slot are registered
- `aria-sort=descending` tracks the active column
- search filters to **12 rows** with the URL synced to `?q=person1`

`bun run check-types` 13/13, `bun run build` 7/7, `bun run test` 276 pass 0 fail, oxlint clean.

<details>
<summary>Screenshot</summary>

Litterbox returned 403 for the upload (it has been rejecting uploads all session), so the screenshot was handed to the maintainer directly rather than embedded. It shows the users table on v9: sort chevrons, the active "Last active" sort arrow, role selects, status, row checkboxes, `0 of 50 row(s) selected`, `50 of 61`, and the Role faceted filter.

</details>

## Note

Only the `@tanstack/react-table` catalog entry moves here. The other bumps sitting uncommitted locally (`@base-ui/react`, `@hono/node-server`, `@scalar/hono-api-reference`, takumi) are all minors and unrelated to this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated table components across access, activity, and waitlist views for improved feature support.
  * Added consistent support for filtering, sorting, faceting, column sizing, visibility, global search, and row selection.
  * Improved table state handling and configuration consistency across the application.
* **Maintenance**
  * Updated the table library to version 9.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->