### PR TITLE
fix(scripts): compute the release number with changelogen's library

### DIFF
--- a/.agents/skills/runtime-apis/index.md
+++ b/.agents/skills/runtime-apis/index.md
@@ -31,7 +31,7 @@ runs under the system Node while Docker and Vercel serve it under Bun.
 | `packages/scripts/src/auth-schema.ts` | Bun | `node:path` (join, resolve) |
 | `packages/scripts/src/data-table-metrics.ts` | Bun | `node:path` (join, resolve) |
 | `packages/scripts/src/generate-env.ts` | Bun | `node:path` (resolve) |
-| `packages/scripts/src/release-version.ts` | Bun | `node:path` (dirname, join) |
+| `packages/scripts/src/release-version.ts` | Bun | `node:path` (join) |
 | `tests/github/scripts/ensure-remote-branches.test.ts` | Bun | `node:fs` (mkdtempSync, rmSync); `node:os` (tmpdir); `node:path` (join) |
 | `tests/github/workflows/auto-labeler.test.ts` | Bun | `node:module` (createRequire); `node:path` (join) |
 | `tests/packages/cli/bin/commands/init.test.ts` | Bun | `node:fs` (mkdirSync, mkdtempSync, rmSync, writeFileSync); `node:os` (tmpdir); `node:path` (join) |

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -43,7 +43,7 @@ jobs:
           # the boundary this changelog covers; tagged below so the next run starts exactly here
           BOUNDARY=$(git rev-parse HEAD)
           LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
-          # the target: the larger of the tree and what the window earned from the last tag (a missing tag counts as v0.0.0); a hand-set ahead of the window stays, one that undercounts it is lifted, a tree below the tag stops here loudly. read before changelogen overwrites package.json below; the script puts every file back after its own dry run
+          # the target: the larger of the tree and what the window earned from the last tag (a missing tag counts as v0.0.0); a hand-set ahead of the window stays, one that undercounts it is lifted, a tree below the tag stops here loudly. read before changelogen overwrites package.json below; the script itself touches no file
           DECISION=$(bun packages/scripts/src/release-version.ts)
           TARGET_VERSION=$(echo "$DECISION" | jq -r .next)
           if [ -z "$TARGET_VERSION" ] || [ "$TARGET_VERSION" = "null" ]; then

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,7 +6,7 @@ on:
       - canary
     paths:
       - "packages/cli/**"
-      # the release-version script this workflow runs lives here; a change to it re-runs the gate
+      # the scripts package holds the release-version script this workflow runs; a change in it re-runs the gate
       - "packages/scripts/**"
       # the matrix gates the publish on the whole suite (bun run test), so a change to any test
       # has to reach it; filtered to the CLI's own tests, a fix elsewhere never re-ran the gate

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -6,6 +6,8 @@ on:
       - canary
     paths:
       - "packages/cli/**"
+      # the release-version script this workflow runs lives here; a change to it re-runs the gate
+      - "packages/scripts/**"
       # the matrix gates the publish on the whole suite (bun run test), so a change to any test
       # has to reach it; filtered to the CLI's own tests, a fix elsewhere never re-ran the gate
       - "tests/**"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -117,7 +117,7 @@ jobs:
             TAG="latest"
           else
             TAG="canary"
-            # preview the next release with the same decision auto-release ships: the larger of the tree and what the window earned. the script runs the scripts package's locked changelogen, so the install (no lifecycle scripts, the npm token is in scope) comes first here; the shared install below is then a no-op
+            # preview the next release with the same decision auto-release ships: the larger of the tree and what the window earned. the script imports the scripts package's locked changelogen, so the install (no lifecycle scripts, the npm token is in scope) comes first here; the shared install below is then a no-op
             (cd ../.. && bun install --frozen-lockfile --ignore-scripts)
             DECISION=$(cd ../.. && bun packages/scripts/src/release-version.ts)
             NEXT_VERSION=$(echo "$DECISION" | jq -r .next)

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -1,12 +1,16 @@
 import { join } from "node:path"
 
-import { determineSemverChange, getGitDiff, loadChangelogConfig, parseCommits } from "changelogen"
+import {
+  determineSemverChange,
+  getGitDiff,
+  loadChangelogConfig,
+  parseCommits,
+  type SemverBumpType,
+} from "changelogen"
 
 // The number the next release will carry, decided before the release merge so the tree main builds from already holds it. Three rules: the number a window has earned is changelogen's bump applied to the last tag's version (a missing tag counts as v0.0.0), never to whatever package.json says, or a number set early would be bumped twice; the tree moves forward only, to max(tree, earned), so a hand-set ahead of both stays; a tree below the last tag is refused loudly. changelogen is used as a library, its own config and commit parsing with no changelog rendered, so the decision touches no file and no network. Prints the decision as JSON; --write moves package.json when the decision is ahead of it. Runs from the repo root (cwd), which is what the workflows and bun run release:version do.
 
 type Version = [number, number, number]
