### PR TITLE
fix(web): run the web functions on Node, not Bun

### DIFF
--- a/web/next/content/docs/deployment/vercel.mdx
+++ b/web/next/content/docs/deployment/vercel.mdx
@@ -9,12 +9,14 @@ Deploy `web/next` and `api/hono` as **two separate Vercel projects** pointed at 
 
 ## The shape
 
-Both apps ship a `vercel.json`, so Vercel reads the install command, build command, framework, and Bun version automatically once you point a project at the right root. You set two things per project: the **Root Directory** and the **environment variables**.
+Both apps ship a `vercel.json`, so Vercel reads the install command, build command, framework, and function runtime automatically once you point a project at the right root. You set two things per project: the **Root Directory** and the **environment variables**.
 
-| Project  | Root Directory | Framework |
-| -------- | -------------- | --------- |
-| Backend  | `api/hono`     | Hono      |
-| Frontend | `web/next`     | Next.js   |
+| Project  | Root Directory | Framework | Function runtime           |
+| -------- | -------------- | --------- | -------------------------- |
+| Backend  | `api/hono`     | Hono      | Bun (`bunVersion`)         |
+| Frontend | `web/next`     | Next.js   | Node (no `bunVersion` set) |
+
+The api runs its own self-contained bundle, built with `bun build --target bun`, so Bun is the runtime it is compiled for. The web app does not set `bunVersion`: Next's server is built for Node, and Vercel's Bun runtime expects the build itself to run under Bun (`bun run --bun next build`) which this build does not do. Pinning the web functions to Bun while building for Node crashes every function on `next/dist/compiled/next-server`, and only prerendered output keeps serving.
 
 Deploy the **backend first**: the frontend needs its URL.
 

--- a/web/next/vercel.json
+++ b/web/next/vercel.json
@@ -2,6 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && bun install --ignore-scripts",
-  "buildCommand": "cd ../.. && SKIP_ENV_VALIDATION_SERVER=true turbo build --filter=@web/next",
-  "bunVersion": "1.3.14"
+  "buildCommand": "cd ../.. && SKIP_ENV_VALIDATION_SERVER=true turbo build --filter=@web/next"
 }


### PR DESCRIPTION
Recovers `canary`, where every dynamic route has been returning 500 since #783.

## What broke

The 16.3.0 deploy crashes identically on every function:

```
Failed to load external module next/dist/compiled/next-server/app-page-turbo.runtime.prod.js:
TypeError: Expected CommonJS module to have a function wrapper.
If you weren't messing around with Bun's internals, this is a bug in Bun
```

Prerendered output masked it. A sweep of 212 paths on canary found 200 OK, 1 correct 404, and 11 x 500: `/og`, `/api/search`, `/api/console/search`, the six `/console` routes and `/dashboard`. The 200s were not healthy either, they were build-time output being replayed: `/llms.txt` and `/llms-full.txt` came back `x-vercel-cache: STALE` with `cacheReason: stale_error`, because each revalidation hit the same crash.

## Why

`web/next/vercel.json` set `bunVersion`, which puts the functions on Bun, while the build runs plain `next build` under Node. Vercel's Bun runtime [expects the build to run under Bun too](https://vercel.com/docs/functions/runtimes/bun) (`bun run --bun next build`), which this build does not do, so the two halves never matched. 16.3.0's Turbopack server runtime is where the mismatch finally became fatal. The `runtime-apis` skill already documents `web/next/**` as Node; this makes the config agree.

The api keeps `bunVersion`: it ships a self-contained bundle built with `bun build --target bun`, so Bun is the runtime it is compiled for.

## Note on #783

The standalone gate in #783 was a real fix for a real build failure, but it was not sufficient, and the deployment under it was already broken. That was verifiable on the preview and was missed there: only static paths were checked. This PR is verified against the dynamic routes.

## Sharpening the mechanism

Bun is not simply incapable of running 16.3.0. Building this app locally at 16.3.0 and serving the standalone output under `bun server.js` works: `/og` renders 200. The crash is specific to the **adapter-packaged function bundle** Vercel produces, where the compiled `next-server` runtime is reached through `externalRequire` out of a Turbopack chunk. Locally the standalone server loads it a different way and Bun copes. So the trigger is Bun plus Vercel's function packaging at 16.3.0, not the version on its own, which is also why 16.2.12 on Bun has been fine in production all along.

## Bun vs Node, measured

Same build, same machine, standalone output served under each runtime, `hyperfine --warmup 5 --runs 30`. A bare static request costs 7.2 ms of curl spawn plus transport, so subtract roughly that to see the server-side work.

next 16.3.0:

| Route | node | bun | |
| --- | --- | --- | --- |
| `/og` (takumi PNG render) | 20.5 ms ± 1.2 | 21.8 ms ± 2.0 | node 1.06x |
| `/api/search` | 9.0 ms ± 0.9 | 11.4 ms ± 2.6 | node 1.26x |

next 16.2.12, to confirm it is not version-specific:

| Route | node | bun | |
| --- | --- | --- | --- |
| `/og` | 20.8 ms ± 0.9 | 21.8 ms ± 1.1 | node 1.05x |
| `/api/search` | 9.4 ms ± 0.9 | 12.2 ms ± 3.1 | node 1.30x |
| `/` (prerendered page) | 7.7 ms ± 0.7 | 7.7 ms ± 0.7 | tie, both at the floor |

Node is faster on every route that does real work, including the CPU-bound render where Bun is supposed to lead, and Bun's variance is consistently wider. Nothing was being paid for by pinning the web functions to Bun.
