### PR TITLE
docs(notes): record the 16.3 assessment, and decline the Rust React Compiler

### DIFF
--- a/.github/notes/plans/README.md
+++ b/.github/notes/plans/README.md
@@ -29,6 +29,7 @@ This is the internal, fork-excluded backlog. It is separate from the published `
 - [Standardize and pin the release-workflow tooling](workflow-tooling-consistency.md) - deferred from #683 (JSON tool standardized on `json`; pinning + read-helper unification left).
 - [OpenAPI: the WS upgrade route lists inapplicable 429/500 responses](openapi-ws-responses.md) - #664; subsumed by api-envelope-typed-endpoint, but shippable on its own as the smaller fix.
 - [An API route harness](api-route-test-harness.md) - the last-owner FOR UPDATE, the ban compare-and-set and the sign-in grant hook are only checked by hand; a mock cannot tell you whether a lock blocks (PR #758 review).
+- [Next.js 16.3 adoption](next-163-adoption.md) - what was taken (`agentRules: false`, PR #786), what was measured and declined (the Rust React Compiler, ~6% here against a claimed 34-46%), and what Instant Navigations would cost.
 - [Unit-test the pure web seams](web-content-source-tests.md) - the contentSource gate and the data-table layout math; needs a web test harness first (PR #691, #754 reviews).
 - [Console not-found status and the anonymous white flash](console-notfound-status.md) - a layout-thrown notFound cannot unwind into an already-streaming parent: console 404s soft-200, and an anonymous visit paints white before hydrating; middleware is the real fix (PR #691, #758 reviews).
 - [Derive BlogPostMeta from the blog zod schema](blog-meta-from-schema.md) - carved out of content-source-consolidation; a decouple-vs-derive tradeoff, not a mechanical rename (PR #691 review).

--- a/.github/notes/plans/console-notfound-status.md
+++ b/.github/notes/plans/console-notfound-status.md
@@ -18,3 +18,19 @@ Two exits, both rejected for now. Rendering the not-found from the layout instea
 Scope check: it is one white paint, for someone with no console access typing a gated address directly, on a noindex area. Every console path still answers identically at every rung, so nothing is enumerable either way.
 
 Low severity: the correct not-found UI shows (no content leaks), and `/console` is `robots: noindex` and gated at member and above, so there is no SEO cost. The only practical downside is that a programmatic client cannot distinguish missing-vs-ok by status on console routes. A real fix is framework-rooted (decide existence before the force-dynamic stream, e.g. in middleware or a segment that can set the status pre-stream); not worth that surgery for a noindex, gated area.
+
+## Next 16.3's `catchError` does not fix it (spiked)
+
+16.3 says error boundaries previously "interfered with application code that called `notFound` or `redirect`", which reads like this bug. It is a different mechanism, and converting the boundary changes nothing here.
+
+Spiked by rewriting `(console)/console/error.tsx` onto `catchError` from `next/error` and re-measuring against a live dev server, with `/console/users` as a control:
+
+| Path                       | Before | With `catchError` |
+| -------------------------- | ------ | ----------------- |
+| `/console/does-not-exist`  | 200    | **200**           |
+| `/console/users` (control) | 200    | 200               |
+| `/nope-at-root` (control)  | 404    | 404               |
+
+What 16.3 fixed is a boundary swallowing the `notFound` signal. What happens here is the status line being committed before the page-level `notFound()` fires mid-stream, exactly as described above, which no boundary can reach. Reverted; the entry stands.
+
+Watch the control: an earlier run of this spike showed 404 and looked like a fix, because the dev server had died and every path was answered by the proxy. `/console/users` returning 404 was the tell.

--- a/.github/notes/plans/next-163-adoption.md
+++ b/.github/notes/plans/next-163-adoption.md
@@ -1,0 +1,41 @@
+# Next.js 16.3 adoption
+
+- Status: backlog
+- Links: PR #786 (`agentRules: false`); #783 (the 16.3 bump); #784 (web functions on Node)
+
+`canary` runs `next@^16.3.0`, so the zero-config wins are already banked: lower dev memory, cached repeat builds, faster server rendering, fewer prefetch requests. This records what was assessed on top of that, and what was decided, so none of it gets re-litigated from the blog post alone.
+
+## Adopted
+
+**`agentRules: false`** (PR #786). Since 16.3, `next dev` upserts a managed agent-rules block, and creates `AGENTS.md` plus a `CLAUDE.md` holding `@AGENTS.md` when neither exists. `next dev` runs in `web/next/`, where neither exists, so it would create a second unmanaged pair beside the generated, symlinked root pair. Verified by calling the writer against an empty directory shaped like `web/next`: `{"agentsMd":"created","claudeMd":"created"}`.
+
+## Measured and declined
+
+**`experimental.turbopackRustReactCompiler`.** The React Compiler runs inside Turbopack instead of through Babel. The release claims 34% cold and 46% warm off `next dev` time-to-ready on a large app.
+
+Measured here as cold `.next` to first `/console/users` render, three runs per arm, same warm turbo cache so package builds could not skew it:
+
+| Arm   | Runs (ms)        | Mean     |
+| ----- | ---------------- | -------- |
+| Rust  | 5544, 5125, 4821 | **5163** |
+| Babel | 5653, 5435, 5453 | **5514** |
+
+About 6%, consistently in the Rust arm's favour but nowhere near the claimed figures, and the ranges overlap. Next reports the key as valid (`✓ turbopackRustReactCompiler`), so this is a real measurement, not a rejected flag.
+
+Declined because the gain does not carry an experimental flag in a starter: every fork inherits `next.config.ts`, and the repo already avoids `unstable_`-grade APIs for that reason. Revisit when the Rust path leaves experimental, or if a later release makes the gap material here.
+
+A first measurement showed a 60% improvement and was wrong: the baseline arm built the workspace packages cold while the second read them from the turbo cache. Warm the cache in both arms before trusting any number from this.
+
+## Assessed, not pursued
+
+- **Instant Navigations** (`cacheComponents` + `partialPrefetching`) - the console tables are the ideal case, but the app has 0 `<Suspense>` boundaries and 0 `use cache`, so adopting it means designing a loading shell per dynamic route. Its own project, with its own entry when it starts.
+- **`catchError` custom error boundaries** - see [console-notfound-status](console-notfound-status.md); spiked against the soft-404 and it does not fix it.
+- **Root params** (`next/root-params`) - no `[lang]` segment, no i18n.
+- **Playwright `instant()` helper** - UI here is verified with agent-browser, not Playwright.
+- **`experimental.useOffline`** - no offline requirement.
+- **`import.meta.glob`** - fumadocs already owns MDX loading.
+- **Immutable static assets** - adapter-level; belongs with the Vercel deploy work.
+
+## Resolved by the upgrade
+
+`next build` type-checks under TypeScript 7 again, so the `catalog:next` TS 6 pin from #724 is gone (removed in #783) and must not come back. On 16.2 the build logged `Detected @typescript/native-preview ... requires the standard typescript package` and finished its check in 85ms, checking nothing. On 16.3 there is no warning, the check takes ~1.3s, and an injected `const x: number = "str"` fails the build with `TS2322`. Re-verify that way rather than by reading timings: the old failure mode was silence.

--- a/web/next/content/docs/getting-started/working-with-agents.mdx
+++ b/web/next/content/docs/getting-started/working-with-agents.mdx
@@ -86,6 +86,8 @@ agent-browser click "@e12"    # act on a referenced element
 
 It is enforced, not just requested. Docs structure and page metadata live in one file, `web/next/docs.config.ts`, and the build derives every page's frontmatter and sidebar from it; `docs.ts --strict` fails the build when a page and the config disagree, so a doc can't silently fall out of sync. The `doc-sync` skill is the checklist an agent runs to keep code, docs, and skills aligned in the same change.
 
+Because that file is generated and symlinked, this starter turns off the one Next.js writes for you. Since 16.3, `next dev` upserts a managed block into `AGENTS.md` whenever it detects an AI coding agent, and creates `AGENTS.md` plus a `CLAUDE.md` containing `@AGENTS.md` when neither exists, which in this repo would mean a second pair inside `web/next/` fighting the generated root pair. `agentRules: false` in `web/next/next.config.ts` turns it off. The docs it points at are still worth reading: they ship in `node_modules/next/dist/docs/` and match the installed version exactly.
+
 ## Next
 
 - [AI Skills](/docs/resources/ai-skills): the full skill catalog, and writing your own.

--- a/web/next/next.config.ts
+++ b/web/next/next.config.ts
@@ -56,6 +56,8 @@ const appDevHost = (() => {
 })()
 
 const nextConfig: NextConfig = {
+  // Off because this repo writes its own agent guides: the root AGENTS.md is generated (skills-manager owns its skills tables) and CLAUDE.md is a symlink to it, so a second writer would fight both. Left on, `next dev` upserts a managed block whenever it detects an AI agent, and its own text says removing it from a diff only re-creates it. The Next 16.3 docs it points at are worth reading; see the AI agents note in web/next/content/docs/getting-started/working-with-agents.mdx.
+  agentRules: false,
   env: { NEXT_PUBLIC_IS_PRIVATE: String(isPrivate) },
   // Standalone is the Docker runner's input only. Vercel builds through a Next adapter, and since 16.3.0 an adapter build writes no .nft.json trace files, so the standalone copy step reads next-server.js.nft.json and fails the build with ENOENT.
   ...(!process.env.VERCEL && { output: "standalone" as const }),


### PR DESCRIPTION
Stacked on #786. **Base is `feat/next-163-adoption`, not `canary`** - review that one first, and this merges to `canary` once it lands.

Notes only, no runtime change. It records the 16.3 decisions in the backlog so none of them get re-litigated from the release post alone.

## The Rust React Compiler was measured, not taken on trust

The release claims 34% cold and 46% warm off `next dev` time-to-ready. Measured here as cold `.next` to first `/console/users` render, three runs per arm, with the turbo cache warm in **both** arms so package builds could not skew it:

| Arm | Runs (ms) | Mean |
| --- | --- | --- |
| Rust | 5544, 5125, 4821 | **5163** |
| Babel | 5653, 5435, 5453 | **5514** |

About **6%**, consistently in its favour, ranges overlapping. Next reports `✓ turbopackRustReactCompiler`, so the key is valid and this is a real number rather than a silently ignored flag.

**Declined.** A starter's `next.config.ts` is inherited by every fork, and this repo already avoids `unstable_`-grade APIs for that reason. 6% does not carry an experimental flag into every downstream project. Revisit when the Rust path leaves experimental.

<details>
<summary>The first measurement said 60% and was wrong</summary>

The baseline arm built the workspace packages cold while the second read them from the turbo cache. Warm the cache in both arms before trusting any number from this. The trap is written into the note.

</details>

## `catchError` does not fix the console soft-404

Folded into `console-notfound-status.md`. 16.3 fixed error boundaries *swallowing* the `notFound` signal; this bug is the status line being committed before a page-level `notFound()` fires mid-stream, which no boundary can reach.

| Path | Before | With `catchError` |
| --- | --- | --- |
| `/console/does-not-exist` | 200 | **200** |
| `/console/users` (control) | 200 | 200 |
| `/nope-at-root` (control) | 404 | 404 |

Spike reverted, icebox entry stands. An earlier run showed 404 and looked like a fix, because the dev server had died and the proxy was answering everything; the `/console/users` control caught it. That is recorded too.

## Verified end to end with agent-browser

Against this branch, signed in as `agent@local.host` on a disposable Postgres with fake rows:

- public pages render clean: `/`, `/hire`, `/resume`, `/waitlist`, `/blog`, `/docs`, `/docs/getting-started/cli`, `/docs/getting-started/working-with-agents`
- the paragraph #786 adds is live on the rendered page (asserted on `agentRules: false` text, not just a build pass)
- console pages render with data: users, activity, allowlist, waitlist all 24 rows; `/console` and `/dashboard` clean
- interactive: search to 12 rows with `?q=person1`, faceted Role filter (`Owner | Admin | Member | User`), select-all reporting `50 of 50 row`

`check-types` 13/13, `test` 276 pass, `build` 7/7, no em-dashes in the new notes.