-
-type Change = NonNullable<ReturnType<typeof determineSemverChange>>
 
 export type Decision = {
   current: string
@@ -38,7 +42,7 @@ export const compare = (a: string, b: string): number => {
 }
 
 // The version one change up from another, as changelogen's bump command moves it: below 1.0 a major counts as a minor and a minor as a patch.
-export const bump = (version: string, change: Change): string => {
+export const bump = (version: string, change: SemverBumpType): string => {
   const [major, minor, patch] = parse(version)
   const step = major > 0 ? change : change === "major" ? "minor" : "patch"
   if (step === "major") return `${major + 1}.0.0`
@@ -103,15 +107,17 @@ export const writeVersion = async (file: string, version: string): Promise<void>
   )
 }
 
-// What the window since the tag has earned on top of the tag's version. The commits are the ones changelogen's own command keeps for the changelog (its config from changelog.config.json, disabled types and non-breaking chore(deps) dropped), so a window that keeps none earns nothing, which is the entry auto-release's content gate demands; the change is its semver reading of them, falling back to the patch its command bumps when no commit says more.
+// What the window since the tag has earned on top of the tag's version. The commits are the ones changelogen's own command keeps for the changelog (its config from changelog.config.json, the type lowercased as its parser is case-insensitive, disabled types and non-breaking chore(deps) dropped), so a window that keeps none earns nothing, which is the entry auto-release's content gate demands; the change is its semver reading of them, falling back to the patch its command bumps when no commit says more.
 const earnedFrom = async (root: string, tag: string | null): Promise<string> => {
   const from = tag === null ? undefined : tag
   const config = await loadChangelogConfig(root, { cwd: root, from, to: "HEAD" })
-  const kept = parseCommits(await getGitDiff(from, "HEAD", root), config).filter(
-    (commit) =>
-      config.types[commit.type] &&
-      !(commit.type === "chore" && commit.scope === "deps" && !commit.isBreaking),
-  )
+  const kept = parseCommits(await getGitDiff(from, "HEAD", root), config)
+    .map((commit) => ({ ...commit, type: commit.type.toLowerCase() }))
+    .filter(
+      (commit) =>
+        config.types[commit.type] &&
+        !(commit.type === "chore" && commit.scope === "deps" && !commit.isBreaking),
+    )
   if (kept.length === 0) return baseOf(tag)
   return bump(baseOf(tag), determineSemverChange(kept, config) ?? "patch")
 }

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -1,8 +1,12 @@
-import { dirname, join } from "node:path"
+import { join } from "node:path"
 
-// The number the next release will carry, decided before the release merge so the tree main builds from already holds it. Three rules: the number a window has earned is changelogen's bump applied to the last tag's version (a missing tag counts as v0.0.0), never to whatever package.json says, or a number set early would be bumped twice; the tree moves forward only, to max(tree, earned), so a hand-set ahead of both stays; a tree below the last tag is refused loudly. Prints the decision as JSON; --write moves package.json when the decision is ahead of it. Runs from the repo root (cwd), which is what the workflows and bun run release:version do.
+import { determineSemverChange, getGitDiff, loadChangelogConfig, parseCommits } from "changelogen"
+
+// The number the next release will carry, decided before the release merge so the tree main builds from already holds it. Three rules: the number a window has earned is changelogen's bump applied to the last tag's version (a missing tag counts as v0.0.0), never to whatever package.json says, or a number set early would be bumped twice; the tree moves forward only, to max(tree, earned), so a hand-set ahead of both stays; a tree below the last tag is refused loudly. changelogen is used as a library, its own config and commit parsing with no changelog rendered, so the decision touches no file and no network. Prints the decision as JSON; --write moves package.json when the decision is ahead of it. Runs from the repo root (cwd), which is what the workflows and bun run release:version do.
 
 type Version = [number, number, number]
+
+type Change = NonNullable<ReturnType<typeof determineSemverChange>>
 
 export type Decision = {
   current: string
@@ -33,6 +37,15 @@ export const compare = (a: string, b: string): number => {
   return x[0] - y[0] || x[1] - y[1] || x[2] - y[2]
 }
 
+// The version one change up from another, as changelogen's bump command moves it: below 1.0 a major counts as a minor and a minor as a patch.
+export const bump = (version: string, change: Change): string => {
+  const [major, minor, patch] = parse(version)
+  const step = major > 0 ? change : change === "major" ? "minor" : "patch"
+  if (step === "major") return `${major + 1}.0.0`
+  if (step === "minor") return `${major}.${minor + 1}.0`
+  return `${major}.${minor}.${patch + 1}`
+}
+
 // The decision, pure: current is the tree, earned is what the window's commits add to the tag's version.
 export const decide = (current: string, earned: string, tag: string | null): Decision => {
   const base = baseOf(tag)
@@ -43,17 +56,8 @@ export const decide = (current: string, earned: string, tag: string | null): Dec
   return { current, earned, moved: next !== current, next, tag }
 }
 
-const run = (
-  cmd: string[],
-  cwd: string,
-  env?: Record<string, string>,
-): { err: string; ok: boolean; out: string } => {
-  const proc = Bun.spawnSync(cmd, {
-    cwd,
-    env: { ...process.env, ...env },
-    stderr: "pipe",
-    stdout: "pipe",
-  })
+const run = (cmd: string[], cwd: string): { err: string; ok: boolean; out: string } => {
+  const proc = Bun.spawnSync(cmd, { cwd, stderr: "pipe", stdout: "pipe" })
   return {
     err: proc.stderr.toString().trim(),
     ok: proc.exitCode === 0,
@@ -99,75 +103,17 @@ export const writeVersion = async (file: string, version: string): Promise<void>
   )
 }
 
-// This package's own changelogen, declared as its dependency and resolved from this file, so a throwaway repository in a test computes with the same locked binary the workflows use. Its bin is read from its manifest (which Bun resolves although changelogen's exports map lists only its entry) rather than from the .bin shim, which Bun writes as .exe and .bunx on Windows.
-const changelogenManifest = Bun.resolveSync("changelogen/package.json", import.meta.dir)
-const changelogen = join(
-  dirname(changelogenManifest),
-  JSON.parse(await Bun.file(changelogenManifest).text()).bin.changelogen,
-)
-
-// changelogen looks every author up on ungh.cc while it renders, with no timeout and no switch that skips the lookup, and a stalled lookup once held a CI test leg past its limit. The decision needs no network, so the lookup is sent through a closed local port and fails at once inside changelogen's own catch. Bun reads the lowercase proxy variables on their own, so both cases are set and both bypass lists cleared.
-const BLACKHOLE = "http://127.0.0.1:9"
-const OFFLINE = {
-  HTTPS_PROXY: BLACKHOLE,
-  HTTP_PROXY: BLACKHOLE,
-  NO_PROXY: "",
-  http_proxy: BLACKHOLE,
-  https_proxy: BLACKHOLE,
-  no_proxy: "",
-}
-
-// changelogen bumps whatever package.json holds and writes the changelog, so it runs against a copy set to the tag's version, and both files are put back afterwards.
+// What the window since the tag has earned on top of the tag's version. The commits are the ones changelogen's own command keeps for the changelog (its config from changelog.config.json, disabled types and non-breaking chore(deps) dropped), so a window that keeps none earns nothing, which is the entry auto-release's content gate demands; the change is its semver reading of them, falling back to the patch its command bumps when no commit says more.
 const earnedFrom = async (root: string, tag: string | null): Promise<string> => {
-  const pkg = join(root, "package.json")
-  const changelog = join(root, "CHANGELOG.md")
-  const pkgText = await Bun.file(pkg).text()
-  const hadChangelog = await Bun.file(changelog).exists()
-  const changelogText = hadChangelog ? await Bun.file(changelog).text() : ""
-  try {
-    await writeVersion(pkg, baseOf(tag))
-    const from = tag === null ? [] : ["--from", tag]
-    const bumped = run(
-      [process.execPath, changelogen, "--bump", "--no-commit", ...from],
-      root,
-      OFFLINE,
-    )
-    // changelogen's CLI reports its own errors and still exits 0, so success is read from what it left behind: the version moved past the tag's and a section for it heads the changelog. Measured: even a window of nothing it recognizes bumps a patch and writes an empty section, which the content gate below then discounts.
-    const version = await readVersion(pkg)
-    const text = (await Bun.file(changelog).exists()) ? await Bun.file(changelog).text() : ""
-    const heading = new RegExp(`^## v${version.replaceAll(".", "\\.")}\\r?$`, "m").exec(text)
-    const headed = heading !== null && text.search(/^## /m) === heading.index
-    if (!bumped.ok || compare(version, baseOf(tag)) <= 0 || !headed) {
-      throw new Error(`changelogen failed: ${bumped.err || bumped.out}`)
-    }
-    // changelogen drops some types from the changelog (ci, and chore(deps)) yet still bumps; auto-release refuses a section with no entry, so a window that earns no entry earns no number either.
-    const entries = (text.split(/^## v/m)[1] ?? "").split("### ❤️ Contributors")[0]
-    if (!/^- /m.test(entries)) return baseOf(tag)
-    return version
-  } finally {
-    await Bun.write(pkg, pkgText)
-    if (hadChangelog) await Bun.write(changelog, changelogText)
-    else if (await Bun.file(changelog).exists()) await Bun.file(changelog).delete()
-  }
-}
-
-// changelogen bumps a patch even for a window of nothing but mechanical commits, so the window is checked first the way auto-release's own gate checks it: with only ci(changelog) and ci(version) commits since the tag, nothing was earned.
-const releasable = (root: string, tag: string | null): boolean => {
-  const range = tag === null ? "HEAD" : `${tag}..HEAD`
-  const counted = run(
-    [
-      "git",
-      "rev-list",
-      "--count",
-      "--invert-grep",
-      "--grep=^ci(changelog)",
-      "--grep=^ci(version)",
-      range,
-    ],
-    root,
+  const from = tag === null ? undefined : tag
+  const config = await loadChangelogConfig(root, { cwd: root, from, to: "HEAD" })
+  const kept = parseCommits(await getGitDiff(from, "HEAD", root), config).filter(
+    (commit) =>
+      config.types[commit.type] &&
+      !(commit.type === "chore" && commit.scope === "deps" && !commit.isBreaking),
   )
-  if (!counted.ok) throw new Error(`git rev-list failed: ${counted.err}`)
-  return counted.out !== "0"
+  if (kept.length === 0) return baseOf(tag)
+  return bump(baseOf(tag), determineSemverChange(kept, config) ?? "patch")
 }
 
 // The last v* tag HEAD can reach, or null for a repository with no tag yet. git describe fails the same way for a repository with no tag and for one whose tags HEAD cannot reach (a shallow clone without them); only the first is a fresh start, the second would compute from v0.0.0 and answer wrong, so it stops here.
@@ -186,8 +132,7 @@ const lastTag = (root: string): string | null => {
 export const decideIn = async (root: string): Promise<Decision> => {
   const tag = lastTag(root)
   const current = await readVersion(join(root, "package.json"))
-  const earned = releasable(root, tag) ? await earnedFrom(root, tag) : baseOf(tag)
-  return decide(current, earned, tag)
+  return decide(current, await earnedFrom(root, tag), tag)
 }
 
 if (import.meta.main) {

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -43,8 +43,17 @@ export const decide = (current: string, earned: string, tag: string | null): Dec
   return { current, earned, moved: next !== current, next, tag }
 }
 
-const run = (cmd: string[], cwd: string): { err: string; ok: boolean; out: string } => {
-  const proc = Bun.spawnSync(cmd, { cwd, stderr: "pipe", stdout: "pipe" })
+const run = (
+  cmd: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): { err: string; ok: boolean; out: string } => {
+  const proc = Bun.spawnSync(cmd, {
+    cwd,
+    env: { ...process.env, ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  })
   return {
     err: proc.stderr.toString().trim(),
     ok: proc.exitCode === 0,
@@ -97,6 +106,13 @@ const changelogen = join(
   JSON.parse(await Bun.file(changelogenManifest).text()).bin.changelogen,
 )
 
+// changelogen looks every author up on ungh.cc while it renders, with no timeout and no switch that skips the lookup, and a stalled lookup once held a CI test leg past its limit. The decision needs no network, so the lookup is sent through a closed local port and fails at once inside changelogen's own catch.
+const OFFLINE = {
+  HTTPS_PROXY: "http://127.0.0.1:9",
+  HTTP_PROXY: "http://127.0.0.1:9",
+  NO_PROXY: "",
+}
+
 // changelogen bumps whatever package.json holds and writes the changelog, so it runs against a copy set to the tag's version, and both files are put back afterwards.
 const earnedFrom = async (root: string, tag: string | null): Promise<string> => {
   const pkg = join(root, "package.json")
@@ -107,7 +123,11 @@ const earnedFrom = async (root: string, tag: string | null): Promise<string> => 
   try {
     await writeVersion(pkg, baseOf(tag))
     const from = tag === null ? [] : ["--from", tag]
-    const bumped = run([process.execPath, changelogen, "--bump", "--no-commit", ...from], root)
+    const bumped = run(
+      [process.execPath, changelogen, "--bump", "--no-commit", ...from],
+      root,
+      OFFLINE,
+    )
     // changelogen's CLI reports its own errors and still exits 0, so success is read from what it left behind: the version moved past the tag's and a section for it heads the changelog. Measured: even a window of nothing it recognizes bumps a patch and writes an empty section, which the content gate below then discounts.
     const version = await readVersion(pkg)
     const text = (await Bun.file(changelog).exists()) ? await Bun.file(changelog).text() : ""

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -106,11 +106,15 @@ const changelogen = join(
   JSON.parse(await Bun.file(changelogenManifest).text()).bin.changelogen,
 )
 
-// changelogen looks every author up on ungh.cc while it renders, with no timeout and no switch that skips the lookup, and a stalled lookup once held a CI test leg past its limit. The decision needs no network, so the lookup is sent through a closed local port and fails at once inside changelogen's own catch.
+// changelogen looks every author up on ungh.cc while it renders, with no timeout and no switch that skips the lookup, and a stalled lookup once held a CI test leg past its limit. The decision needs no network, so the lookup is sent through a closed local port and fails at once inside changelogen's own catch. Bun reads the lowercase proxy variables on their own, so both cases are set and both bypass lists cleared.
+const BLACKHOLE = "http://127.0.0.1:9"
 const OFFLINE = {
-  HTTPS_PROXY: "http://127.0.0.1:9",
-  HTTP_PROXY: "http://127.0.0.1:9",
+  HTTPS_PROXY: BLACKHOLE,
+  HTTP_PROXY: BLACKHOLE,
   NO_PROXY: "",
+  http_proxy: BLACKHOLE,
+  https_proxy: BLACKHOLE,
+  no_proxy: "",
 }
 
 // changelogen bumps whatever package.json holds and writes the changelog, so it runs against a copy set to the tag's version, and both files are put back afterwards.

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -41,8 +41,10 @@ export const compare = (a: string, b: string): number => {
   return x[0] - y[0] || x[1] - y[1] || x[2] - y[2]
 }
 
-// The version one change up from another, as changelogen's bump command moves it: below 1.0 a major counts as a minor and a minor as a patch.
-export const bump = (version: string, change: SemverBumpType): string => {
+type Step = Extract<SemverBumpType, "major" | "minor" | "patch">
+
+// The version one change up from another, as changelogen's bumpVersion moves it: below 1.0 a major counts as a minor and a minor as a patch.
+export const bump = (version: string, change: Step): string => {
   const [major, minor, patch] = parse(version)
   const step = major > 0 ? change : change === "major" ? "minor" : "patch"
   if (step === "major") return `${major + 1}.0.0`
@@ -107,7 +109,7 @@ export const writeVersion = async (file: string, version: string): Promise<void>
   )
 }
 
-// What the window since the tag has earned on top of the tag's version. The commits are the ones changelogen's own command keeps for the changelog (its config from changelog.config.json, the type lowercased as its parser is case-insensitive, disabled types and non-breaking chore(deps) dropped), so a window that keeps none earns nothing, which is the entry auto-release's content gate demands; the change is its semver reading of them, falling back to the patch its command bumps when no commit says more.
+// What the window since the tag has earned on top of the tag's version, read the way changelogen's own command reads it. Its default command keeps a commit for the changelog when its lowercased type is enabled in the config and it is not a non-breaking chore(deps); the one deliberate difference is that the type must be the config's own key, since a name inherited from Object.prototype (a "constructor:" title) passes the command's lookup and crashes it further on. A window that keeps nothing earns nothing, which is the entry auto-release's content gate demands.
 const earnedFrom = async (root: string, tag: string | null): Promise<string> => {
   const from = tag === null ? undefined : tag
   const config = await loadChangelogConfig(root, { cwd: root, from, to: "HEAD" })
@@ -115,11 +117,17 @@ const earnedFrom = async (root: string, tag: string | null): Promise<string> => 
     .map((commit) => ({ ...commit, type: commit.type.toLowerCase() }))
     .filter(
       (commit) =>
+        Object.hasOwn(config.types, commit.type) &&
         config.types[commit.type] &&
         !(commit.type === "chore" && commit.scope === "deps" && !commit.isBreaking),
     )
   if (kept.length === 0) return baseOf(tag)
-  return bump(baseOf(tag), determineSemverChange(kept, config) ?? "patch")
+  // Its bumpVersion falls back to a patch when no kept commit carries a semver, and only ever reads major, minor, or patch out of them; anything else here is a changelogen that changed shape.
+  const change = determineSemverChange(kept, config) ?? "patch"
+  if (change !== "major" && change !== "minor" && change !== "patch") {
+    throw new Error(`changelogen read an unexpected change from the window: ${change}`)
+  }
+  return bump(baseOf(tag), change)
 }
 
 // The last v* tag HEAD can reach, or null for a repository with no tag yet. git describe fails the same way for a repository with no tag and for one whose tags HEAD cannot reach (a shallow clone without them); only the first is a fresh start, the second would compute from v0.0.0 and answer wrong, so it stops here.

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -41,10 +41,10 @@ export const compare = (a: string, b: string): number => {
   return x[0] - y[0] || x[1] - y[1] || x[2] - y[2]
 }
 
-type Step = Extract<SemverBumpType, "major" | "minor" | "patch">
+type SemverStep = Extract<SemverBumpType, "major" | "minor" | "patch">
 
 // The version one change up from another, as changelogen's bumpVersion moves it: below 1.0 a major counts as a minor and a minor as a patch.
-export const bump = (version: string, change: Step): string => {
+export const bump = (version: string, change: SemverStep): string => {
   const [major, minor, patch] = parse(version)
   const step = major > 0 ? change : change === "major" ? "minor" : "patch"
   if (step === "major") return `${major + 1}.0.0`

--- a/packages/scripts/src/release-version.ts
+++ b/packages/scripts/src/release-version.ts
@@ -109,7 +109,7 @@ export const writeVersion = async (file: string, version: string): Promise<void>
   )
 }
 
-// What the window since the tag has earned on top of the tag's version, read the way changelogen's own command reads it. Its default command keeps a commit for the changelog when its lowercased type is enabled in the config and it is not a non-breaking chore(deps); the one deliberate difference is that the type must be the config's own key, since a name inherited from Object.prototype (a "constructor:" title) passes the command's lookup and crashes it further on. A window that keeps nothing earns nothing, which is the entry auto-release's content gate demands.
+// What the window since the tag has earned on top of the tag's version. changelogen's default command keeps a commit for the changelog when its lowercased type is enabled in the config and it is not a non-breaking chore(deps); the one deliberate difference is that the type must be the config's own key, since a name inherited from Object.prototype (a "constructor:" title) passes the command's lookup and crashes it further on. A window that keeps nothing earns nothing, which is the entry auto-release's content gate demands.
 const earnedFrom = async (root: string, tag: string | null): Promise<string> => {
   const from = tag === null ? undefined : tag
   const config = await loadChangelogConfig(root, { cwd: root, from, to: "HEAD" })

--- a/tests/packages/scripts/src/release-version.test.ts
+++ b/tests/packages/scripts/src/release-version.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import {
+  bump,
   compare,
   decide,
   decideIn,
@@ -11,7 +12,7 @@ import {
   writeVersion,
 } from "../../../../packages/scripts/src/release-version"
 
-// The pure decision, then the whole script against throwaway git repositories shaped like each stage of a project: a fresh fork with no tag, a steady-state window, a window that turns breaking halfway, a window of nothing but mechanical commits, a hand-set ahead of everything, a tree already moved forward, and a tree below the last tag. The repositories are real so changelogen reads real commits, and the script runs this repo's locked changelogen offline whatever directory it is pointed at.
+// The pure decision, then the whole script against throwaway git repositories shaped like each stage of a project: a fresh fork with no tag, a steady-state window, a window that turns breaking halfway, a window of nothing but mechanical commits, a hand-set ahead of everything, a tree already moved forward, and a tree below the last tag. The repositories are real so changelogen's own parsing reads real commits, and one scenario runs changelogen's command beside the script to keep the two agreeing.
 
 describe("compare", () => {
   test("orders numeric semver by major, then minor, then patch", () => {
@@ -26,6 +27,18 @@ describe("compare", () => {
   test("refuses anything that is not three numbers", () => {
     expect(() => compare("0.1", "0.1.0")).toThrow("not a release version")
     expect(() => compare("v0.1.0", "0.1.0")).toThrow("not a release version")
+  })
+})
+
+describe("bump", () => {
+  test("moves one step, collapsing major and minor below 1.0 as changelogen does", () => {
+    expect(bump("0.1.27", "patch")).toBe("0.1.28")
+    expect(bump("0.1.27", "minor")).toBe("0.1.28")
+    expect(bump("0.1.27", "major")).toBe("0.2.0")
+    expect(bump("0.0.99", "patch")).toBe("0.0.100")
+    expect(bump("1.4.2", "patch")).toBe("1.4.3")
+    expect(bump("1.4.2", "minor")).toBe("1.5.0")
+    expect(bump("1.4.2", "major")).toBe("2.0.0")
   })
 })
 
@@ -70,6 +83,7 @@ const repo = async (version: string): Promise<string> => {
   await Bun.$`git init -q -b canary ${dir}`
   await Bun.$`git -C ${dir} config user.email probe@example.com`
   await Bun.$`git -C ${dir} config user.name probe`
+  await Bun.$`git -C ${dir} remote add origin https://github.com/probe/probe.git`
   // The changelog config rides along, as it does in this repo and in a fork: it is what drops ci commits from the changelog, which the content gate reads.
   await Bun.write(
     join(dir, "changelog.config.json"),
@@ -191,19 +205,44 @@ describe("decideIn, against real repositories", () => {
     }
   })
 
-  test("changelogen's own errors are failures, not an empty window", async () => {
+  test("a broken changelog config is a failure, not an empty window", async () => {
     const dir = await repo("0.1.27")
     try {
       await commit(dir, "chore: release", "v0.1.27")
       await commit(dir, "feat: one")
       await Bun.write(join(dir, "changelog.config.json"), "{ broken\n")
-      await expect(decideIn(dir)).rejects.toThrow("changelogen failed")
+      await expect(decideIn(dir)).rejects.toThrow()
       expect(await readVersion(join(dir, "package.json"))).toBe("0.1.27")
-      expect(await Bun.file(join(dir, "CHANGELOG.md")).exists()).toBe(false)
     } finally {
       cleanup(dir)
     }
   }, 30000)
+
+  test("agrees with changelogen's own command on the number a window earns", async () => {
+    const dir = await repo("0.1.27")
+    try {
+      await commit(dir, "chore: release", "v0.1.27")
+      await commit(dir, "feat: one")
+      await commit(dir, "chore(deps): bump something")
+      await commit(dir, "fix(api)!: two")
+      // The command looks every author up over the network while it renders; an empty exclusion matches every author, so this run stays offline.
+      const configFile = join(dir, "changelog.config.json")
+      const config = JSON.parse(await Bun.file(configFile).text())
+      await Bun.write(configFile, JSON.stringify({ ...config, excludeAuthors: [""] }))
+      const manifest = Bun.resolveSync("changelogen/package.json", join(script, ".."))
+      const cli = join(manifest, "..", JSON.parse(await Bun.file(manifest).text()).bin.changelogen)
+      const proc = Bun.spawnSync(
+        [process.execPath, cli, "--bump", "--no-commit", "--from", "v0.1.27"],
+        { cwd: dir, stderr: "pipe", stdout: "pipe" },
+      )
+      expect(proc.exitCode).toBe(0)
+      const commanded = await readVersion(join(dir, "package.json"))
+      expect(commanded).toBe("0.2.0")
+      expect((await decideIn(dir)).earned).toBe(commanded)
+    } finally {
+      cleanup(dir)
+    }
+  }, 60000)
 
   test("the entry point prints the decision, and moves the tree only with --write", async () => {
     const dir = await repo("0.1.27")

--- a/tests/packages/scripts/src/release-version.test.ts
+++ b/tests/packages/scripts/src/release-version.test.ts
@@ -11,7 +11,7 @@ import {
   writeVersion,
 } from "../../../../packages/scripts/src/release-version"
 
-// The pure decision, then the whole script against throwaway git repositories shaped like each stage of a project: a fresh fork with no tag, a steady-state window, a window that turns breaking halfway, a window of nothing but mechanical commits, a hand-set ahead of everything, a tree already moved forward, and a tree below the last tag. The repositories are real so changelogen reads real commits, and the script runs this repo's locked changelogen whatever directory it is pointed at.
+// The pure decision, then the whole script against throwaway git repositories shaped like each stage of a project: a fresh fork with no tag, a steady-state window, a window that turns breaking halfway, a window of nothing but mechanical commits, a hand-set ahead of everything, a tree already moved forward, and a tree below the last tag. The repositories are real so changelogen reads real commits, and the script runs this repo's locked changelogen offline whatever directory it is pointed at.
 
 describe("compare", () => {
   test("orders numeric semver by major, then minor, then patch", () => {

--- a/tests/packages/scripts/src/release-version.test.ts
+++ b/tests/packages/scripts/src/release-version.test.ts
@@ -84,7 +84,7 @@ const repo = async (version: string): Promise<string> => {
   await Bun.$`git -C ${dir} config user.email probe@example.com`
   await Bun.$`git -C ${dir} config user.name probe`
   await Bun.$`git -C ${dir} remote add origin https://github.com/probe/probe.git`
-  // The changelog config rides along, as it does in this repo and in a fork: it is what drops ci commits from the changelog, which the content gate reads.
+  // The changelog config rides along, as it does in this repo and in a fork: it is what drops ci commits, which the decision reads the way the content gate does.
   await Bun.write(
     join(dir, "changelog.config.json"),
     await Bun.file(join(import.meta.dir, "../../../../changelog.config.json")).text(),
@@ -149,6 +149,28 @@ describe("decideIn, against real repositories", () => {
         moved: false,
         next: "0.1.27",
       })
+    } finally {
+      cleanup(dir)
+    }
+  }, 30000)
+
+  test("a window of one non-conventional commit earns nothing", async () => {
+    const dir = await repo("0.1.27")
+    try {
+      await commit(dir, "chore: release", "v0.1.27")
+      await commit(dir, "wip, not a conventional message")
+      expect(await decideIn(dir)).toMatchObject({ earned: "0.1.27", moved: false })
+    } finally {
+      cleanup(dir)
+    }
+  }, 30000)
+
+  test("reads a type whatever its case, as changelogen's command does", async () => {
+    const dir = await repo("0.1.27")
+    try {
+      await commit(dir, "chore: release", "v0.1.27")
+      await commit(dir, "Fix: shouted")
+      expect(await decideIn(dir)).toMatchObject({ earned: "0.1.28", moved: true })
     } finally {
       cleanup(dir)
     }
@@ -285,7 +307,7 @@ describe("decideIn, against real repositories", () => {
     }
   }, 30000)
 
-  test("a hand-set major stays, and the files are put back after the computation", async () => {
+  test("a hand-set major stays, and the computation touches no file", async () => {
     const dir = await repo("0.1.27")
     try {
       await commit(dir, "chore: release", "v0.1.27")

--- a/tests/packages/scripts/src/release-version.test.ts
+++ b/tests/packages/scripts/src/release-version.test.ts
@@ -83,6 +83,7 @@ const repo = async (version: string): Promise<string> => {
   await Bun.$`git init -q -b canary ${dir}`
   await Bun.$`git -C ${dir} config user.email probe@example.com`
   await Bun.$`git -C ${dir} config user.name probe`
+  // changelogen's config loader reads the remote URL to resolve the repository; without one it prints a git error for every decision.
   await Bun.$`git -C ${dir} remote add origin https://github.com/probe/probe.git`
   // The changelog config rides along, as it does in this repo and in a fork: it is what drops ci commits, which the decision reads the way the content gate does.
   await Bun.write(
@@ -159,6 +160,17 @@ describe("decideIn, against real repositories", () => {
     try {
       await commit(dir, "chore: release", "v0.1.27")
       await commit(dir, "wip, not a conventional message")
+      expect(await decideIn(dir)).toMatchObject({ earned: "0.1.27", moved: false })
+    } finally {
+      cleanup(dir)
+    }
+  }, 30000)
+
+  test("a type the config only inherits from Object.prototype earns nothing", async () => {
+    const dir = await repo("0.1.27")
+    try {
+      await commit(dir, "chore: release", "v0.1.27")
+      await commit(dir, "constructor: exotic")
       expect(await decideIn(dir)).toMatchObject({ earned: "0.1.27", moved: false })
     } finally {
       cleanup(dir)

--- a/tests/packages/scripts/src/release-version.test.ts
+++ b/tests/packages/scripts/src/release-version.test.ts
@@ -12,7 +12,7 @@ import {
   writeVersion,
 } from "../../../../packages/scripts/src/release-version"
 
-// The pure decision, then the whole script against throwaway git repositories shaped like each stage of a project: a fresh fork with no tag, a steady-state window, a window that turns breaking halfway, a window of nothing but mechanical commits, a hand-set ahead of everything, a tree already moved forward, and a tree below the last tag. The repositories are real so changelogen's own parsing reads real commits, and one scenario runs changelogen's command beside the script to keep the two agreeing.
+// The pure decision and the bump rule, then the whole script against throwaway git repositories shaped like each stage of a project: a fresh fork with no tag, a steady-state window, a window that turns breaking halfway, windows of nothing but mechanical commits or one non-conventional message, a window whose types changelogen drops or only inherits from Object.prototype, a shouted type, a hand-set ahead of everything, a tree already moved forward, a tree below the last tag, and tags HEAD cannot reach. The repositories are real so changelogen's own parsing reads real commits, and one scenario runs changelogen's command beside the script to keep the two agreeing.
 
 describe("compare", () => {
   test("orders numeric semver by major, then minor, then patch", () => {

--- a/web/next/content/docs/getting-started/scripts.mdx
+++ b/web/next/content/docs/getting-started/scripts.mdx
@@ -39,7 +39,7 @@ Every script lives in the root `package.json`; run any of them with `bun run <na
 ## Release / production
 
 - `bun run build`: build every app with Turbo, then print each workspace's size. This is the same build the pre-commit hook runs.
-- `bun run release:version`: print the version decision for the current release window as JSON (the last tag, the tree, what the window earned, and the larger of the two); `--write` moves `package.json` to it. The draft-PR workflow runs this on every push to `canary`; running it by hand only previews. It reads the `v*` tags, so fetch them first: with tags present but none reachable from HEAD it stops rather than computing from v0.0.0.
+- `bun run release:version`: print the version decision for the current release window as JSON (the last tag, the tree, what the window earned, and the larger of the two); `--write` moves `package.json` to it. The draft-PR workflow runs this on every push to `canary`; running it by hand only previews, and it needs no network. It reads the `v*` tags, so fetch them first: with tags present but none reachable from HEAD it stops rather than computing from v0.0.0.
 - `bun run start`: serve the production build.
 
 The changelog, version bump, tag, and GitHub release are automated: you don't run them by hand. See [Releases](/docs/manage/release).


### PR DESCRIPTION
## Summary

`release-version.ts` no longer runs changelogen's command. It uses the package as a library, which `packages/scripts` already declares: `loadChangelogConfig` reads `changelog.config.json`, `getGitDiff` and `parseCommits` read the window's commits, and `determineSemverChange` gives the semver reading of the ones the command would keep. Nothing is rendered, so no author is looked up over the network, and nothing is written, so `package.json` and `CHANGELOG.md` are never touched during a decision.

Why: running the command against a copy of the tree was the root of every guard the script had grown since #826. The `.bin` shim Windows does not have, the command's exit-0 error handling, the version-and-heading success check, the temp writes and restores, and finally the author lookup on ungh.cc that stalled the v0.1.28 publish leg on macOS (Bun killed the child at the 30s test limit; a re-run passed). An earlier revision of this PR blackholed that lookup through the proxy variables; this one removes the reason for it.

**Four rules are mirrored, one line each**, because the command applies them outside the functions it exports: the type is lowercased, since the parser is case-insensitive; commits of a disabled type or a non-breaking `chore(deps)` are dropped before anything renders (the scope keeps its case in both, so `Chore(Deps)` is kept by both and they agree); a window with kept commits but no semver-bearing type bumps a patch; below 1.0 a major counts as a minor and a minor as a patch. A window that keeps no commit earns nothing, which is exactly the entry auto-release's content gate demands. One deliberate difference: the type must be the config's own key. A name inherited from `Object.prototype` (a `constructor:` title) passes the command's lookup and crashes it while rendering, with exit 0 and no section written; the script earns nothing for it, so auto-release's rewrite puts the manifest back and its gate skips. Had the script earned a patch there, the gate would have passed on the previous section's entries and shipped a bump, a tag, and a release with empty notes.

Also in this PR: `cli-release.yml` lists `packages/scripts/**` in its push path filter, so a change to the script it runs re-runs the three-platform gate on its own; the scripts page says a hand run needs no network; an auto-release comment that described the old dry run now says the script touches no file; the test fixture gives its throwaway repositories an `origin` remote, since changelogen's config loader reads it to resolve the repository; and the runtime-apis index row for the script drops the import the rewrite removed.

## Measured

In throwaway repositories: the library calls take 27-71ms in process, 70-90ms wall with Bun's startup, where the command took 650-800ms with its author lookup and about 90ms with authors excluded; the same with the network blocked. The answers match the command's for a feature window (0.1.28), a breaking window (0.2.0), `build(deps)` (0.1.28), and a tagless fork's first fix (0.0.1). For a `chore(deps)` plus `ci` window and for a window of one non-conventional commit the script answers nothing earned, where the command bumps the manifest to a patch but renders no entry, which is exactly what the content gate discounts. A broken `changelog.config.json` throws.

## Verification

- 25 tests in `tests/packages/scripts/src/release-version.test.ts`: the pure decision and the bump rule, every stage against real repositories (no tag, feature window, breaking mid-window, mechanical-only, non-conventional and dropped-types windows, a capitalized type, a prototype-key type, already moved, hand-set major, below the tag, unreachable tags), a broken config as a failure, the entry point with and without `--write`, the version field found at the top level, and one run of the real command beside the script on a window with a feature, a dependency bump, and a breaking fix, both answering 0.2.0. That parity scenario is the only place the command still runs, offline through the throwaway config's author exclusion.
- The whole file runs in about 3s where it took about 9s.
- Lint, format, types clean; the dry run on this branch answers 0.1.29 (its own fix commits earn a patch) with the tree untouched.
- The three-platform matrix runs on the canary push after merge, through both `packages/scripts/**` and `tests/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBYxUtQGsiCZ57FgqffMu3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release version calculations now run directly through the changelog tooling, including support for prerelease version bump rules.
  - Release workflows now rerun when release scripts change.

- **Bug Fixes**
  - Improved handling of commit types, configuration errors, and release-version calculations without modifying files.

- **Documentation**
  - Clarified that manually running the release-version command only previews the decision and requires no network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->