### PR TITLE
docs(hire): six years, and settle the pages against the biography

### DIFF
--- a/web/next/src/app/(marketing)/hire/page.tsx
+++ b/web/next/src/app/(marketing)/hire/page.tsx
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
 }
 
 const proof: { value: string; label: string }[] = [
-  { value: "5+ years", label: "shipping production software" },
+  { value: "6+ years", label: "shipping production software" },
   { value: "500+ PRs", label: "at LightWork AI" },
   { value: "1,000+", label: "GitHub stars across open source" },
   { value: "250+", label: "public repositories" },
@@ -169,7 +169,7 @@ export default function Page() {
             </span>
           </p>
           <p>
-            Five-plus years shipping production web apps, internal platforms, open-source developer
+            Six-plus years shipping production web apps, internal platforms, open-source developer
             tools, and AI-native systems. Right now I'm a Product Engineer at{" "}
             <a
               href="https://lightwork.co"

--- a/web/next/src/app/(marketing)/resume/page.tsx
+++ b/web/next/src/app/(marketing)/resume/page.tsx
@@ -173,7 +173,7 @@ export default function Page() {
       <div className="container mx-auto max-w-3xl space-y-8 px-4 md:px-6">
         <h1 className={cn(caveat.className, "text-3xl font-bold tracking-wide")}>résumé</h1>
         <p className="text-lg">
-          AI-native Product Engineer with 5+ years shipping production SaaS, developer tools,
+          AI-native Product Engineer with 6+ years shipping production SaaS, developer tools,
           full-stack TypeScript systems, and AI agent infrastructure. Currently building AI-powered
           product surfaces and agent tooling at LightWork AI. Author of 250+ public repositories and
           open-source tools with 1,045+ GitHub stars, used by projects including TanStack, SST,


### PR DESCRIPTION
Six years now, on `/hire` and `/resume`.

Both pages already carried the number twice and disagreed with themselves: the claim said `5+ years` while the biography blurb further down the same page said "six years". So this is not only a bump, it settles the contradiction.

| where | before | after |
| ----- | ------ | ----- |
| `/hire` stat | `5+ years` | `6+ years` |
| `/hire` intro | "Five-plus years shipping production web apps" | "Six-plus years ..." |
| `/resume` summary | "with 5+ years shipping production SaaS" | "with 6+ years ..." |
| `/hire` + `/resume` biography blurb | "six years" | unchanged, now agrees |
| `blog/a-biography-written-in-code` | "six" in 4 places | unchanged |

Verified in a real browser at 1782x972: `/hire` renders `6+ years` in the stat block and "Six-plus years" in the intro, `/resume` renders `6+ years`, and neither page now contradicts its own biography line.

`bun run check-types` and `bun run lint` are green.

Screenshots could not be attached: litterbox has been returning 403 for every upload this session.
