### PR TITLE
chore(hire): drop the PR-count stat from the proof grid

### DIFF
--- a/web/next/src/app/(marketing)/hire/page.tsx
+++ b/web/next/src/app/(marketing)/hire/page.tsx
@@ -45,7 +45,6 @@ export const metadata: Metadata = {
 
 const proof: { value: string; label: string }[] = [
   { value: "6+ years", label: "shipping production software" },
-  { value: "500+ PRs", label: "at LightWork AI" },
   { value: "1,000+", label: "GitHub stars across open source" },
   { value: "250+", label: "public repositories" },
   { value: "10,000+", label: "installs across VS Code extensions" },


### PR DESCRIPTION
Removes the "500+ PRs at LightWork AI" stat from the /hire proof grid; a PR count drifts the moment it is published, and the remaining five stats carry the proof. Verified in a real browser at 1782x972; the grid flows 3+2.

| Before (production) | After (this branch) |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/7bbf12ca-1d16-4ce0-9283-ec13ce24bc60) | ![After](https://github.com/user-attachments/assets/6bb21ba5-402f-4edf-80ac-54af9324fee3) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQws4o1n4PHoYCKu3Yk62P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The marketing hire page now displays three proof statistics instead of four.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->