### PR TITLE
feat(web): turn off Next's agent-rules writer, this repo generates its own

### DIFF
--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -86,6 +86,8 @@ agent-browser click "@e12"    # act on a referenced element
 
 It is enforced, not just requested. Docs structure and page metadata live in one file, `web/next/docs.config.ts`, and the build derives every page's frontmatter and sidebar from it; `docs.ts --strict` fails the build when a page and the config disagree, so a doc can't silently fall out of sync. The `doc-sync` skill is the checklist an agent runs to keep code, docs, and skills aligned in the same change.
 
+Because that file is generated and symlinked, this starter turns off the one Next.js writes for you. Since 16.3, `next dev` upserts a managed block into `AGENTS.md` whenever it detects an AI coding agent, and creates `AGENTS.md` plus a `CLAUDE.md` containing `@AGENTS.md` when neither exists, which in this repo would mean a second pair inside `web/next/` fighting the generated root pair. `agentRules: false` in `web/next/next.config.ts` turns it off. The docs it points at are still worth reading: they ship in `node_modules/next/dist/docs/` and match the installed version exactly.
+
 ## Next
 
 - [AI Skills](/docs/resources/ai-skills): the full skill catalog, and writing your own.

--- a/web/next/next.config.ts
+++ b/web/next/next.config.ts
@@ -56,6 +56,8 @@ const appDevHost = (() => {
 })()
 
 const nextConfig: NextConfig = {
+  // Off because this repo writes its own agent guides: the root AGENTS.md is generated (skills-manager owns its skills tables) and CLAUDE.md is a symlink to it, so a second writer would fight both. Left on, `next dev` upserts a managed block whenever it detects an AI agent, and its own text says removing it from a diff only re-creates it. The Next 16.3 docs it points at are worth reading; see the AI agents note in web/next/content/docs/getting-started/working-with-agents.mdx.
+  agentRules: false,
   env: { NEXT_PUBLIC_IS_PRIVATE: String(isPrivate) },
   // Standalone is the Docker runner's input only. Vercel builds through a Next adapter, and since 16.3.0 an adapter build writes no .nft.json trace files, so the standalone copy step reads next-server.js.nft.json and fails the build with ENOENT.
   ...(!process.env.VERCEL && { output: "standalone" as const }),


### PR DESCRIPTION
Next 16.3 added an agent-rules writer to `next dev`. This repo already generates its agent guide, so the two would fight.

## What it does

`next/dist/server/lib/generate-agent-files.js` upserts a `<!-- BEGIN:nextjs-agent-rules -->` block on dev boot when it detects an AI coding agent. The target depends on what exists:

| Situation | Result |
| --- | --- |
| `AGENTS.md` exists | upsert into it, leave `CLAUDE.md` alone |
| only `CLAUDE.md` exists | upsert into that |
| **neither exists** | **create both** |

`next dev` runs in `web/next/`, where neither exists, so it takes the third branch. Proven by calling the writer against an empty directory shaped like `web/next`:

```
writeAgentFiles -> {"agentsMd":"created","claudeMd":"created"}
files created: AGENTS.md, CLAUDE.md
CLAUDE.md content: "@AGENTS.md"
```

That is a second, unmanaged pair inside `web/next/` while the root pair is generated (`skills-manager` owns its skills tables) and symlinked (`CLAUDE.md` -> `AGENTS.md`). The block is self-restoring by design; its own text says removing it from a diff only re-creates the change. It also contains two em-dashes, which this repo forbids.

## The fix

`agentRules: false`, the documented switch, read at dev bootstrap:

```js
// Gated on `agentRules` in next.config (default true).
if (initResult.agentRules !== false) {
```

The version-matched docs it advertises are still readable in `node_modules/next/dist/docs/`, which the docs page now points at.

## Honest limitation

I could not reproduce the write through `next dev` itself in this setup. Detection returns `claude-code_2-1-221_agent` and neither guide exists, yet no file appeared, so the path may not be reachable under Turbopack dev today. The flag is the guarantee either way and costs nothing if it never fires.

## Verified

- `bun run dev` then `git status`: clean, no `web/next/CLAUDE.md`
- `bun .github/scripts/skills-manager.ts --check`: up to date
- `check-types` 13/13, `test` 276 pass, `build` 7/7 (`docs.ts --strict` runs in it)
- no em-dashes in either changed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disabled automatic generation and management of Next.js agent-rules files to preserve the project’s existing setup.

* **Documentation**
  * Added guidance explaining this configuration and linking to the relevant Next.js documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->