### PR TITLE
fix(ci): make the seed test pass on Windows and let any test change re-run the publish gate

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,9 +6,9 @@ on:
       - canary
     paths:
       - "packages/cli/**"
-      # the CLI's suite lives at the repo-root tests/ mirror, so a test-only change has to reach
-      # this matrix too; without it the legs that gate the publish never re-run on the fix
-      - "tests/packages/cli/**"
+      # the matrix gates the publish on the whole suite (bun run test), so a change to any test
+      # has to reach it; filtered to the CLI's own tests, a fix elsewhere never re-ran the gate
+      - "tests/**"
   workflow_run:
     workflows: ["auto-release"]
     types: [completed]

--- a/tests/github/scripts/ensure-remote-branches.test.ts
+++ b/tests/github/scripts/ensure-remote-branches.test.ts
@@ -47,9 +47,10 @@ test("repoSlug detects GitHub remotes (SSH and HTTPS) and is empty otherwise", (
   expect(repoSlug("https://gitlab.com/acme/widgets.git")).toBe("")
 })
 
-// End to end against a throwaway remote: a local bare repo whose path ends in github.com/acme/widgets.git, which the
-// hook's GitHub detection matches, so every real git call runs (remote get-url, rev-parse, ls-remote, push --no-verify)
-// and the config marker makes the second run a no-op. An insteadOf rewrite would not do: get-url returns the rewritten URL.
+// End to end against a throwaway remote: a local bare repo at a path ending in github.com/acme/widgets.git, added by
+// its file:// URL so the hook's GitHub detection matches on Windows too (a joined path there uses backslashes). Every
+// real git call runs (remote get-url, rev-parse, ls-remote, push --no-verify) and the config marker makes the second
+// run a no-op. An insteadOf rewrite would not do: get-url returns the rewritten URL.
 const SCRIPT = join(import.meta.dir, "../../../.github/scripts/ensure-remote-branches.ts")
 
 const sh = (cwd: string, args: string[]): string => {
@@ -78,7 +79,7 @@ test("seeds main on a fresh GitHub remote once canary exists, then no-ops via th
     sh(work, ["git", "config", "user.email", "t@example.com"])
     sh(work, ["git", "config", "user.name", "t"])
     sh(work, ["git", "commit", "-q", "--allow-empty", "-m", "init"])
-    sh(work, ["git", "remote", "add", "origin", bare])
+    sh(work, ["git", "remote", "add", "origin", Bun.pathToFileURL(bare).href])
     sh(work, ["git", "push", "-q", "origin", "canary"])
     sh(work, ["git", "branch", "main"])
 


### PR DESCRIPTION
## What

The `v0.1.24` release's `cli-release` run failed on its Windows leg: `tests/github/scripts/ensure-remote-branches.test.ts` (added in #805) built its throwaway GitHub-looking remote with `join()`, which on Windows yields backslashes, so the hook's `github.com/<owner>/<repo>` regex did not match, the hook silently treated it as a non-GitHub remote, and the seeding assertion failed. macOS and Linux passed, and the PR check runs ubuntu only, which is why it reached the release.

1. **test(scripts)**: the remote is added by its `file://` URL (`Bun.pathToFileURL`), which git accepts on every OS and keeps forward slashes.
2. **ci(release)**: the publish gate runs the whole suite, but its `push` path filter only re-ran on `tests/packages/cli/**`, so a fix to any other test could never clear a red gate. Now `tests/**`.

## Effect on the release

`v0.1.24` stays unpublished on npm: every automated re-trigger either checks out the tag (still broken there) or, once this lands, would count it as releasable and cut a spurious `v0.1.25`. No user impact: `packages/cli` is byte-identical between `v0.1.23` and `v0.1.24`, so npm's `0.1.23` is the same CLI. Merging this triggers the matrix on the fix (the Windows proof) and publishes the usual `canary` pre-release; the next real release publishes `latest` normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MtdjXQt9EgfHLXb6fyfn43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow coverage so changes anywhere in the repository’s tests directory trigger the appropriate checks.
  * Improved cross-platform handling of temporary repository remotes, including Windows paths.

* **Documentation**
  * Clarified end-to-end test documentation for file-based remote URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->