### PR TITLE
docs(skills): rejoin the heading a merge resolution split in the runtime-apis index

### DIFF
--- a/.agents/skills/runtime-apis/index.md
+++ b/.agents/skills/runtime-apis/index.md
@@ -42,8 +42,7 @@ runs under the system Node while Docker and Vercel serve it under Bun.
 | `web/next/next.config.ts` | Both | `node:fs` (readFileSync); `node:path` (resolve) |
 | `web/next/src/app/layout.tsx` | Both | `node:fs` (existsSync); `node:path` (join) |
 
-## Convertible
- to `Bun.*` (Bun-only files)
+## Convertible to `Bun.*` (Bun-only files)
 
 Nothing remains. The last two (`execFileSync` in `ensure-remote-branches.ts`; `execFileSync`, `readFileSync`,
 `writeFileSync` in `shadcn-customize.ts`) moved to `Bun.spawnSync`, `Bun.file` and `Bun.write` in 2026-08.


### PR DESCRIPTION
One-line fix: the #798 canary merge's regeneration of `.agents/skills/runtime-apis/index.md` spliced the trailing section back with a newline inside the `## Convertible to `Bun.*` (Bun-only files)` heading, leaving a bare `## Convertible` and an orphan line (caught by the post-merge re-review). Rejoined; no other change, verified by diffing every non-table line against the pre-merge file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtdjXQt9EgfHLXb6fyfn43