### PR TITLE
refactor(scripts): move the Bun-only scripts off node:child_process and node:fs

### DIFF
--- a/.agents/skills/runtime-apis/index.md
+++ b/.agents/skills/runtime-apis/index.md
@@ -1,17 +1,17 @@
 # Node API index
 
 Per-file inventory of every Node built-in used in the repo, for the [`runtime-apis`](SKILL.md) skill.
-Snapshot: 2026-07-26. Regenerate with the `rg "node:..."` command in `SKILL.md`.
+Snapshot: 2026-08-23. Regenerate with the `rg "node:..."` command in `SKILL.md`.
 
-The `Runtime` column drives the rule: **Node** and **Both** files stay on `node:` (no `Bun.*`);
-**Bun** files may move a call to a `Bun.*` equivalent where one exists.
+The `Runtime` column drives the rule: **Node**, **Both** and **Build** files stay on `node:` (no `Bun.*`);
+**Bun** files may move a call to a `Bun.*` equivalent where one exists. `web/next` is **Both**: `next dev`
+runs under the system Node while Docker and Vercel serve it under Bun.
 
 | File | Runtime | `node:` modules (APIs used) |
 | --- | --- | --- |
 | `.github/scripts/compress-images.ts` | Bun | `node:path` (path) |
 | `.github/scripts/docs.ts` | Bun | `node:path` (path) |
-| `.github/scripts/ensure-remote-branches.ts` | Bun | `node:child_process` (execFileSync) |
-| `.github/scripts/shadcn-customize.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (readFileSync, writeFileSync) |
+| `.github/scripts/skills-manager.ts` | Bun | `node:crypto` (createHash); `node:path` (path) |
 | `.github/workflows/auto-labeler.yml` | Node | `node:fs`, `node:path` (via `require`, `actions/github-script`) |
 | `packages/auth/tsdown.config.ts` | Build | `node:fs` (existsSync, readFileSync); `node:path` (resolve) |
 | `packages/cli/bin/commands/_args.ts` | Node | `node:util` (parseArgs, ParseArgsConfig) |
@@ -24,26 +24,28 @@ The `Runtime` column drives the rule: **Node** and **Both** files stay on `node:
 | `packages/cli/src/db.ts` | Node | `node:crypto` (randomBytes); `node:path` (join) |
 | `packages/cli/src/git.ts` | Node | `node:path` (join) |
 | `packages/cli/src/io.ts` | Node | `node:fs` (existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync); `node:path` (dirname, join) |
+| `packages/cli/src/skills.ts` | Node | `node:crypto` (createHash); `node:fs` (readdirSync); `node:path` (join) |
 | `packages/cli/src/vendor/nano-spawn.ts` | Node | `node:child_process` (spawn, SpawnOptions); `node:fs/promises` (access); `node:path` (delimiter, resolve) |
 | `packages/env/src/lib/utils.ts` | Both | `node:path` (path) |
 | `packages/env/tsdown.config.ts` | Build | `node:child_process` (execSync) |
 | `packages/scripts/src/data-table-metrics.ts` | Bun | `node:path` (join, resolve) |
 | `packages/scripts/src/generate-env.ts` | Bun | `node:path` (resolve) |
