### PR TITLE
fix(dev): find the shared proxy on the port it was told to use

### DIFF
--- a/.agents/skills/dev/SKILL.md
+++ b/.agents/skills/dev/SKILL.md
@@ -37,7 +37,7 @@ The API dev task runs `bun --hot src/index.ts`, and **`--hot` does not pick up n
 # A linked worktree lives under the primary checkout, so its stack is skipped by path.
 ROOT=$(git rev-parse --show-toplevel)
 # The shared proxy is itself a portless process, and it lives wherever the first stack to start ran, so it is spared by port, not by path
-PROXY=$(lsof -nP -iTCP:1355 -sTCP:LISTEN -t 2>/dev/null | tr '\n' ' ')
+PROXY=$(lsof -nP -iTCP:"${PORTLESS_PORT:-1355}" -sTCP:LISTEN -t 2>/dev/null | tr '\n' ' ')
 for p in $(pgrep -f "turbo run dev|bun run dev|dev:app|next dev|next-server|src/index.ts|tsdown|portless"); do
   case " $PROXY " in *" $p "*) continue ;; esac
   cwd=$(lsof -a -p "$p" -d cwd -Fn 2>/dev/null | grep ^n | cut -c2-)
@@ -52,7 +52,7 @@ API=$(bunx portless get api.zerostarter)
 curl -sf --retry 60 --retry-delay 1 --retry-connrefused "$API/api/health" > /dev/null
 ```
 
-Killing turbo alone is not enough: `pkill -f "turbo run dev"` matches the turbo processes and none of the children they spawned, and the survivors include both `next-server`, which keeps its port so the next `bun run dev` dies with "Another next dev server is already running", and the `.bin/portless` supervisors that hold the route registration. It is also worktree-blind, so it would take down another worktree's stack. Hence the wide pattern, narrowed by each process's own working directory. The shared proxy needs the extra guard because it matches that pattern too and its own directory says nothing about who depends on it: whichever stack started first hosts it, and killing it drops routing for every worktree on the machine. The shared portless proxy keeps running either way, and this worktree's apps re-register on restart; `bunx portless list` showing no route for this branch confirms the old stack is gone. Done when the previously-NOT_FOUND route responds.
+Killing turbo alone is not enough: `pkill -f "turbo run dev"` matches the turbo processes and none of the children they spawned, and the survivors include both `next-server`, which keeps its port so the next `bun run dev` dies with "Another next dev server is already running", and the `.bin/portless` supervisors that hold the route registration. It is also worktree-blind, so it would take down another worktree's stack. Hence the wide pattern, narrowed by each process's own working directory. The shared proxy needs the extra guard because it matches that pattern too and its own directory says nothing about who depends on it: whichever stack started first hosts it, and killing it drops routing for every worktree on the machine. It is found by the port it listens on, `PORTLESS_PORT` or 1355, so a fork that moves the port keeps the protection. The shared portless proxy keeps running either way, and this worktree's apps re-register on restart; `bunx portless list` showing no route for this branch confirms the old stack is gone. Done when the previously-NOT_FOUND route responds.
 
 Restart the same way after changing `@packages/*` exports the API consumes: they resolve to built dist, so run `bunx turbo run build --filter=@packages/<name>` first.
 


### PR DESCRIPTION
The last residual from the review of #830 and #832.

The proxy guard added in #832 resolves the listener on a hardcoded 1355, but `PORTLESS_PORT` is a real knob: the root `dev` script sets it explicitly and `turbo.json` passes it through. On a fork that moves the port, `lsof` finds nothing, the empty result is indistinguishable from no proxy running, and the guard silently stops protecting the one process it exists to protect. `${PORTLESS_PORT:-1355}` closes it.

Verified: with the default the proxy still resolves to the pid actually listening; with a port nothing listens on the list is empty, which is the correct answer rather than a false spare; the block parses under `bash -n`.

Found by the review peer, who also exercised the collision shapes around the guard: an empty list spares nothing, and 44100 against 4410, 4410 against 44100, and 144100 against 44100 all avoid false spares, because the space delimiters carry the match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBYxUtQGsiCZ57FgqffMu3