### PR TITLE
chore(deps): type-check with stable typescript, not the native preview

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "@octokit/rest": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
-        "@typescript/native-preview": "catalog:",
         "@viz-js/viz": "catalog:",
         "changelogen": "catalog:",
         "globby": "catalog:",
@@ -23,6 +22,7 @@
         "svgo": "catalog:",
         "ts-morph": "catalog:",
         "turbo": "catalog:",
+        "typescript": "catalog:",
       },
     },
     "api/hono": {
@@ -247,7 +247,6 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/ws": "^8.18.1",
-    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "@viz-js/viz": "^3.28.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "better-auth": "^1.6.23",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "scripts": {
     "build": "turbo run build --summarize && bun .github/scripts/build-sizes.ts",
     "check-types": "turbo run check-types --summarize && bun run check-types:scripts && bun run check-types:tests",
-    "check-types:scripts": "tsgo -p .github/scripts/tsconfig.json",
-    "check-types:tests": "if [ -d tests ]; then find tests -name tsconfig.json -print0 | xargs -0 -n1 tsgo -p; fi",
+    "check-types:scripts": "tsc -p .github/scripts/tsconfig.json",
+    "check-types:tests": "if [ -d tests ]; then find tests -name tsconfig.json -print0 | xargs -0 -n1 tsc -p; fi",
     "clean": "bash .github/scripts/clean.sh",
     "console:roles": "bun .github/scripts/console-roles.ts",
     "db:generate": "turbo run build --filter=@packages/env && bun --cwd packages/db drizzle-kit generate",
@@ -44,7 +44,6 @@
     "@octokit/rest": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
-    "@typescript/native-preview": "catalog:",
     "@viz-js/viz": "catalog:",
     "changelogen": "catalog:",
     "globby": "catalog:",
@@ -56,7 +55,8 @@
     "sharp": "catalog:",
     "svgo": "catalog:",
     "ts-morph": "catalog:",
-    "turbo": "catalog:"
+    "turbo": "catalog:",
+    "typescript": "catalog:"
   },
   "commitlint": {
     "extends": [
@@ -97,7 +97,6 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/ws": "^8.18.1",
-    "@typescript/native-preview": "^7.0.0-dev.20260707.2",
     "@viz-js/viz": "^3.28.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "better-auth": "^1.6.23",

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "tsdown"
 
 export default defineConfig({
-  dts: { tsgo: true },
   entry: {
     index: "src/index.ts",
     "bin/index": "bin/index.ts",

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "tsdown"
 
 export default defineConfig({
-  dts: { tsgo: true },
   entry: ["src/console.ts", "src/site.ts"],
   minify: true,
   outDir: "dist",

--- a/packages/config/tsdown.ts
+++ b/packages/config/tsdown.ts
@@ -5,7 +5,7 @@ type BundleDeps = {
   alwaysBundle?: (string | RegExp)[]
 }
 
-// Shared tsdown config for the backend packages: validates env in build:prepare via the caller's getSafeEnv (passed in so this package stays env-agnostic, avoiding a config<->env cycle), emits tsgo dts, and minifies. Callers supply only their name, env, and any bundle overrides.
+// Shared tsdown config for the backend packages: validates env in build:prepare via the caller's getSafeEnv (passed in so this package stays env-agnostic, avoiding a config<->env cycle), emits dts, and minifies. Callers supply only their name, env, and any bundle overrides.
 export function definePackageConfig(options: {
   name: string
   env: Record<string, unknown>
@@ -21,7 +21,6 @@ export function definePackageConfig(options: {
     defineConfig({
       ...(define ? { define } : {}),
       ...(deps ? { deps } : {}),
-      dts: { tsgo: true },
       entry: entry ?? ["src/index.ts"],
       hooks: {
         "build:prepare": () => {

--- a/packages/env/tsdown.config.ts
+++ b/packages/env/tsdown.config.ts
@@ -22,9 +22,7 @@ export default defineConfig({
     __GIT_SHA__: JSON.stringify(GIT_SHA),
     __VERSION__: JSON.stringify(VERSION),
   },
-  dts: {
-    tsgo: true,
-  },
+  dts: {},
   entry: ["src/index.ts", "src/api-hono.ts", "src/auth.ts", "src/db.ts", "src/web-next.ts"],
   minify: true,
   outDir: "dist",


### PR DESCRIPTION
Redo of #724 on current `canary`, which had gone `CONFLICTING` across 16 files while the TypeScript 7 migration landed separately in #783. This is the part that never landed.

## What was still wrong

The root declared `@typescript/native-preview` (catalog `^7.0.0-dev.20260707.2`) and ran both type-check slices through its `tsgo` binary:

```
"check-types:scripts": "tsgo -p .github/scripts/tsconfig.json",
"check-types:tests":   "... xargs -0 -n1 tsgo -p"
```

So the repo type-checked its own scripts and tests with a **dated dev prerelease**, while every workspace already compiled against stable `typescript@^7.0.2`. TypeScript 7 *is* that native compiler and ships `tsc`, making the preview redundant for our use.

Also `dts: { tsgo: true }` sat in all four tsdown configs, dead since `rolldown-plugin-dts` auto-selects native once the installed TypeScript major is >= 7.

## What changed

- root declares `typescript` instead of `@typescript/native-preview`; both slices call `tsc`
- `dts: { tsgo: true }` removed from `packages/config/tsdown.ts`, `packages/config/tsdown.config.ts`, `packages/cli/tsdown.config.ts`, `packages/env/tsdown.config.ts`, and the stale "emits tsgo dts" comment corrected
- `devDependencies` re-sorted A to Z, per the ordering rule

`@typescript/native-preview` still resolves in the tree, but only as an **optional peer of `rolldown-plugin-dts`**, no longer as something this repo asks for. Worth stating plainly rather than claiming a compiler was removed.

## Verified, not assumed

**The dead config really was dead.** Hashed every emitted declaration before and after a forced rebuild:

```
IDENTICAL: all 13 declaration files byte-for-byte unchanged
```

**The checks still bite.** The historic failure mode in this area was silence, so injecting `const x: number = "nope"` into each slice:

| Slice | Result |
| --- | --- |
| `.github/scripts` | `error TS2322`, exit 1 |
| `tests/` | `error TS2322`, exit 1 |

`check-types` 13/13, `test` 276 pass, `build` 7/7.

Closes #724