+| `tests/packages/cli/bin/commands/init.test.ts` | Bun | `node:fs` (mkdirSync, mkdtempSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
+| `tests/packages/cli/features-consistency.test.ts` | Bun | `node:fs` (readFileSync); `node:path` (join) |
 | `tests/packages/cli/src/convert.test.ts` | Bun | `node:fs` (mkdtempSync, readFileSync, rmSync); `node:os` (tmpdir); `node:path` (join) |
 | `tests/packages/cli/src/db.test.ts` | Bun | `node:fs` (mkdtempSync, readFileSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
+| `tests/packages/cli/src/fork-layout.test.ts` | Bun | `node:fs` (readFileSync); `node:path` (join) |
 | `tests/packages/cli/src/git.test.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
 | `tests/packages/cli/src/io.test.ts` | Bun | `node:child_process` (execFileSync); `node:fs` (mkdirSync, mkdtempSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |
-| `web/next/next.config.ts` | Node | `node:fs` (readFileSync); `node:path` (resolve) |
-| `web/next/src/app/layout.tsx` | Node | `node:fs` (existsSync); `node:path` (join) |
+| `tests/packages/cli/src/skills.test.ts` | Bun | `node:fs` (mkdtempSync, rmSync); `node:os` (tmpdir); `node:path` (join) |
+| `web/next/next.config.ts` | Both | `node:fs` (readFileSync); `node:path` (resolve) |
+| `web/next/src/app/layout.tsx` | Both | `node:fs` (existsSync); `node:path` (join) |
 
-## Convertible to `Bun.*` (optional, Bun-only files)
+## Convertible to `Bun.*` (Bun-only files)
 
-Only where the file runs **only** under Bun and the call has a `Bun.*` equivalent:
-
-| File | Node call | Bun equivalent |
-| --- | --- | --- |
-| `.github/scripts/ensure-remote-branches.ts` | `execFileSync` | `Bun.spawnSync` |
-| `.github/scripts/shadcn-customize.ts` | `execFileSync` | `Bun.spawnSync` |
-| `.github/scripts/shadcn-customize.ts` | `readFileSync` / `writeFileSync` | `Bun.file().text()` / `Bun.write` |
-
-`ensure-remote-branches.ts` is also shared into forks via `lefthook.yml`, where portable `node:child_process` is a feature, not a gap.
+Nothing remains. The last two (`execFileSync` in `ensure-remote-branches.ts`; `execFileSync`, `readFileSync`,
+`writeFileSync` in `shadcn-customize.ts`) moved to `Bun.spawnSync`, `Bun.file` and `Bun.write` in 2026-08.
+What is left on a Bun-only file is `node:path`, `node:os`, or the directory half of `node:fs`, which Bun's
+own docs route to `node:` ("for operations they don't cover, such as `mkdir` or `readdir`, use `node:fs`"),
+plus two deliberate keeps: `skills-manager.ts`'s `createHash` mirrors the CLI's (Node) ledger digest line for
+line, and the CLI tests mirror the CLI's `node:` style on purpose.

--- a/.github/scripts/ensure-remote-branches.ts
+++ b/.github/scripts/ensure-remote-branches.ts
@@ -1,5 +1,3 @@
-import { execFileSync } from "node:child_process"
-
 // Pre-push guard for fresh forks, GitHub remotes only (other remotes are left alone). The user's first `git push origin canary` creates canary, which GitHub makes the default branch; on the next push the hook seeds the release branches (main by default, from RELEASE_BRANCHES) as separate refs, so they never collide with the canary push, so auto-canary-into-main opens the release PR. No gh or repo-admin is needed: the default branch falls out of push order. A per-branch, per-remote git-config marker makes it a no-op once done; shared via lefthook.yml so it runs here and in every fork.
 
 // Per-branch, per-remote local-only marker; the remote is sanitized and prefixed so the key is always a valid git-config name.
@@ -8,8 +6,12 @@ export const markerKey = (branch: string, remote: string): string => {
   return `zerostarter.seeded.${branch}.${/^[A-Za-z]/.test(safe) ? safe : `r-${safe}`}`
 }
 
-const git = (args: string[]): string =>
-  execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim()
+// Throws on a non-zero exit like execFileSync did, which every try/catch below relies on.
+const git = (args: string[]): string => {
+  const proc = Bun.spawnSync(["git", ...args], { stdin: "ignore", stdout: "pipe", stderr: "pipe" })
+  if (proc.exitCode !== 0) throw new Error(proc.stderr.toString().trim() || `git ${args[0]} failed`)
+  return proc.stdout.toString().trim()
+}
 
 // The repo's Actions settings URL from a GitHub remote URL (SSH or HTTPS); "" when not GitHub.
 export const settingsUrl = (remoteUrl: string): string => {
@@ -118,9 +120,12 @@ const ensureRemoteBranches = (remote: string): void => {
       `zerostarter: seeding ${branch} on ${remote} so the canary -> ${branch} release PR can open ...`,
     )
     try {
-      execFileSync("git", ["push", "--no-verify", remote, branch], {
-        stdio: ["ignore", "inherit", "inherit"],
+      const push = Bun.spawnSync(["git", "push", "--no-verify", remote, branch], {
+        stdin: "ignore",
+        stdout: "inherit",
+        stderr: "inherit",
       })
+      if (push.exitCode !== 0) throw new Error(`git push exited ${push.exitCode}`)
     } catch {
       console.error(
         `zerostarter: could not push ${branch} automatically. Push it yourself: git push ${remote} ${branch}`,

--- a/.github/scripts/shadcn-customize.ts
+++ b/.github/scripts/shadcn-customize.ts
@@ -1,6 +1,3 @@
-import { execFileSync } from "node:child_process"
-import { readFileSync, writeFileSync } from "node:fs"
-
 import { Node, Project, SyntaxKind } from "ts-morph"
 
 // Re-applies every local override after `shadcn-update.sh` wipes ui/ and re-scaffolds the app.
@@ -29,7 +26,13 @@ const RESTORE = [
   "web/next/src/app/layout.tsx",
   "web/next/src/lib/utils.ts",
 ]
-execFileSync("git", ["checkout", "HEAD", "--", ...RESTORE], { stdio: "inherit" })
+const restore = Bun.spawnSync(["git", "checkout", "HEAD", "--", ...RESTORE], {
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+})
+if (restore.exitCode !== 0)
+  throw new Error(`shadcn-customize: git checkout exited ${restore.exitCode}`)
 log(`restored from HEAD: ${RESTORE.join(", ")}`)
 
 const project = new Project({
@@ -178,8 +181,8 @@ function patchSidebar() {
 // globals.css: two brand overrides init reverts. --font-sans repoints at its own Inter variable;
 // --sidebar gets hardcoded light/dark defaults where we flush it with --background (PR #566). Both
 // are stable, uniquely-anchored lines, so guarded string swaps suffice; no CSS parser warranted.
-function patchGlobals() {
-  let css = readFileSync(GLOBALS, "utf8")
+async function patchGlobals() {
+  let css = await Bun.file(GLOBALS).text()
 
   const FONT_FROM = "--font-sans: var(--font-sans);"
   const FONT_TO = "--font-sans: var(--font-dm-sans), sans-serif;"
@@ -196,7 +199,7 @@ function patchGlobals() {
     )
   css = css.replace(SIDEBAR_LINE, "$1--sidebar: var(--background);")
 
-  writeFileSync(GLOBALS, css)
+  await Bun.write(GLOBALS, css)
   log(`patched: ${GLOBALS}`)
 }
 
@@ -204,4 +207,4 @@ patchButton()
 patchCheckbox()
 patchSpinner()
 patchSidebar()
-patchGlobals()
+await patchGlobals()

--- a/tests/github/scripts/ensure-remote-branches.test.ts
+++ b/tests/github/scripts/ensure-remote-branches.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import { markerKey, repoSlug, settingsUrl } from "../../../.github/scripts/ensure-remote-branches"
 
@@ -42,4 +45,69 @@ test("repoSlug detects GitHub remotes (SSH and HTTPS) and is empty otherwise", (
   expect(repoSlug("git@github.com:acme/widgets.git")).toBe("acme/widgets")
   expect(repoSlug("https://github.com/acme/widgets.git")).toBe("acme/widgets")
   expect(repoSlug("https://gitlab.com/acme/widgets.git")).toBe("")
+})
+
+// End to end against a throwaway remote: a local bare repo whose path ends in github.com/acme/widgets.git, which the
+// hook's GitHub detection matches, so every real git call runs (remote get-url, rev-parse, ls-remote, push --no-verify)
+// and the config marker makes the second run a no-op. An insteadOf rewrite would not do: get-url returns the rewritten URL.
+const SCRIPT = join(import.meta.dir, "../../../.github/scripts/ensure-remote-branches.ts")
+
+const sh = (cwd: string, args: string[]): string => {
+  const proc = Bun.spawnSync(args, { cwd, stdin: "ignore", stdout: "pipe", stderr: "pipe" })
+  if (proc.exitCode !== 0) throw new Error(proc.stderr.toString())
+  return proc.stdout.toString().trim()
+}
+
+const runHook = (cwd: string): { code: number; stderr: string } => {
+  const proc = Bun.spawnSync([process.execPath, SCRIPT, "origin"], {
+    cwd,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  return { code: proc.exitCode, stderr: proc.stderr.toString() }
+}
+
+test("seeds main on a fresh GitHub remote once canary exists, then no-ops via the marker", () => {
+  const root = mkdtempSync(join(tmpdir(), "zerostarter-seed-"))
+  try {
+    const bare = join(root, "github.com", "acme", "widgets.git")
+    const work = join(root, "work")
+    sh(root, ["git", "init", "--bare", "-q", bare])
+    sh(root, ["git", "init", "-q", "-b", "canary", work])
+    sh(work, ["git", "config", "user.email", "t@example.com"])
+    sh(work, ["git", "config", "user.name", "t"])
+    sh(work, ["git", "commit", "-q", "--allow-empty", "-m", "init"])
+    sh(work, ["git", "remote", "add", "origin", bare])
+    sh(work, ["git", "push", "-q", "origin", "canary"])
+    sh(work, ["git", "branch", "main"])
+
+    const first = runHook(work)
+    expect(first.code).toBe(0)
+    expect(first.stderr).toContain("seeding main on origin")
+    expect(sh(work, ["git", "ls-remote", "--heads", "origin", "main"])).toContain("refs/heads/main")
+    expect(sh(work, ["git", "config", "--local", "--get", markerKey("main", "origin")])).toBe(
+      "true",
+    )
+
+    const second = runHook(work)
+    expect(second.code).toBe(0)
+    expect(second.stderr).toBe("")
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test("leaves a non-GitHub remote alone", () => {
+  const root = mkdtempSync(join(tmpdir(), "zerostarter-seed-"))
+  try {
+    const work = join(root, "work")
+    sh(root, ["git", "init", "-q", "-b", "canary", work])
+    sh(work, ["git", "remote", "add", "origin", "https://gitlab.com/acme/widgets.git"])
+    const run = runHook(work)
+    expect(run.code).toBe(0)
+    expect(run.stderr).toBe("")
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## What

The `node:` to `Bun.*` migration, done rather than recorded (supersedes #804). Every `node:` import in the repo was judged against the `runtime-apis` rule with Bun 1.4's own API docs as the reference; exactly two Bun-only scripts had calls with a Bun equivalent, and both move here:

| File | Before | After |
| --- | --- | --- |
| `.github/scripts/ensure-remote-branches.ts` | `execFileSync` in the `git()` helper and the seeding push | `Bun.spawnSync`; the helper still throws on a non-zero exit (every `try/catch` in the hook relies on it, and `spawnSync` does not throw by itself) |
| `.github/scripts/shadcn-customize.ts` | `execFileSync` restore, `readFileSync` / `writeFileSync` in `patchGlobals` | `Bun.spawnSync` with an exit check, `await Bun.file().text()` / `await Bun.write()` |

Everything else stays on `node:` for a reason now written into the regenerated `runtime-apis/index.md`: `node:path` (Bun ships no path module), the directory half of `node:fs` (Bun's docs route `mkdir`/`readdir` to `node:fs`), `node:os`, the CLI tests (mirror the CLI's `node:` style by rule), and `skills-manager.ts`'s `createHash` (a line-for-line mirror of the CLI's ledger digest). The index was a July snapshot missing six files and still called `web/next` a Node area; it now reflects the current tree with `web/next` as Both and "nothing convertible remains".

## Verification

- **Pre-push hook, end to end**: new test spins up a local bare remote at a `github.com/acme/widgets.git` path (which the hook's GitHub detection matches, no network), pushes `canary`, creates `main`, runs the hook via `bun`: it seeds `main` on the remote, sets the config marker, and the second run is silent; a non-GitHub remote is left alone. Plus the real thing: pushing this branch ran the migrated hook against origin (`ensure-branches` green in lefthook).
- **Customize script, end to end**: standalone run on the customized tree is idempotent (restores, patches all five targets, tree byte-identical); then a full `bun run shadcn:update` (wipe `ui/`, `shadcn init` + `add -a`, customize, format, reinstall) ran the migrated step inside the real sync and applied every patch. The sync also surfaced two days of registry drift (one-line className changes in `checkbox`, `field`, `radio-group`, `switch`, and a new `date-fns` dependency), reverted here as out of scope; that is a separate `chore(ui)` sync like #796.
- `bun run check-types` clean, `bun run test` 278/278 (276 + 2 new), lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtdjXQt9EgfHLXb6fyfn43
